### PR TITLE
Do not foreground-attenuate torus emission

### DIFF
--- a/src/grahspj/config.py
+++ b/src/grahspj/config.py
@@ -175,7 +175,7 @@ class AGNConfig:
 class LikelihoodConfig:
     """Likelihood and extra model-mismatch configuration."""
     systematics_width: float = 0.05
-    fit_systematics_width: bool = False
+    fit_systematics_width: bool = True
     systematics_width_prior_scale: float = 0.01
     student_t_df: float = 5.0
     fit_intrinsic_scatter: bool = True

--- a/src/grahspj/config.py
+++ b/src/grahspj/config.py
@@ -175,6 +175,8 @@ class AGNConfig:
 class LikelihoodConfig:
     """Likelihood and extra model-mismatch configuration."""
     systematics_width: float = 0.05
+    fit_systematics_width: bool = False
+    systematics_width_prior_scale: float = 0.01
     student_t_df: float = 5.0
     fit_intrinsic_scatter: bool = True
     intrinsic_scatter_default: float = 1.0e-4

--- a/src/grahspj/model.py
+++ b/src/grahspj/model.py
@@ -33,6 +33,7 @@ C_MS = 2.99792458e8
 L_SUN_W = 3.828e26
 ERG_PER_WATT = 1.0e7
 AGN_BOLOMETRIC_CORRECTION_5100 = 9.26
+DSPS_SOLAR_METALLICITY = 0.019
 MPC_TO_M = 3.085677581491367e22
 GRAHSP_BIATTENUATION_BREAK_A = 11000.0
 GRAHSP_PL_BEND_LOC_A = 1000.0
@@ -199,11 +200,41 @@ def _sample_log_stellar_mass(prior_config: dict[str, Any]):
     return numpyro.sample("log_stellar_mass", dist.StudentT(df=5.0, loc=10.0, scale=2.0))
 
 
+def _ssp_lgmet_solar_offset(ssp_lgmet):
+    """Return the solar-metallicity offset for the SSP metallicity convention."""
+    ssp_lgmet = jnp.asarray(ssp_lgmet, dtype=jnp.float64)
+    # DSPS SSP grids use absolute log10(Z). Older/simple test grids may use
+    # log10(Z/Zsun). A max below -1 is a robust signature of absolute log10(Z).
+    return jnp.where(jnp.nanmax(ssp_lgmet) < -1.0, jnp.log10(DSPS_SOLAR_METALLICITY), 0.0)
+
+
+def _default_gal_lgmet_loc(ssp_lgmet):
+    """Default galaxy metallicity center in the SSP grid's metallicity convention."""
+    ssp_lgmet = jnp.asarray(ssp_lgmet, dtype=jnp.float64)
+    loc = _ssp_lgmet_solar_offset(ssp_lgmet) - 0.3
+    return jnp.clip(loc, jnp.nanmin(ssp_lgmet), jnp.nanmax(ssp_lgmet))
+
+
+def _cfg_lgmet_value(
+    cfg: dict[str, Any],
+    solar_relative_key: str,
+    default_logzsol: float,
+    solar_offset,
+    *,
+    absolute_key: str | None = None,
+):
+    """Read metallicity config values and convert log(Z/Zsun) defaults to log10(Z)."""
+    if absolute_key is not None and absolute_key in cfg:
+        return jnp.asarray(cfg[absolute_key], dtype=jnp.float64)
+    return jnp.asarray(cfg.get(solar_relative_key, default_logzsol), dtype=jnp.float64) + solar_offset
+
+
 def _mass_metallicity_relation_logprior(
     log_stellar_mass,
     gal_lgmet,
     prior_config: dict[str, Any],
     *,
+    ssp_lgmet=None,
     redshift: float = 0.0,
 ):
     """Return an optional soft stellar mass-metallicity log-prior."""
