### PR TITLE
[codex] Fix upper-limit likelihood scaling

### DIFF
--- a/src/grahspj/model.py
+++ b/src/grahspj/model.py
@@ -1124,7 +1124,7 @@ def _sample_redshift(context: ModelContext, prior_config: dict[str, Any], cfg) -
 
 def _chi2_upper_limit(obs_fluxes, model_fluxes, total_variance):
     """Return the one-sided chi-square contribution for upper limits."""
-    z = (obs_fluxes - model_fluxes) / (jnp.sqrt(2.0) * jnp.maximum(total_variance, 1e-30))
+    z = (obs_fluxes - model_fluxes) / jnp.sqrt(2.0 * jnp.maximum(total_variance, 1e-60))
     return -2.0 * jnp.log(0.5 * (1.0 + jax.scipy.special.erf(z)) + 1e-300)
 
 

--- a/tests/test_model_helpers.py
+++ b/tests/test_model_helpers.py
@@ -37,6 +37,7 @@ from grahspj.model import (
     _attenuation_curve,
     _apply_biattenuation,
     _balmer_continuum_jax,
+    _chi2_upper_limit,
     _feii_component,
     _flux_conserving_line_gaussians,
     _host_dust_emission,
@@ -392,6 +393,19 @@ def test_redshift_projection_uses_luminosity_distance_and_one_plus_z():
     obs = np.asarray(_redshift_to_obs(rest_wave, rest_lum, obs_wave, redshift=1.0, luminosity_distance_m=d_l))
 
     assert np.allclose(obs, rest_lum / (4.0 * np.pi * d_l**2 * 2.0))
+
+
+def test_upper_limit_likelihood_uses_standard_deviation_not_variance():
+    limit = np.asarray([1.0])
+    model = np.asarray([1.2])
+    sigma = np.asarray([0.1])
+
+    chi2 = np.asarray(_chi2_upper_limit(limit, model, sigma**2))
+
+    flux_scale = 1.0e3
+    chi2_scaled = np.asarray(_chi2_upper_limit(limit * flux_scale, model * flux_scale, (sigma * flux_scale) ** 2))
+
+    assert chi2_scaled == pytest.approx(chi2, rel=1.0e-12)
 
 
 def test_filter_projection_flat_flambda_to_mjy_units():


### PR DESCRIPTION
## Summary

- Fix the upper-limit likelihood denominator to use the total standard deviation instead of total variance.
- Add a regression test that verifies the upper-limit contribution is invariant under flux-unit rescaling.

## Why

`total_variance` is built as a variance from squared observational, systematic, and variability uncertainties. The one-sided Gaussian upper-limit term needs `sqrt(2) * sigma`, not `sqrt(2) * sigma^2`. Using variance directly made upper-limit behavior depend on the arbitrary flux units and made the transition too sharp for small flux errors.

## Validation

```bash
PYTHONPATH=src:../jaxqsofit/src conda run -n jaxcpu pytest tests/test_model_helpers.py::test_upper_limit_likelihood_uses_standard_deviation_not_variance -q
PYTHONPATH=src:../jaxqsofit/src conda run -n jaxcpu pytest tests/test_model_helpers.py -q
```

Results: `1 passed` and `38 passed`.
