### PR TITLE
[codex] Fix padded filter projection weights

### DIFF
--- a/src/grahspj/model.py
+++ b/src/grahspj/model.py
@@ -494,7 +494,7 @@ def _project_filters(obs_flux, packed_filters):
     values = left * (1.0 - interp_weight) + right * interp_weight
     values = jnp.where(valid_mask, values, 0.0)
     weighted_trans = jnp.where(valid_mask, transmission, 0.0)
-    weighted_wave = jnp.where(valid_mask, work_wave, 0.0)
+    weighted_wave = work_wave
     numer = jnp.trapezoid(values * weighted_trans, weighted_wave, axis=1)
     denom = jnp.maximum(jnp.trapezoid(weighted_trans, weighted_wave, axis=1), 1e-30)
     f_lambda = numer / denom

--- a/src/grahspj/preload.py
+++ b/src/grahspj/preload.py
@@ -869,7 +869,7 @@ def _build_fixed_filter_projection_matrices(
 
     for i in range(n_filters):
         weighted_trans = np.where(packed_filters.valid_mask[i], packed_filters.transmission[i], 0.0)
-        weighted_wave = np.where(packed_filters.valid_mask[i], packed_filters.work_wave[i], 0.0)
+        weighted_wave = packed_filters.work_wave[i]
         denom = max(float(np.trapezoid(weighted_trans, weighted_wave)), 1.0e-30)
         coeff = _trapezoid_weights(weighted_wave) * weighted_trans / denom
         coeff *= 1.0e-10 / 299792458.0 * 1.0e29 * float(packed_filters.effective_wavelength[i]) ** 2
@@ -904,8 +904,8 @@ def _build_filter_projection_matrices_for_redshift(
         valid = np.asarray(packed_filters.valid_mask[i], dtype=bool)
         filt_wave = np.asarray(packed_filters.work_wave[i], dtype=float)
         filt_trans = np.where(valid, packed_filters.transmission[i], 0.0)
-        denom = max(float(np.trapezoid(filt_trans, np.where(valid, filt_wave, 0.0))), 1.0e-30)
-        coeff = _trapezoid_weights(np.where(valid, filt_wave, 0.0)) * filt_trans / denom
+        denom = max(float(np.trapezoid(filt_trans, filt_wave)), 1.0e-30)
+        coeff = _trapezoid_weights(filt_wave) * filt_trans / denom
         coeff *= 1.0e-10 / 299792458.0 * 1.0e29 * float(packed_filters.effective_wavelength[i]) ** 2
         rest_at_filter = filt_wave / max(1.0 + float(redshift), 1.0e-8)
         pos = np.searchsorted(rest_wave, rest_at_filter, side="right") - 1

--- a/tests/test_model_helpers.py
+++ b/tests/test_model_helpers.py
@@ -51,10 +51,13 @@ from grahspj.model import (
 from grahspj.preload import _build_fixed_igm_jax, _build_igm_cache_jax, build_model_context
 from grahspj.preload import (
     ModelContext,
+    PackedFilters,
     PackedFiltersJax,
     SSPData,
     _DALE2014_CACHE,
     _HOST_BASIS_CACHE,
+    _build_filter_projection_matrices_for_redshift,
+    _build_fixed_filter_projection_matrices,
     _build_host_basis,
     _lnu_lsun_per_hz_to_llambda_w_per_a_np,
     _load_vendored_filter_curve,
@@ -408,6 +411,58 @@ def test_filter_projection_flat_flambda_to_mjy_units():
     expected = 1.0e-10 / 299792458.0 * 1.0e29 * 5000.0**2 * 2.0e-20
 
     assert projected[0] == pytest.approx(expected)
+
+
+def test_filter_projection_padded_rows_do_not_add_spurious_trapezoid_segment():
+    work_wave = np.asarray([[4000.0, 5000.0, 6000.0, 6000.0]], dtype=float)
+    transmission = np.asarray([[1.0, 1.0, 0.1, 0.0]], dtype=float)
+    valid_mask = np.asarray([[True, True, True, False]], dtype=bool)
+    interp_indices = np.asarray([[0, 1, 2, 2]], dtype=np.int32)
+    interp_weight = np.zeros_like(work_wave)
+    effective_wavelength = np.asarray([5000.0], dtype=float)
+    obs_flux = 1.0e-20 * (np.asarray([4000.0, 5000.0, 6000.0, 7000.0]) / 5000.0) ** 2
+    packed_jax = PackedFiltersJax(
+        interp_indices=interp_indices,
+        interp_weight=interp_weight,
+        transmission=transmission,
+        work_wave=work_wave,
+        effective_wavelength=effective_wavelength,
+        valid_mask=valid_mask,
+    )
+    packed_np = PackedFilters(
+        interp_indices=interp_indices,
+        interp_weight=interp_weight,
+        transmission=transmission,
+        work_wave=work_wave,
+        effective_wavelength=effective_wavelength,
+        valid_mask=valid_mask,
+    )
+
+    real_wave = work_wave[0, valid_mask[0]]
+    real_trans = transmission[0, valid_mask[0]]
+    real_flux = obs_flux[: real_wave.size]
+    f_lambda = np.trapezoid(real_flux * real_trans, real_wave) / np.trapezoid(real_trans, real_wave)
+    expected = 1.0e-10 / 299792458.0 * 1.0e29 * effective_wavelength[0] ** 2 * f_lambda
+
+    projected = np.asarray(_project_filters(obs_flux, packed_jax))
+    _, fixed_scalar_matrix = _build_fixed_filter_projection_matrices(
+        rest_wave=np.asarray([4000.0, 5000.0, 6000.0, 7000.0]),
+        packed_filters=packed_np,
+        fixed_igm=np.ones(4),
+        luminosity_distance_m=1.0,
+        redshift=0.0,
+    )
+    _, dynamic_scalar_matrix = _build_filter_projection_matrices_for_redshift(
+        rest_wave=np.asarray([4000.0, 5000.0, 6000.0, 7000.0]),
+        packed_filters=packed_np,
+        igm=np.ones(4),
+        luminosity_distance_m=1.0,
+        redshift=0.0,
+    )
+
+    assert projected[0] == pytest.approx(expected)
+    assert (fixed_scalar_matrix @ obs_flux)[0] == pytest.approx(expected)
+    assert (dynamic_scalar_matrix @ obs_flux)[0] == pytest.approx(expected)
 
 
 def test_ukidss_dr11plus_vendored_filters_load_in_angstroms():


### PR DESCRIPTION
## Summary

- Preserve padded filter wavelength coordinates during trapezoid integration instead of replacing invalid/padded coordinates with zero.
- Apply the same fix to the direct JAX projection path and both NumPy projection matrix builders.
- Add a regression test for padded filter rows with a sloped spectrum, covering direct, fixed-z matrix, and dynamic-redshift matrix projections.

## Why

Packed filters pad shorter filter rows by repeating the last wavelength and setting padded transmission to zero. The projection code zeroed the padded wavelength coordinate, creating a spurious trapezoid segment from the last real wavelength back to zero. This biased filter normalization and projected fluxes for non-flat spectra.

## Validation

```bash
PYTHONPATH=src:../jaxqsofit/src conda run -n jaxcpu pytest tests/test_model_helpers.py::test_filter_projection_padded_rows_do_not_add_spurious_trapezoid_segment -q
PYTHONPATH=src:../jaxqsofit/src conda run -n jaxcpu pytest tests/test_model_helpers.py -q
```

Results: `1 passed` and `38 passed`.
