### PR TITLE
Add nested sampling control options and bump jax version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
   { name = "grahspj contributors" }
 ]
 dependencies = [
-  "numpy<2.4",
+  "numpy>=2,<2.4",
   "scipy",
   "setuptools>=68,<81",
   "astropy",
@@ -21,10 +21,12 @@ dependencies = [
   "extinction",
   "matplotlib",
   "corner",
-  "jax>=0.4.30,<0.6",
-  "jaxlib>=0.4.30,<0.6",
+  "jax==0.6.2",
+  "jaxlib==0.6.2",
   "jax_cosmo",
-  "numpyro>=0.15,<0.20",
+  "numpyro==0.19.0",
+  "jaxns==2.6.9",
+  "tensorflow-probability==0.25.0",
   "optax",
   "dsps",
   "diffstar",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,8 @@
 -e .
+numpy>=2,<2.4
+jax==0.6.2
+jaxlib==0.6.2
+numpyro==0.19.0
+jaxns==2.6.9
+tensorflow-probability==0.25.0
 pytest

--- a/src/grahspj/core.py
+++ b/src/grahspj/core.py
@@ -212,6 +212,13 @@ class GRAHSPJ:
         ns_live_points: int | None = None,
         ns_max_samples: int | None = None,
         ns_dlogz: float | None = None,
+        ns_resamples: int | None = None,
+        ns_difficult_model: bool = False,
+        ns_parameter_estimation: bool = False,
+        ns_num_parallel_workers: int | None = None,
+        ns_init_efficiency_threshold: float | None = None,
+        ns_max_likelihood_evals: int | None = None,
+        ns_efficiency_threshold: float | None = None,
         plot_fig: bool = False,
         save_fig: bool = False,
         save_result: bool = False,
@@ -241,6 +248,20 @@ class GRAHSPJ:
             ns_max_samples = kwargs.pop("ns_max_samples")
         if "ns_dlogz" in kwargs and ns_dlogz is None:
             ns_dlogz = kwargs.pop("ns_dlogz")
+        if "ns_resamples" in kwargs and ns_resamples is None:
+            ns_resamples = kwargs.pop("ns_resamples")
+        if "ns_difficult_model" in kwargs:
+            ns_difficult_model = kwargs.pop("ns_difficult_model")
+        if "ns_parameter_estimation" in kwargs:
+            ns_parameter_estimation = kwargs.pop("ns_parameter_estimation")
+        if "ns_num_parallel_workers" in kwargs and ns_num_parallel_workers is None:
+            ns_num_parallel_workers = kwargs.pop("ns_num_parallel_workers")
+        if "ns_init_efficiency_threshold" in kwargs and ns_init_efficiency_threshold is None:
+            ns_init_efficiency_threshold = kwargs.pop("ns_init_efficiency_threshold")
+        if "ns_max_likelihood_evals" in kwargs and ns_max_likelihood_evals is None:
+            ns_max_likelihood_evals = kwargs.pop("ns_max_likelihood_evals")
+        if "ns_efficiency_threshold" in kwargs and ns_efficiency_threshold is None:
+            ns_efficiency_threshold = kwargs.pop("ns_efficiency_threshold")
         if "target_accept_prob" in kwargs and target_accept_prob is None:
             target_accept_prob = kwargs.pop("target_accept_prob")
         use_map_init_explicit = "use_map_init" in kwargs
@@ -324,6 +345,20 @@ class GRAHSPJ:
                 ns_kwargs["max_samples"] = ns_max_samples
             if ns_dlogz is not None:
                 ns_kwargs["dlogz"] = ns_dlogz
+            if ns_resamples is not None:
+                ns_kwargs["num_resamples"] = ns_resamples
+            if ns_difficult_model:
+                ns_kwargs["difficult_model"] = bool(ns_difficult_model)
+            if ns_parameter_estimation:
+                ns_kwargs["parameter_estimation"] = bool(ns_parameter_estimation)
+            if ns_num_parallel_workers is not None:
+                ns_kwargs["num_parallel_workers"] = ns_num_parallel_workers
+            if ns_init_efficiency_threshold is not None:
+                ns_kwargs["init_efficiency_threshold"] = ns_init_efficiency_threshold
+            if ns_max_likelihood_evals is not None:
+                ns_kwargs["max_likelihood_evals"] = ns_max_likelihood_evals
+            if ns_efficiency_threshold is not None:
+                ns_kwargs["efficiency_threshold"] = ns_efficiency_threshold
             fit_output = self.fit_ns(**ns_kwargs)
         else:
             raise ValueError("fit_method must be one of: 'optax+nuts', 'optax', 'nuts', 'ns'")
@@ -475,19 +510,59 @@ class GRAHSPJ:
         num_live_points: int | None = None,
         max_samples: int | None = None,
         dlogz: float | None = None,
+        num_resamples: int | None = None,
+        difficult_model: bool | None = None,
+        parameter_estimation: bool | None = None,
+        num_parallel_workers: int | None = None,
+        init_efficiency_threshold: float | None = None,
+        max_likelihood_evals: int | None = None,
+        efficiency_threshold: float | None = None,
+        ns_difficult_model: bool | None = None,
+        ns_parameter_estimation: bool | None = None,
+        ns_num_parallel_workers: int | None = None,
+        ns_init_efficiency_threshold: float | None = None,
+        ns_max_likelihood_evals: int | None = None,
+        ns_efficiency_threshold: float | None = None,
+        ns_resamples: int | None = None,
         progress_bar: bool = True,
     ):
         """Run full-model nested sampling and resample equal-weight posterior draws."""
         NestedSampler = _get_nested_sampler_cls()
 
+        if ns_difficult_model is not None:
+            difficult_model = ns_difficult_model
+        if ns_parameter_estimation is not None:
+            parameter_estimation = ns_parameter_estimation
+        if ns_num_parallel_workers is not None and num_parallel_workers is None:
+            num_parallel_workers = ns_num_parallel_workers
+        if ns_init_efficiency_threshold is not None and init_efficiency_threshold is None:
+            init_efficiency_threshold = ns_init_efficiency_threshold
+        if ns_max_likelihood_evals is not None and max_likelihood_evals is None:
+            max_likelihood_evals = ns_max_likelihood_evals
+        if ns_efficiency_threshold is not None and efficiency_threshold is None:
+            efficiency_threshold = ns_efficiency_threshold
+        if ns_resamples is not None and num_resamples is None:
+            num_resamples = ns_resamples
+
         constructor_kwargs: dict[str, Any] = {"verbose": bool(progress_bar)}
         if num_live_points is not None:
             constructor_kwargs["num_live_points"] = int(num_live_points)
-        if max_samples is not None:
-            constructor_kwargs["max_samples"] = int(max_samples)
+        constructor_kwargs["max_samples"] = None if max_samples is None else int(max_samples)
+        if difficult_model:
+            constructor_kwargs["difficult_model"] = bool(difficult_model)
+        if parameter_estimation:
+            constructor_kwargs["parameter_estimation"] = bool(parameter_estimation)
+        if num_parallel_workers is not None:
+            constructor_kwargs["num_parallel_workers"] = int(num_parallel_workers)
+        if init_efficiency_threshold is not None:
+            constructor_kwargs["init_efficiency_threshold"] = float(init_efficiency_threshold)
         termination_kwargs: dict[str, Any] = {}
         if dlogz is not None:
             termination_kwargs["dlogZ"] = float(dlogz)
+        if max_likelihood_evals is not None:
+            termination_kwargs["max_num_likelihood_evaluations"] = int(max_likelihood_evals)
+        if efficiency_threshold is not None:
+            termination_kwargs["efficiency_threshold"] = float(efficiency_threshold)
 
         sampler = NestedSampler(
             self._model,
@@ -497,9 +572,10 @@ class GRAHSPJ:
         rng_key = jax.random.PRNGKey(self.config.inference.seed + 2)
         sampler.run(rng_key)
         posterior_rng_key = jax.random.PRNGKey(self.config.inference.seed + 3)
+        posterior_num_samples = int(self.config.inference.num_samples if num_resamples is None else num_resamples)
         samples = sampler.get_samples(
             posterior_rng_key,
-            num_samples=int(self.config.inference.num_samples),
+            num_samples=posterior_num_samples,
             group_by_chain=False,
         )
         self.ns_result = {
@@ -507,6 +583,7 @@ class GRAHSPJ:
             "results": getattr(sampler, "_results", None),
             "constructor_kwargs": dict(getattr(sampler, "constructor_kwargs", constructor_kwargs)),
             "termination_kwargs": dict(getattr(sampler, "termination_kwargs", termination_kwargs)),
+            "num_resamples": posterior_num_samples,
         }
         self.samples = {k: np.asarray(v) for k, v in samples.items()}
         self.predictive = None

--- a/tests/test_diffstar_host.py
+++ b/tests/test_diffstar_host.py
@@ -382,6 +382,13 @@ def test_fit_dispatch_methods(monkeypatch):
         ns_live_points=25,
         ns_max_samples=200,
         ns_dlogz=0.1,
+        ns_resamples=30,
+        ns_difficult_model=True,
+        ns_parameter_estimation=True,
+        ns_num_parallel_workers=3,
+        ns_init_efficiency_threshold=0.2,
+        ns_max_likelihood_evals=5000,
+        ns_efficiency_threshold=0.001,
     )
     assert calls == [
         (
@@ -390,6 +397,13 @@ def test_fit_dispatch_methods(monkeypatch):
                 "num_live_points": 25,
                 "max_samples": 200,
                 "dlogz": 0.1,
+                "num_resamples": 30,
+                "difficult_model": True,
+                "parameter_estimation": True,
+                "num_parallel_workers": 3,
+                "init_efficiency_threshold": 0.2,
+                "max_likelihood_evals": 5000,
+                "efficiency_threshold": 0.001,
                 "progress_bar": False,
             },
         )
@@ -409,7 +423,7 @@ def test_fit_ns_populates_samples(monkeypatch):
             self.run_args = (rng_key, args, kwargs)
 
         def get_samples(self, rng_key, num_samples, *, group_by_chain=False):
-            assert num_samples == 5
+            assert num_samples == 7
             assert group_by_chain is False
             return {
                 "log_stellar_mass": np.linspace(10.0, 10.4, num_samples),
@@ -430,6 +444,13 @@ def test_fit_ns_populates_samples(monkeypatch):
         num_live_points=17,
         max_samples=123,
         dlogz=0.05,
+        ns_difficult_model=True,
+        ns_parameter_estimation=True,
+        ns_num_parallel_workers=2,
+        ns_init_efficiency_threshold=0.15,
+        ns_max_likelihood_evals=1000,
+        ns_efficiency_threshold=0.01,
+        ns_resamples=7,
         progress_bar=False,
     )
 
@@ -437,11 +458,45 @@ def test_fit_ns_populates_samples(monkeypatch):
     assert result["constructor_kwargs"]["num_live_points"] == 17
     assert result["constructor_kwargs"]["max_samples"] == 123
     assert result["constructor_kwargs"]["verbose"] is False
+    assert result["constructor_kwargs"]["difficult_model"] is True
+    assert result["constructor_kwargs"]["parameter_estimation"] is True
+    assert result["constructor_kwargs"]["num_parallel_workers"] == 2
+    assert result["constructor_kwargs"]["init_efficiency_threshold"] == 0.15
     assert result["termination_kwargs"]["dlogZ"] == 0.05
+    assert result["termination_kwargs"]["max_num_likelihood_evaluations"] == 1000
+    assert result["termination_kwargs"]["efficiency_threshold"] == 0.01
+    assert result["num_resamples"] == 7
     assert fitter.ns_result is result
     assert set(fitter.samples) == {"log_stellar_mass", "host_age_weights", "host_lgmet_weights"}
-    assert fitter.samples["log_stellar_mass"].shape == (5,)
+    assert fitter.samples["log_stellar_mass"].shape == (7,)
     assert fitter.predictive is None
+
+
+def test_fit_ns_passes_explicit_none_max_samples(monkeypatch):
+    captured = {}
+
+    class _FakeNestedSampler:
+        def __init__(self, model, *, constructor_kwargs=None, termination_kwargs=None):
+            captured["constructor_kwargs"] = constructor_kwargs or {}
+            self._results = {"status": "ok"}
+
+        def run(self, rng_key, *args, **kwargs):
+            return None
+
+        def get_samples(self, rng_key, num_samples, *, group_by_chain=False):
+            return {"log_stellar_mass": np.linspace(10.0, 10.4, num_samples)}
+
+    monkeypatch.setattr("grahspj.core._get_nested_sampler_cls", lambda: _FakeNestedSampler)
+
+    fitter = GRAHSPJ.__new__(GRAHSPJ)
+    fitter.config = _mock_config()
+    fitter.config.inference.num_samples = 5
+    fitter.predictive = None
+    fitter._model = lambda: None
+
+    GRAHSPJ.fit_ns(fitter, num_live_points=17, progress_bar=False)
+
+    assert captured["constructor_kwargs"]["max_samples"] is None
 
 
 def test_ns_samples_work_with_summary_and_predict(monkeypatch):


### PR DESCRIPTION
## Summary

This PR updates the JAX/NumPyro/JAXNS dependency stack and enables the newer JAXNS runtime behavior that reports `log(Z | remaining) est` during nested-sampling progress output. That diagnostic is useful for seeing whether the run is genuinely approaching the requested evidence tolerance or stopping early with substantial remaining evidence.

It also adds nested-sampling controls to `GRAHSPJ.fit()` / `fit_ns()` so production runs can tune JAXNS behavior directly.

## Changes

- Pin the nested-sampling runtime stack:
  - `jax==0.6.2`
  - `jaxlib==0.6.2`
  - `numpyro==0.19.0`
  - `jaxns==2.6.9`
  - `tensorflow-probability==0.25.0`
  - `numpy>=2,<2.4`

- Add nested-sampling options:
  - posterior resample count
  - difficult-model mode
  - parameter-estimation mode
  - parallel workers
  - init efficiency threshold
  - likelihood-evaluation cap
  - efficiency threshold

- Pass `max_samples=None` explicitly when no nested-sampler max is requested, avoiding NumPyro’s hidden `max_samples=1e4` default and allowing JAXNS to use its own larger static allocation.

- Store the resolved nested posterior resample count in `ns_result`.

## Why

The previous environment could silently stop nested sampling around the default sample cap, even when `NS_MAX_SAMPLES` was not configured by the caller. With the newer JAXNS stack and explicit `max_samples=None`, runs expose better progress diagnostics and avoid the unexpectedly low NumPyro wrapper cap.

The new `log(Z | remaining) est` output makes it much easier to diagnose whether a run is still evidence-limited.

## Validation

- Compiled updated source and tests.
- Ran a runtime smoke check confirming `fit_ns()` passes `constructor_kwargs["max_samples"] is None`.
- Added tests covering nested-sampling option forwarding and explicit `None` max-sample behavior.
- Tests were run with `pytest`.
