### PR TITLE
Add posterior diagnostic corner and trace functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
   "speclite",
   "extinction",
   "matplotlib",
+  "corner",
   "jax>=0.4.30,<0.6",
   "jaxlib>=0.4.30,<0.6",
   "jax_cosmo",

--- a/src/grahspj/__init__.py
+++ b/src/grahspj/__init__.py
@@ -35,7 +35,9 @@ __all__ = [
     "PhotometryData",
     "SpectroscopyConfig",
     "SpectroscopyData",
+    "plot_corner",
     "plot_fit_sed",
+    "plot_trace",
     "style_path",
     "load_chimera_benchmark_dataset",
     "run_chimera_mass_benchmark",
@@ -53,6 +55,14 @@ def __getattr__(name):
         from .plotting import plot_fit_sed
 
         return plot_fit_sed
+    if name == "plot_corner":
+        from .plotting import plot_corner
+
+        return plot_corner
+    if name == "plot_trace":
+        from .plotting import plot_trace
+
+        return plot_trace
     if name == "style_path":
         from .mplstyle import style_path
 

--- a/src/grahspj/core.py
+++ b/src/grahspj/core.py
@@ -593,6 +593,48 @@ class GRAHSPJ:
             annotate_band_names=annotate_band_names,
         )
 
+    def plot_corner(
+        self,
+        output_path: str | Path | None = None,
+        params: list[str] | tuple[str, ...] | None = None,
+        max_params: int | None = 12,
+        labels: dict[str, str] | list[str] | tuple[str, ...] | None = None,
+        truths: dict[str, float | None] | list[float | None] | tuple[float | None, ...] | None = None,
+        show: bool = False,
+        **corner_kwargs,
+    ):
+        """Plot scalar posterior samples with the corner package."""
+        from .plotting import plot_corner
+
+        return plot_corner(
+            self,
+            output_path=output_path,
+            params=params,
+            max_params=max_params,
+            labels=labels,
+            truths=truths,
+            show=show,
+            **corner_kwargs,
+        )
+
+    def plot_trace(
+        self,
+        output_path: str | Path | None = None,
+        params: list[str] | tuple[str, ...] | None = None,
+        max_params: int | None = 12,
+        show: bool = False,
+    ):
+        """Plot scalar posterior sample traces, preserving chains when available."""
+        from .plotting import plot_trace
+
+        return plot_trace(
+            self,
+            output_path=output_path,
+            params=params,
+            max_params=max_params,
+            show=show,
+        )
+
     @staticmethod
     def _posterior_median_array(value: Any) -> np.ndarray:
         """Return a median predictive array over the leading sample axis."""

--- a/src/grahspj/plotting.py
+++ b/src/grahspj/plotting.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -20,6 +21,238 @@ _COMPONENT_STYLE = [
     (("agn_obs_sed",), "AGN total", "#718096", 1.4),
     (("total_obs_sed",), "Model total", "#000000", 2.0),
 ]
