### PR TITLE
[codex] Fix Lyman-break uncertainty threshold

### DIFF
--- a/src/grahspj/model.py
+++ b/src/grahspj/model.py
@@ -1189,7 +1189,7 @@ def photometric_loglike(pred_fluxes, obs_fluxes, obs_errors, upper_limits, data_
         att_unc = 10 ** log_unc_frac / tf
         sys_variance = sys_variance + (att_unc * pred_fluxes) ** 2
     if lyman_break_uncertainty:
-        ly_unc = jnp.where(filter_wavelength / (1.0 + redshift) < 150.0, 1.0e8, 0.0)
+        ly_unc = jnp.where(filter_wavelength / (1.0 + redshift) < 1500.0, 1.0e8, 0.0)
         sys_variance = sys_variance + (ly_unc * pred_fluxes) ** 2
     total_variance = jnp.nan_to_num(obs_variance + sys_variance + var_variance, nan=1.0e30, posinf=1.0e30, neginf=1.0e30)
     scale = jnp.sqrt(jnp.clip(total_variance, 1e-30, 1.0e60))

--- a/tests/test_model_helpers.py
+++ b/tests/test_model_helpers.py
@@ -47,6 +47,7 @@ from grahspj.model import (
     _redshift_to_obs,
     _torus_component,
     grahsp_photometric_model,
+    photometric_loglike,
 )
 from grahspj.preload import _build_fixed_igm_jax, _build_igm_cache_jax, build_model_context
 from grahspj.preload import (
@@ -392,6 +393,34 @@ def test_redshift_projection_uses_luminosity_distance_and_one_plus_z():
     obs = np.asarray(_redshift_to_obs(rest_wave, rest_lum, obs_wave, redshift=1.0, luminosity_distance_m=d_l))
 
     assert np.allclose(obs, rest_lum / (4.0 * np.pi * d_l**2 * 2.0))
+
+
+def test_lyman_break_uncertainty_threshold_uses_angstroms():
+    kwargs = dict(
+        pred_fluxes=np.asarray([100.0]),
+        obs_fluxes=np.asarray([1.0]),
+        obs_errors=np.asarray([0.1]),
+        upper_limits=np.asarray([False]),
+        data_mask=np.asarray([True]),
+        systematics_width=0.0,
+        intrinsic_scatter=0.0,
+        likelihood_family="gaussian",
+        student_t_df=5.0,
+        agn_component=np.asarray([0.0]),
+        agn_bol_lum_w=1.0e38,
+        agn_nev=0.1,
+        variability_uncertainty=False,
+        attenuation_model_uncertainty=False,
+        transmitted_fraction=np.asarray([1.0]),
+        filter_wavelength=np.asarray([1400.0]),
+        redshift=0.0,
+    )
+
+    logl_without_uncertainty = float(photometric_loglike(**kwargs, lyman_break_uncertainty=False))
+    logl_with_uncertainty = float(photometric_loglike(**kwargs, lyman_break_uncertainty=True))
+
+    assert logl_without_uncertainty < -1.0e5
+    assert logl_with_uncertainty > -100.0
 
 
 def test_filter_projection_flat_flambda_to_mjy_units():


### PR DESCRIPTION
## Summary

- Convert the Lyman-break uncertainty threshold from the unconverted GRAHSP nm value to Angstroms.
- Add a regression test showing a 1400 Angstrom rest-frame band is protected when `lyman_break_uncertainty=True`.

## Why

The photometric likelihood uses filter wavelengths in Angstroms, but the Lyman-break uncertainty gate used `150.0`, inherited from GRAHSP's nm convention. This made the uncertainty apply only below 150 Angstrom instead of below 1500 Angstrom, so the default-off feature was ineffective when enabled.

## Validation

```bash
PYTHONPATH=src:../jaxqsofit/src conda run -n jaxcpu pytest tests/test_model_helpers.py::test_lyman_break_uncertainty_threshold_uses_angstroms -q
PYTHONPATH=src:../jaxqsofit/src conda run -n jaxcpu pytest tests/test_model_helpers.py -q
```

Results: `1 passed` and `38 passed`.
