### PR TITLE
[codex] Fix Balmer continuum wavelength units

### DIFF
--- a/src/grahspj/model.py
+++ b/src/grahspj/model.py
@@ -392,7 +392,7 @@ def _cigale_nebular_correction(f_esc, f_dust):
 def _balmer_continuum_jax(wave, balmer_norm, balmer_te, balmer_tau, balmer_vel):
     """Evaluate the broadened Balmer continuum template."""
     lam_be = 3646.0
-    h_c_per_k_B = 1.439e7
+    h_c_per_k_B = 1.4388e8
     bb = (wave**-5) / jnp.expm1(jnp.clip(h_c_per_k_B / (balmer_te * wave), 1e-9, 700.0))
     bb0 = (lam_be**-5) / jnp.expm1(jnp.clip(h_c_per_k_B / (balmer_te * lam_be), 1e-9, 700.0))
     tau = balmer_tau * (wave / lam_be) ** 3

--- a/tests/test_model_helpers.py
+++ b/tests/test_model_helpers.py
@@ -384,6 +384,22 @@ def test_balmer_continuum_has_3646_angstrom_edge_and_blueward_emission():
     assert np.all(np.isfinite(balmer))
 
 
+def test_balmer_continuum_planck_factor_uses_angstrom_kelvin_constant():
+    wave = np.linspace(1000.0, 3646.0, 2647)
+    balmer = np.asarray(_balmer_continuum_jax(wave, balmer_norm=1.0, balmer_te=15000.0, balmer_tau=1.0, balmer_vel=0.0))
+
+    idx_1500 = np.argmin(np.abs(wave - 1500.0))
+    idx_3646 = np.argmin(np.abs(wave - 3646.0))
+    h_c_per_k_B_angstrom = 1.4388e8
+    ratio_wave = np.asarray([wave[idx_1500], wave[idx_3646]])
+    tau = (ratio_wave / 3646.0) ** 3
+    bb = (ratio_wave**-5) / np.expm1(h_c_per_k_B_angstrom / (15000.0 * ratio_wave))
+    bb0 = (3646.0**-5) / np.expm1(h_c_per_k_B_angstrom / (15000.0 * 3646.0))
+    expected = (1.0 - np.exp(-tau)) * bb / bb0
+
+    assert balmer[idx_1500] / balmer[idx_3646] == pytest.approx(expected[0] / expected[1], rel=1.0e-6)
+
+
 def test_redshift_projection_uses_luminosity_distance_and_one_plus_z():
     rest_wave = np.asarray([1000.0, 2000.0, 3000.0])
     rest_lum = np.asarray([4.0, 4.0, 4.0])


### PR DESCRIPTION
## Summary

- Convert the Balmer continuum Planck constant from nm K to Angstrom K units.
- Add a regression test that checks the normalized Balmer continuum shape against the expected Angstrom-based Planck factor.

## Why

The Balmer continuum implementation uses wavelengths in Angstrom, including `lam_be = 3646.0`, but the Planck exponent used `hc/k_B = 1.439e7`, which is the nm K value. This made the exponent 10x too small and flattened the Balmer continuum as if the hardcoded 15,000 K temperature were 150,000 K.

## Validation

```bash
PYTHONPATH=src:../jaxqsofit/src conda run -n jaxcpu pytest \
  tests/test_model_helpers.py::test_balmer_continuum_has_3646_angstrom_edge_and_blueward_emission \
  tests/test_model_helpers.py::test_balmer_continuum_planck_factor_uses_angstrom_kelvin_constant -q
```

Result: `2 passed, 15 warnings`.