+
+_CORNER_SIGMA_LEVELS = tuple(1.0 - np.exp(-0.5 * np.asarray([1.0, 2.0, 3.0]) ** 2))
+_CORNER_ONE_SIGMA_QUANTILES = (0.16, 0.5, 0.84)
+
+
+def _posterior_samples(fitter_or_samples: Any) -> Mapping[str, Any]:
+    if isinstance(fitter_or_samples, Mapping):
+        samples = fitter_or_samples
+    else:
+        samples = getattr(fitter_or_samples, "samples", None)
+    if not samples:
+        raise RuntimeError("No fitted posterior samples are available.")
+    return samples
+
+
+def _grouped_trace_samples(fitter_or_samples: Any) -> tuple[Mapping[str, Any], bool]:
+    if not isinstance(fitter_or_samples, Mapping):
+        nuts_result = getattr(fitter_or_samples, "nuts_result", None)
+        if isinstance(nuts_result, Mapping):
+            mcmc = nuts_result.get("mcmc")
+            if mcmc is not None and hasattr(mcmc, "get_samples"):
+                return mcmc.get_samples(group_by_chain=True), True
+    return _posterior_samples(fitter_or_samples), False
+
+
+def _finite_scalar_sample_array(value: Any, *, grouped: bool) -> np.ndarray | None:
+    arr = np.asarray(value, dtype=float)
+    if grouped:
+        if arr.ndim != 2:
+            return None
+    elif arr.ndim != 1:
+        return None
+    if arr.size == 0 or not np.all(np.isfinite(arr)):
+        return None
+    return arr
+
+
+def _has_dynamic_range(value: Any, *, grouped: bool) -> bool:
+    arr = _finite_scalar_sample_array(value, grouped=grouped)
+    if arr is None:
+        return False
+    flat = arr.reshape(-1)
+    return bool(np.nanmin(flat) < np.nanmax(flat))
+
+
+def _select_scalar_params(
+    samples: Mapping[str, Any],
+    params: list[str] | tuple[str, ...] | None,
+    *,
+    max_params: int | None,
+    grouped: bool,
+) -> list[str]:
+    if params is not None:
+        selected = [str(param) for param in params]
+        for param in selected:
+            if param not in samples:
+                raise KeyError(f"Posterior sample {param!r} is not available.")
+            if _finite_scalar_sample_array(samples[param], grouped=grouped) is None:
+                raise ValueError(f"Posterior sample {param!r} is not a finite scalar sample site.")
+        return selected
+
+    selected = [
+        str(param)
+        for param, value in samples.items()
+        if _finite_scalar_sample_array(value, grouped=grouped) is not None
+    ]
+    if max_params is not None:
+        selected = selected[: int(max_params)]
+    if not selected:
+        raise RuntimeError("No finite scalar posterior sample sites are available for plotting.")
+    return selected
+
+
+def _select_corner_params(
+    samples: Mapping[str, Any],
+    params: list[str] | tuple[str, ...] | None,
+    *,
+    max_params: int | None,
+    grouped: bool,
+) -> list[str]:
+    if params is not None:
+        selected = [str(param) for param in params]
+        for param in selected:
+            if param not in samples:
+                raise KeyError(f"Posterior sample {param!r} is not available.")
+            if _finite_scalar_sample_array(samples[param], grouped=grouped) is None:
+                raise ValueError(f"Posterior sample {param!r} is not a finite scalar sample site.")
+            if not _has_dynamic_range(samples[param], grouped=grouped):
+                raise ValueError(f"Posterior sample {param!r} has no dynamic range and cannot be used in a corner plot.")
+        return selected
+
+    selected = [
+        str(param)
+        for param, value in samples.items()
+        if _has_dynamic_range(value, grouped=grouped)
+    ]
+    if max_params is not None:
+        selected = selected[: int(max_params)]
+    if not selected:
+        raise RuntimeError("No finite scalar posterior sample sites with dynamic range are available for corner plotting.")
+    return selected
+
+
+def _labels_for_params(params: list[str], labels: Mapping[str, str] | list[str] | tuple[str, ...] | None) -> list[str]:
+    if labels is None:
+        return params
+    if isinstance(labels, Mapping):
+        return [str(labels.get(param, param)) for param in params]
+    label_list = [str(label) for label in labels]
+    if len(label_list) != len(params):
+        raise ValueError("labels must have the same length as params.")
+    return label_list
+
+
+def _truths_for_params(params: list[str], truths: Mapping[str, float | None] | list[float | None] | tuple[float | None, ...] | None):
+    if truths is None:
+        return None
+    if isinstance(truths, Mapping):
+        return [truths.get(param) for param in params]
+    truth_list = list(truths)
+    if len(truth_list) != len(params):
+        raise ValueError("truths must have the same length as params.")
+    return truth_list
+
+
+def _sample_matrix(samples: Mapping[str, Any], params: list[str], *, grouped: bool) -> np.ndarray:
+    columns = []
+    draw_count = None
+    for param in params:
+        arr = _finite_scalar_sample_array(samples[param], grouped=grouped)
+        if arr is None:
+            raise ValueError(f"Posterior sample {param!r} is not a finite scalar sample site.")
+        column = arr.reshape(-1)
+        if draw_count is None:
+            draw_count = column.size
+        elif column.size != draw_count:
+            raise ValueError("Selected posterior samples do not have the same number of draws.")
+        columns.append(column)
+    return np.column_stack(columns)
+
+
+def plot_corner(
+    fitter_or_samples: Any,
+    output_path: str | Path | None = None,
+    params: list[str] | tuple[str, ...] | None = None,
+    max_params: int | None = 12,
+    labels: Mapping[str, str] | list[str] | tuple[str, ...] | None = None,
+    truths: Mapping[str, float | None] | list[float | None] | tuple[float | None, ...] | None = None,
+    show: bool = False,
+    **corner_kwargs,
+):
+    """Render a corner plot for scalar posterior sample sites."""
+    try:
+        import corner as corner_lib
+    except ModuleNotFoundError as exc:  # pragma: no cover - depends on optional runtime install state
+        raise RuntimeError("plot_corner requires the 'corner' package.") from exc
+
+    samples, grouped = _grouped_trace_samples(fitter_or_samples)
+    selected = _select_corner_params(samples, params, max_params=max_params, grouped=grouped)
+    matrix = _sample_matrix(samples, selected, grouped=grouped)
+    plot_labels = _labels_for_params(selected, labels)
+    plot_truths = _truths_for_params(selected, truths)
+    corner_kwargs.setdefault("levels", _CORNER_SIGMA_LEVELS)
+    corner_kwargs.setdefault("quantiles", _CORNER_ONE_SIGMA_QUANTILES)
+    corner_kwargs.setdefault("title_quantiles", _CORNER_ONE_SIGMA_QUANTILES)
+    corner_kwargs.setdefault("show_titles", True)
+    corner_kwargs.setdefault("smooth", 1.0)
+    corner_kwargs.setdefault("smooth1d", 1.0)
+    corner_kwargs.setdefault("plot_datapoints", False)
+    corner_kwargs.setdefault("fill_contours", True)
+    corner_kwargs.setdefault("title_kwargs", {"fontsize": 8})
+    corner_kwargs.setdefault("title_fmt", ".3g")
+
+    with use_style():
+        fig = corner_lib.corner(matrix, labels=plot_labels, truths=plot_truths, **corner_kwargs)
+        if output_path is not None:
+            output_path = Path(output_path)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            fig.savefig(output_path)
+        if show:
+            plt.show()
+        else:
+            plt.close(fig)
+        return fig
+
+
+def plot_trace(
+    fitter_or_samples: Any,
+    output_path: str | Path | None = None,
+    params: list[str] | tuple[str, ...] | None = None,
+    max_params: int | None = 12,
+    show: bool = False,
+):
+    """Render per-parameter trace plots, preserving NUTS chains when available."""
+    samples, grouped = _grouped_trace_samples(fitter_or_samples)
+    selected = _select_scalar_params(samples, params, max_params=max_params, grouped=grouped)
+    chain_values = []
+    for param in selected:
+        arr = _finite_scalar_sample_array(samples[param], grouped=grouped)
+        if arr is None:
+            raise ValueError(f"Posterior sample {param!r} is not a finite scalar sample site.")
+        chain_values.append(arr if grouped else arr.reshape(1, -1))
+
+    with use_style():
+        fig, axes = plt.subplots(
+            len(selected),
+            1,
+            figsize=(10, max(2.4, 1.7 * len(selected))),
+            sharex=True,
+            squeeze=False,
+        )
+        axes_flat = axes.ravel()
+        for ax, param, values in zip(axes_flat, selected, chain_values):
+            draws = np.arange(values.shape[1])
+            for chain_index, chain in enumerate(values):
+                label = f"chain {chain_index}" if values.shape[0] > 1 else None
+                ax.plot(draws, chain, lw=0.8, alpha=0.85, label=label)
+            ax.set_ylabel(param, fontsize=8)
+            ax.tick_params(axis="both", labelsize=8)
+            if values.shape[0] > 1:
+                ax.legend(loc="upper right", fontsize=8)
+        axes_flat[-1].set_xlabel("Draw", fontsize=9)
+        fig.tight_layout()
+        if output_path is not None:
+            output_path = Path(output_path)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            fig.savefig(output_path)
+        if show:
+            plt.show()
+        else:
+            plt.close(fig)
+        return fig
 
 
 def _median_site(pred: dict[str, Any], key: str) -> np.ndarray:

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,8 +1,12 @@
 from pathlib import Path
