### PR TITLE
[codex] Fix predictive AGN line photometry

### DIFF
--- a/src/grahspj/model.py
+++ b/src/grahspj/model.py
@@ -1638,7 +1638,6 @@ def evaluate_photometric_state(
         fit_agn
         and include_sed_agn_features
         and bool(cfg.likelihood.use_local_line_photometry)
-        and not include_components
     )
     if correct_agn_line_photometry:
         if agn_type == 1:
@@ -1966,6 +1965,9 @@ def evaluate_photometric_state(
         line_liner_fluxes = _project_filters(line_liner_obs, context.packed_filters_jax)
         balmer_fluxes = _project_filters(balmer_obs, context.packed_filters_jax)
         trans_fluxes = _project_filters(transmitted_fraction_obs, context.packed_filters_jax)
+        if correct_agn_line_photometry:
+            agn_fluxes = agn_fluxes - coarse_agn_line_fluxes + local_agn_line_fluxes
+            line_fluxes = local_agn_line_fluxes
     else:
         nebular_lines_local_obs_wave = jnp.zeros((1,), dtype=jnp.float64)
         nebular_lines_local_obs = jnp.zeros((1,), dtype=jnp.float64)

--- a/tests/test_model_assembly.py
+++ b/tests/test_model_assembly.py
@@ -521,6 +521,39 @@ def test_local_line_photometry_improves_coarse_grid_line_projection(monkeypatch)
     assert np.all(local_error < legacy_error)
 
 
+def test_component_prediction_uses_local_agn_line_photometry(monkeypatch):
+    _patch_ssp(monkeypatch)
+
+    cfg = _cfg(fit_host=False, n_wave=64, rest_wave_max=2000.0)
+    cfg.photometry = PhotometryData(filter_names=["ha"], fluxes=[1.0], errors=[0.1])
+    cfg.filters = FilterSet(
+        curves=[
+            FilterCurve(
+                name="ha",
+                wave=[650.0, 690.0, 730.0],
+                transmission=[0.0, 1.0, 0.0],
+            )
+        ],
+        use_grahsp_database=False,
+    )
+    cfg.likelihood.use_fast_photometry_projection = False
+    cfg.likelihood.use_local_line_photometry = True
+    cfg.likelihood.variability_uncertainty = False
+    cfg.nebular.enabled = False
+    cfg.agn.fit_balmer_continuum = False
+    cfg.agn.feii_strength_default = 0.0
+    context = build_model_context(cfg)
+
+    data = _fixed_component_data()
+    data["line_width_kms"] = np.array(1200.0)
+    data["feii_norm"] = np.array(0.0)
+    predictive = _deterministic_trace(context, data)
+    likelihood = _deterministic_likelihood_trace(context, data)
+
+    np.testing.assert_allclose(_site(predictive, "pred_fluxes"), _site(likelihood, "pred_fluxes"), rtol=2.0e-10, atol=1.0e-30)
+    np.testing.assert_allclose(_site(predictive, "agn_fluxes"), _site(likelihood, "pred_fluxes"), rtol=2.0e-10, atol=1.0e-30)
+
+
 def test_fixed_local_line_cache_matches_exact_local_line_projection(monkeypatch):
     _patch_ssp(monkeypatch)
 


### PR DESCRIPTION
## Summary

- Apply local-grid AGN line photometry in component/predictive mode, not only in the likelihood path.
- Correct returned `agn_fluxes` and total `line_fluxes` to use the same local-grid AGN line contribution as `pred_fluxes`.
- Add a regression test that compares component-mode predictive photometry against the fitted likelihood prediction for coarse-grid AGN lines.

## Why

`predict()` and plotting use `include_components=True`, but the AGN local-line correction was disabled in that mode. This made posterior-predictive `pred_fluxes` and `agn_fluxes` use coarse-grid AGN line photometry while the likelihood used local-grid quadrature. Bands containing strong broad lines could therefore show misleading residuals or component photometry.

## Validation

```bash
PYTHONPATH=src:../jaxqsofit/src conda run -n jaxcpu pytest tests/test_model_assembly.py::test_component_prediction_uses_local_agn_line_photometry -q
PYTHONPATH=src:../jaxqsofit/src conda run -n jaxcpu pytest tests/test_model_assembly.py -q
```

Results: `1 passed` and `21 passed`.