@@ -213,16 +244,21 @@ def _mass_metallicity_relation_logprior(
     if not isinstance(cfg, dict) or cfg.get("enabled", True) is False:
         return jnp.asarray(0.0, dtype=jnp.float64)
 
+    solar_offset = _ssp_lgmet_solar_offset(ssp_lgmet) if ssp_lgmet is not None else jnp.asarray(0.0, dtype=jnp.float64)
     pivot_mass = jnp.asarray(cfg.get("pivot_mass", 10.0), dtype=jnp.float64)
-    pivot_logzsol = jnp.asarray(cfg.get("pivot_logzsol", -0.15), dtype=jnp.float64)
+    pivot_lgmet = _cfg_lgmet_value(cfg, "pivot_logzsol", -0.15, solar_offset, absolute_key="pivot_lgmet")
     slope = jnp.asarray(cfg.get("slope", 0.35), dtype=jnp.float64)
     scale = jnp.maximum(jnp.asarray(cfg.get("scale", 0.25), dtype=jnp.float64), 1.0e-6)
     redshift_ref = jnp.asarray(cfg.get("redshift_ref", 0.0), dtype=jnp.float64)
     redshift_slope = jnp.asarray(cfg.get("redshift_slope", -0.15), dtype=jnp.float64)
-    min_loc = jnp.asarray(cfg.get("min", -1.5), dtype=jnp.float64)
-    max_loc = jnp.asarray(cfg.get("max", 0.3), dtype=jnp.float64)
+    min_loc = _cfg_lgmet_value(cfg, "min", -1.5, solar_offset, absolute_key="min_lgmet")
+    max_loc = _cfg_lgmet_value(cfg, "max", 0.3, solar_offset, absolute_key="max_lgmet")
+    if ssp_lgmet is not None:
+        ssp_lgmet = jnp.asarray(ssp_lgmet, dtype=jnp.float64)
+        min_loc = jnp.maximum(min_loc, jnp.nanmin(ssp_lgmet))
+        max_loc = jnp.minimum(max_loc, jnp.nanmax(ssp_lgmet))
 
-    loc = pivot_logzsol + slope * (jnp.asarray(log_stellar_mass, dtype=jnp.float64) - pivot_mass)
+    loc = pivot_lgmet + slope * (jnp.asarray(log_stellar_mass, dtype=jnp.float64) - pivot_mass)
     loc = loc + redshift_slope * (jnp.asarray(redshift, dtype=jnp.float64) - redshift_ref)
     loc = jnp.clip(loc, jnp.minimum(min_loc, max_loc), jnp.maximum(min_loc, max_loc))
     return dist.Normal(loc, scale).log_prob(jnp.asarray(gal_lgmet, dtype=jnp.float64))
@@ -625,12 +661,13 @@ def _build_diffstar_host(context: ModelContext, prior_config: dict[str, Any], *,
         return_smh=True,
     )
 
-    gal_lgmet = numpyro.sample("gal_lgmet", dist.Normal(*_cfg_mean_scale(prior_config, "gal_lgmet", -0.3, 0.5)))
+    gal_lgmet = numpyro.sample("gal_lgmet", dist.Normal(*_cfg_mean_scale(prior_config, "gal_lgmet", _default_gal_lgmet_loc(ssp_lgmet), 0.5)))
     gal_lgmet_scatter = numpyro.sample("gal_lgmet_scatter", dist.HalfNormal(_cfg_halfnorm(prior_config, "gal_lgmet_scatter", 0.2)))
     mmr_logprior = _mass_metallicity_relation_logprior(
         log_stellar_mass,
         gal_lgmet,
         prior_config,
+        ssp_lgmet=ssp_lgmet,
         redshift=float(context.fit_config.observation.redshift),
     )
     numpyro.factor("mass_metallicity_relation_prior", mmr_logprior)

--- a/src/grahspj/model.py
+++ b/src/grahspj/model.py
@@ -281,6 +281,7 @@ def _torus_component(wave, fcov, si, cool_lam, cool_width, hot_lam, hot_width, h
         si_em_ampl * jnp.exp(-0.5 * ((wave - si_em_lam) / si_em_width) ** 2)
         - si_abs_ampl * jnp.exp(-0.5 * ((wave - si_abs_lam) / si_abs_width) ** 2)
     )
+    si_spec = jnp.maximum(si_spec, -torus)
     return torus + si_spec
 
 
@@ -1252,10 +1253,11 @@ def evaluate_photometric_state(
         igm = context.fixed_igm_jax
     nebular = _build_nebular_components(context, host_state, host_rest, prior_config)
     host_with_nebular_rest = host_rest + nebular["absorption_rest"] + nebular["emission_rest"]
-    gal_att_rest, agn_att_rest, host_absorbed_rest, dust_luminosity = _apply_biattenuation(
+    agn_attenuated_input_rest = disk_rest + feii_rest + line_rest + balmer_rest
+    gal_att_rest, agn_attenuated_rest, host_absorbed_rest, dust_luminosity = _apply_biattenuation(
         rest_wave,
         host_with_nebular_rest,
-        disk_rest + torus_rest + feii_rest + line_rest + balmer_rest,
+        agn_attenuated_input_rest,
         ebv_gal,
         ebv_agn,
         -1.2,
@@ -1272,7 +1274,7 @@ def evaluate_photometric_state(
     nebular_lines_att_rest = nebular["lines_rest"] * gal_att_factor
     nebular_continuum_att_rest = nebular["continuum_rest"] * gal_att_factor
     disk_att_rest = disk_rest * agn_att_factor
-    torus_att_rest = torus_rest * agn_att_factor
+    torus_att_rest = torus_rest
     feii_att_rest = feii_rest * agn_att_factor
     line_bl_att_rest = line_bl_rest * agn_att_factor
     line_nl_att_rest = line_nl_rest * agn_att_factor
@@ -1284,8 +1286,8 @@ def evaluate_photometric_state(
         _host_dust_emission(context, dust_luminosity, dust_alpha),
         jnp.zeros_like(rest_wave),
     )
-    total_rest = gal_att_rest + dust_rest + agn_att_rest
-    agn_rest = agn_att_rest
+    agn_rest = agn_attenuated_rest + torus_att_rest
+    total_rest = gal_att_rest + dust_rest + agn_rest
     transmitted_fraction = jnp.clip(total_rest / jnp.maximum(host_with_nebular_rest + disk_rest + torus_rest + feii_rest + line_rest + balmer_rest, 1e-30), 1e-4, 1.0)
     fast_projection_enabled = _can_use_fixed_filter_projection(context, cfg) and not include_components
     redshift_projection_enabled = (

--- a/src/grahspj/model.py
+++ b/src/grahspj/model.py
@@ -129,6 +129,16 @@ def _cfg_halfnorm(prior_config: dict[str, Any], key: str, default_scale: float):
     return jnp.asarray(default_scale)
 
 
+def _cfg_exponential(prior_config: dict[str, Any], key: str, default_scale: float):
+    """Read an Exponential scale value from prior_config."""
+    cfg = prior_config.get(key, None)
+    if isinstance(cfg, dict) and "scale" in cfg:
+        return jnp.asarray(cfg["scale"])
+    if isinstance(cfg, (int, float)):
+        return jnp.asarray(cfg)
+    return jnp.asarray(default_scale)
+
+
 def _cfg_mean_scale(prior_config: dict[str, Any], key: str, default_loc: float, default_scale: float):
     """Alias for reading mean/scale prior settings from prior_config."""
     return _cfg_norm(prior_config, key, default_loc, default_scale)
@@ -1239,6 +1249,23 @@ def evaluate_photometric_state(
         intrinsic_scatter = jnp.exp(log_intrinsic_scatter)
     else:
         intrinsic_scatter = jnp.asarray(float(cfg.likelihood.intrinsic_scatter_default), dtype=jnp.float64)
+    if cfg.likelihood.fit_systematics_width:
+        systematics_width = numpyro.sample(
+            "systematics_width",
+            dist.Exponential(
+                1.0
+                / jnp.maximum(
+                    _cfg_exponential(
+                        prior_config,
+                        "systematics_width",
+                        cfg.likelihood.systematics_width_prior_scale,
+                    ),
+                    1.0e-12,
+                )
+            ),
+        )
+    else:
+        systematics_width = jnp.asarray(float(cfg.likelihood.systematics_width), dtype=jnp.float64)
     if cfg.observation.fit_redshift:
         redshift = _sample_redshift(context, prior_config, cfg)
         luminosity_distance_m = _luminosity_distance_m_jax(
@@ -1529,7 +1556,7 @@ def evaluate_photometric_state(
         obs_errors=obs_errors,
         upper_limits=upper_limits,
         data_mask=data_mask,
-        systematics_width=cfg.likelihood.systematics_width,
+        systematics_width=systematics_width,
         intrinsic_scatter=intrinsic_scatter,
         student_t_df=cfg.likelihood.student_t_df,
         agn_component=agn_fluxes,

--- a/tests/test_diffstar_host.py
+++ b/tests/test_diffstar_host.py
@@ -15,7 +15,7 @@ from grahspj.config import (
     PhotometryData,
 )
 from grahspj.core import GRAHSPJ
-from grahspj.model import _luminosity_distance_m_jax, grahsp_photometric_model
+from grahspj.model import _default_gal_lgmet_loc, _mass_metallicity_relation_logprior, _luminosity_distance_m_jax, grahsp_photometric_model
 from grahspj.preload import build_model_context
 
 
@@ -175,6 +175,29 @@ def test_mass_metallicity_prior_is_enabled_by_default(monkeypatch):
     assert "mass_metallicity_relation_prior" in tr
     assert np.all(np.isfinite(np.asarray(tr["mass_metallicity_relation_prior"]["value"], dtype=float)))
     assert np.all(np.isfinite(np.asarray(tr["mass_metallicity_relation_logprior"]["value"], dtype=float)))
+
+
+def test_default_metallicity_prior_uses_dsps_absolute_lgmet_grid():
+    ssp_lgmet = np.array([-4.34771165, -3.34771165, -2.34771165, -1.34771165])
+
+    default_loc = float(np.asarray(_default_gal_lgmet_loc(ssp_lgmet)))
+    assert np.isclose(default_loc, np.log10(0.019) - 0.3)
+
+    low_mass_prior = _mass_metallicity_relation_logprior(
+        8.0,
+        np.log10(0.019) - 0.85,
+        {},
+        ssp_lgmet=ssp_lgmet,
+    )
+    old_convention_prior = _mass_metallicity_relation_logprior(
+        8.0,
+        -0.85,
+        {},
+        ssp_lgmet=ssp_lgmet,
+    )
+
+    assert np.isfinite(float(np.asarray(low_mass_prior)))
+    assert float(np.asarray(low_mass_prior)) > float(np.asarray(old_convention_prior))
 
 
 def test_mass_metallicity_prior_can_be_disabled(monkeypatch):

--- a/tests/test_model_assembly.py
+++ b/tests/test_model_assembly.py
@@ -179,6 +179,23 @@ def test_component_rest_and_observed_seds_sum_to_total(monkeypatch):
     assert np.allclose(_site(tr, "total_obs_sed"), total_obs_parts, rtol=2.0e-10, atol=1.0e-40)
 
 
+def test_torus_component_is_not_foreground_attenuated(monkeypatch):
+    _patch_ssp(monkeypatch)
+    context = build_model_context(_cfg())
+    low_ebv = _fixed_component_data()
+    high_ebv = _fixed_component_data()
+    low_ebv["ebv_gal"] = np.array(0.0)
+    low_ebv["ebv_agn"] = np.array(0.0)
+    high_ebv["ebv_gal"] = np.array(0.5)
+    high_ebv["ebv_agn"] = np.array(0.5)
+
+    tr_low = _deterministic_trace(context, low_ebv)
+    tr_high = _deterministic_trace(context, high_ebv)
+
+    np.testing.assert_allclose(_site(tr_high, "torus_rest_sed"), _site(tr_low, "torus_rest_sed"))
+    assert np.sum(_site(tr_high, "disk_rest_sed")) < np.sum(_site(tr_low, "disk_rest_sed"))
+
+
 def test_evaluate_photometric_state_matches_deterministic_sites(monkeypatch):
     _patch_ssp(monkeypatch)
     context = build_model_context(_cfg())

--- a/tests/test_model_assembly.py
+++ b/tests/test_model_assembly.py
@@ -129,6 +129,27 @@ def _fixed_component_data():
     }
 
 
+def test_systematics_width_can_be_sampled_with_exponential_prior(monkeypatch):
+    _patch_ssp(monkeypatch)
+    cfg = _cfg()
+    cfg.likelihood.fit_systematics_width = True
+    cfg.likelihood.systematics_width = 0.05
+    cfg.likelihood.systematics_width_prior_scale = 0.01
+    context = build_model_context(cfg)
+
+    tr = _deterministic_likelihood_trace(
+        context,
+        {
+            **_fixed_component_data(),
+            "systematics_width": np.array(0.02),
+        },
+    )
+
+    assert "systematics_width" in tr
+    assert np.isclose(_site(tr, "systematics_width"), 0.02)
+    assert "photometry_loglike" in tr
+
+
 def test_component_rest_and_observed_seds_sum_to_total(monkeypatch):
     _patch_ssp(monkeypatch)
     context = build_model_context(_cfg(fit_balmer_continuum=True))

--- a/tests/test_model_helpers.py
+++ b/tests/test_model_helpers.py
@@ -338,6 +338,31 @@ def test_torus_silicate_features_are_in_mid_ir_angstroms():
     assert torus[1] > torus[2]
 
 
+def test_torus_silicate_absorption_cannot_make_negative_flux():
+    wave = np.linspace(GRAHSP_SI_EM_LAM_A, GRAHSP_SI_ABS_LAM_A, 128)
+    torus = np.asarray(
+        _torus_component(
+            wave,
+            fcov=0.2,
+            si=100.0,
+            cool_lam=17.0,
+            cool_width=0.45,
+            hot_lam=2.0,
+            hot_width=0.2,
+            hot_fcov=0.1,
+            si_ratio=10.0,
+            si_em_lam=GRAHSP_SI_EM_LAM_A,
+            si_abs_lam=GRAHSP_SI_ABS_LAM_A,
+            si_em_width=GRAHSP_SI_EM_WIDTH_A,
+            si_abs_width=GRAHSP_SI_ABS_WIDTH_A,
+            l_agn=10.0,
+        )
+    )
+
+    assert np.min(torus) >= 0.0
+    assert np.min(torus) == pytest.approx(0.0, abs=1.0e-30)
+
+
 def test_feii_velocity_shift_moves_template_feature_by_fractional_wavelength():
     wave = np.linspace(2400.0, 2800.0, 4001)
     template = np.exp(-0.5 * ((wave - 2600.0) / 5.0) ** 2)


### PR DESCRIPTION
## Summary
- exclude torus emission from foreground AGN/galaxy attenuation while keeping disk, FeII, lines, and Balmer continuum attenuated
- keep torus emission in the AGN and total rest SED after attenuation is applied to the other AGN components
- clip silicate absorption so the torus component cannot become negative

## Validation
- python -m py_compile src/grahspj/model.py
- conda run -n jaxcpu env PYTHONPATH=src pytest tests/test_model_assembly.py tests/test_model_helpers.py -q