+import sys
+import types
 
+import matplotlib.pyplot as plt
 import numpy as np
+import pytest
 
-from grahspj.plotting import plot_fit_sed
+from grahspj.plotting import plot_corner, plot_fit_sed, plot_trace
 
 
 def test_plot_fit_sed_writes_output(tmp_path):
@@ -94,3 +98,217 @@ def test_plot_fit_sed_can_disable_band_annotations(tmp_path):
     assert fig is not None
     assert output.exists()
     assert output.stat().st_size > 0
+
+
+def test_plot_corner_writes_output_and_calls_corner(tmp_path, monkeypatch):
+    captured = {}
+    fake_corner_module = types.ModuleType("corner")
+
+    def _corner(data, labels=None, truths=None, **kwargs):
+        captured["data"] = data
+        captured["labels"] = labels
+        captured["truths"] = truths
+        captured["kwargs"] = kwargs
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        ax.plot([0.0, 1.0], [0.0, 1.0])
+        return fig
+
+    fake_corner_module.corner = _corner
+    monkeypatch.setitem(sys.modules, "corner", fake_corner_module)
+
+    output = tmp_path / "corner.pdf"
+    fig = plot_corner(
+        {
+            "alpha": np.array([1.0, 2.0, 3.0]),
+            "vector_site": np.ones((3, 2)),
+            "beta": np.array([3.0, 2.0, 1.0]),
+        },
+        output_path=output,
+        params=["beta", "alpha"],
+        labels={"beta": "Beta", "alpha": "Alpha"},
+        truths={"beta": 2.0},
+        bins=4,
+    )
+
+    assert fig is not None
+    assert output.exists()
+    assert output.stat().st_size > 0
+    assert captured["data"].shape == (3, 2)
+    np.testing.assert_allclose(captured["data"][:, 0], [3.0, 2.0, 1.0])
+    np.testing.assert_allclose(captured["data"][:, 1], [1.0, 2.0, 3.0])
+    assert captured["labels"] == ["Beta", "Alpha"]
+    assert captured["truths"] == [2.0, None]
+    assert captured["kwargs"]["bins"] == 4
+    np.testing.assert_allclose(captured["kwargs"]["levels"], 1.0 - np.exp(-0.5 * np.array([1.0, 2.0, 3.0]) ** 2))
+    assert captured["kwargs"]["quantiles"] == (0.16, 0.5, 0.84)
+    assert captured["kwargs"]["title_quantiles"] == (0.16, 0.5, 0.84)
+    assert captured["kwargs"]["show_titles"] is True
+    assert captured["kwargs"]["smooth"] == 1.0
+    assert captured["kwargs"]["smooth1d"] == 1.0
+    assert captured["kwargs"]["plot_datapoints"] is False
+    assert captured["kwargs"]["fill_contours"] is True
+    assert captured["kwargs"]["title_kwargs"] == {"fontsize": 8}
+    assert captured["kwargs"]["title_fmt"] == ".3g"
+
+
+def test_plot_corner_allows_default_overrides(monkeypatch):
+    captured = {}
+    fake_corner_module = types.ModuleType("corner")
+
+    def _corner(data, labels=None, truths=None, **kwargs):
+        captured["kwargs"] = kwargs
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        ax.plot([0.0, 1.0], [0.0, 1.0])
+        return fig
+
+    fake_corner_module.corner = _corner
+    monkeypatch.setitem(sys.modules, "corner", fake_corner_module)
+
+    plot_corner(
+        {"alpha": np.array([1.0, 2.0, 3.0])},
+        levels=[0.5],
+        quantiles=[0.25, 0.75],
+        title_quantiles=[0.1, 0.5, 0.9],
+        show_titles=False,
+        smooth=0.5,
+        smooth1d=None,
+        plot_datapoints=True,
+        fill_contours=False,
+        title_kwargs={"fontsize": 6},
+        title_fmt=".2f",
+    )
+
+    assert captured["kwargs"]["levels"] == [0.5]
+    assert captured["kwargs"]["quantiles"] == [0.25, 0.75]
+    assert captured["kwargs"]["title_quantiles"] == [0.1, 0.5, 0.9]
+    assert captured["kwargs"]["show_titles"] is False
+    assert captured["kwargs"]["smooth"] == 0.5
+    assert captured["kwargs"]["smooth1d"] is None
+    assert captured["kwargs"]["plot_datapoints"] is True
+    assert captured["kwargs"]["fill_contours"] is False
+    assert captured["kwargs"]["title_kwargs"] == {"fontsize": 6}
+    assert captured["kwargs"]["title_fmt"] == ".2f"
+
+
+def test_plot_corner_skips_constant_default_params(monkeypatch):
+    captured = {}
+    fake_corner_module = types.ModuleType("corner")
+
+    def _corner(data, labels=None, truths=None, **kwargs):
+        captured["data"] = data
+        captured["labels"] = labels
+        captured["truths"] = truths
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        ax.plot([0.0, 1.0], [0.0, 1.0])
+        return fig
+
+    fake_corner_module.corner = _corner
+    monkeypatch.setitem(sys.modules, "corner", fake_corner_module)
+
+    fig = plot_corner(
+        {
+            "constant": np.array([2.0, 2.0, 2.0]),
+            "dynamic": np.array([1.0, 2.0, 3.0]),
+        }
+    )
+
+    assert fig is not None
+    assert captured["data"].shape == (3, 1)
+    np.testing.assert_allclose(captured["data"][:, 0], [1.0, 2.0, 3.0])
+    assert captured["labels"] == ["dynamic"]
+
+
+def test_plot_corner_rejects_explicit_constant_param(monkeypatch):
+    fake_corner_module = types.ModuleType("corner")
+    fake_corner_module.corner = lambda *args, **kwargs: plt.figure()
+    monkeypatch.setitem(sys.modules, "corner", fake_corner_module)
+
+    with pytest.raises(ValueError, match="has no dynamic range"):
+        plot_corner({"constant": np.array([2.0, 2.0, 2.0])}, params=["constant"])
+
+
+def test_plot_corner_rejects_all_constant_default_params(monkeypatch):
+    fake_corner_module = types.ModuleType("corner")
+    fake_corner_module.corner = lambda *args, **kwargs: plt.figure()
+    monkeypatch.setitem(sys.modules, "corner", fake_corner_module)
+
+    with pytest.raises(RuntimeError, match="dynamic range"):
+        plot_corner({"constant": np.array([2.0, 2.0, 2.0])})
+
+
+def test_plot_trace_writes_grouped_chain_samples(tmp_path):
+    class _MCMC:
+        def __init__(self):
+            self.grouped = None
+
+        def get_samples(self, group_by_chain=False):
+            self.grouped = group_by_chain
+            return {
+                "alpha": np.array([[1.0, 2.0, 3.0], [1.5, 2.5, 3.5]]),
+                "vector_site": np.ones((2, 3, 2)),
+                "beta": np.array([[3.0, 2.0, 1.0], [3.5, 2.5, 1.5]]),
+            }
+
+    class _Fitter:
+        def __init__(self):
+            self.mcmc = _MCMC()
+            self.samples = {"alpha": np.array([-1.0])}
+            self.nuts_result = {"mcmc": self.mcmc}
+
+    fitter = _Fitter()
+    output = tmp_path / "trace.pdf"
+    fig = plot_trace(fitter, output_path=output, params=["beta", "alpha"])
+
+    assert fitter.mcmc.grouped is True
+    assert fig is not None
+    assert output.exists()
+    assert output.stat().st_size > 0
+    assert [ax.get_ylabel() for ax in fig.axes] == ["beta", "alpha"]
+    assert len(fig.axes[0].lines) == 2
+    assert fig.axes[0].yaxis.label.get_size() == 8
+    assert fig.axes[-1].xaxis.label.get_size() == 9
+    assert {tick.get_fontsize() for ax in fig.axes for tick in ax.get_xticklabels() + ax.get_yticklabels()} == {8.0}
+
+
+def test_grahspj_corner_and_trace_methods_delegate(monkeypatch):
+    import grahspj.plotting as plotting
+
+    model = types.ModuleType("grahspj.model")
+    model.grahsp_photometric_model = lambda *args, **kwargs: None
+    preload = types.ModuleType("grahspj.preload")
+    preload.ModelContext = object
+    preload.build_model_context = lambda config: None
+    monkeypatch.setitem(sys.modules, "grahspj.model", model)
+    monkeypatch.setitem(sys.modules, "grahspj.preload", preload)
+    sys.modules.pop("grahspj.core", None)
+
+    calls = {}
+
+    def _plot_corner(fitter, **kwargs):
+        calls["corner"] = (fitter, kwargs)
+        return "corner"
+
+    def _plot_trace(fitter, **kwargs):
+        calls["trace"] = (fitter, kwargs)
+        return "trace"
+
+    try:
+        from grahspj.core import GRAHSPJ
+
+        monkeypatch.setattr(plotting, "plot_corner", _plot_corner)
+        monkeypatch.setattr(plotting, "plot_trace", _plot_trace)
+        fitter = object.__new__(GRAHSPJ)
+
+        assert fitter.plot_corner(output_path="corner.pdf", params=["alpha"]) == "corner"
+        assert fitter.plot_trace(output_path="trace.pdf", params=["beta"]) == "trace"
+        assert calls["corner"][0] is fitter
+        assert calls["corner"][1]["output_path"] == "corner.pdf"
+        assert calls["corner"][1]["params"] == ["alpha"]
+        assert calls["trace"][0] is fitter
+        assert calls["trace"][1]["output_path"] == "trace.pdf"
+        assert calls["trace"][1]["params"] == ["beta"]
+    finally:
+        sys.modules.pop("grahspj.core", None)


### PR DESCRIPTION
## Summary

Add posterior diagnostic plotting support to GRAHSPJ with public corner and trace plot helpers, plus convenience methods on `GRAHSPJ`.

## Changes

- Added `plot_corner()` and `plot_trace()` helpers.
- Added `GRAHSPJ.plot_corner()` and `GRAHSPJ.plot_trace()` convenience methods.
- Added `corner` as a package dependency.
- Improved corner plot defaults:
  - 1, 2, and 3 sigma contour levels
  - 16/50/84 percentile titles
  - smoothed filled contours
  - hidden raw sample points
  - compact numeric formatting
  - smaller title fonts
  - constant scalar parameters skipped by default
- Updated trace plots to preserve grouped NUTS chains when available.
- Reduced trace plot label and tick font sizes for better readability.

## Validation

```bash
env MPLCONFIGDIR=/tmp/matplotlib-grahspj PYTHONPATH=/home/dutra/dev/nicholas/grahspj/src /home/dutra/.conda/envs/jaxcpu4/bin/python -m pytest -o cache_dir=/tmp/pytest-cache-nicholas tests/test_plotting.py