### PR TITLE
[codex] Apply Milky Way dereddening to spectra

### DIFF
--- a/src/grahspj/preload.py
+++ b/src/grahspj/preload.py
@@ -350,6 +350,20 @@ def _mw_band_attenuation_factor(wave_obs, filt_trans, ebv, r_v=3.1):
     return numer / denom
 
 
+def _mw_pixel_attenuation_factor(wave_obs, ebv, r_v=3.1):
+    """Compute the Milky Way attenuation factor at observed-frame wavelengths."""
+    wave_obs = np.asarray(wave_obs, dtype=float)
+    factors = np.ones_like(wave_obs, dtype=float)
+    if (not np.isfinite(ebv)) or ebv == 0.0 or wave_obs.size == 0:
+        return factors
+    valid = np.isfinite(wave_obs) & (wave_obs > 0.0)
+    if not np.any(valid):
+        return factors
+    a_lambda = extinction.fitzpatrick99(wave_obs[valid], a_v=float(r_v) * float(ebv), r_v=float(r_v))
+    factors[valid] = 10.0 ** (-0.4 * np.asarray(a_lambda, dtype=float))
+    return factors
+
+
 def _map_logzsol_to_dsps_lgmet(logzsol_grid: Sequence[float], ssp_lgmet: np.ndarray) -> np.ndarray:
     """Map log(Z/Zsun) fitting values onto the DSPS metallicity convention."""
     logzsol_grid = np.asarray(logzsol_grid, dtype=float)
@@ -1533,7 +1547,6 @@ def build_model_context(cfg: FitConfig) -> ModelContext:
         spec_effective_spatial_scale_arcsec = np.array([], dtype=float)
         spec_aperture_diameter_arcsec = np.array([], dtype=float)
         spec_instruments = ()
-    jaxqsofit_prior_config = _build_jaxqsofit_prior_config(cfg, spec_fluxes, spec_mask)
 
     rest_wave = np.geomspace(cfg.galaxy.rest_wave_min, cfg.galaxy.rest_wave_max, cfg.galaxy.n_wave).astype(float)
     obs_wave = rest_wave * (1.0 + max(cfg.observation.redshift, 0.0))
@@ -1630,6 +1643,12 @@ def build_model_context(cfg: FitConfig) -> ModelContext:
         )
         fluxes = fluxes / np.clip(factors, 1e-12, None)
         errors = errors / np.clip(factors, 1e-12, None)
+        if spec_wave_obs.size > 0:
+            spec_factors = _mw_pixel_attenuation_factor(spec_wave_obs, mw_ebv)
+            spec_fluxes = spec_fluxes / np.clip(spec_factors, 1e-12, None)
+            spec_errors = spec_errors / np.clip(spec_factors, 1e-12, None)
+
+    jaxqsofit_prior_config = _build_jaxqsofit_prior_config(cfg, spec_fluxes, spec_mask)
 
     return ModelContext(
         fit_config=cfg,

--- a/tests/test_model_helpers.py
+++ b/tests/test_model_helpers.py
@@ -62,6 +62,8 @@ from grahspj.preload import (
     _build_fixed_filter_projection_matrices,
     _build_host_basis,
     _lnu_lsun_per_hz_to_llambda_w_per_a_np,
+    _mw_band_attenuation_factor,
+    _mw_pixel_attenuation_factor,
     _load_vendored_filter_curve,
     _load_vendored_dale2014_templates,
 )
@@ -589,6 +591,56 @@ def test_build_context_with_inline_templates(monkeypatch):
     assert context.spec_mask.tolist() == [True, False, True]
     assert context.spec_spectrum_index.tolist() == [0, 0, 0]
     assert context.spec_instruments == ("test",)
+
+
+def test_mw_dereddening_applies_to_photometry_and_spectra(monkeypatch):
+    class _SSPData:
+        ssp_lgmet = np.array([-1.0, 0.0])
+        ssp_lg_age_gyr = np.array([-1.0, 0.0])
+        ssp_wave = np.array([900.0, 2000.0, 5000.0, 10000.0])
+        ssp_flux = np.ones((2, 2, 4))
+
+    monkeypatch.setattr("grahspj.preload._load_ssp_templates", lambda fn: _SSPData())
+    monkeypatch.setattr("grahspj.preload._get_sfd_query", lambda: (lambda coord: 0.1))
+
+    filt_wave = np.asarray([1000.0, 2000.0, 3000.0])
+    filt_trans = np.asarray([0.0, 1.0, 0.0])
+    spec_wave = np.asarray([3500.0, 4500.0, 5500.0])
+    spec_flux = np.asarray([0.1, 0.2, 0.15])
+    spec_err = np.asarray([0.01, 0.02, 0.015])
+    cfg = FitConfig(
+        observation=Observation(
+            object_id="obj",
+            redshift=0.1,
+            ra=180.0,
+            dec=0.0,
+            apply_mw_deredden=True,
+        ),
+        photometry=PhotometryData(filter_names=["f1"], fluxes=[1.0], errors=[0.1]),
+        filters=FilterSet(curves=[FilterCurve(name="f1", wave=filt_wave, transmission=filt_trans)], use_grahsp_database=False),
+        galaxy=GalaxyConfig(dsps_ssp_fn="fake.h5", n_wave=64),
+        agn=AGNConfig(),
+        likelihood=LikelihoodConfig(),
+        spectroscopy=SpectroscopyData(
+            wave_obs=spec_wave,
+            fluxes=spec_flux,
+            errors=spec_err,
+            instrument="test",
+        ),
+        spectroscopy_config=SpectroscopyConfig(enabled=True),
+        inference=InferenceConfig(map_steps=2),
+    )
+
+    context = build_model_context(cfg)
+
+    loaded_filter = context.filters[0]
+    band_factor = _mw_band_attenuation_factor(loaded_filter.work_wave, loaded_filter.transmission, 0.1)
+    spec_factors = _mw_pixel_attenuation_factor(spec_wave, 0.1)
+    assert context.mw_ebv == pytest.approx(0.1)
+    np.testing.assert_allclose(context.fluxes, np.asarray([1.0]) / band_factor)
+    np.testing.assert_allclose(context.errors, np.asarray([0.1]) / band_factor)
+    np.testing.assert_allclose(context.spec_fluxes, spec_flux / spec_factors)
+    np.testing.assert_allclose(context.spec_errors, spec_err / spec_factors)
 
 
 def test_context_accepts_multiple_spectra(monkeypatch):


### PR DESCRIPTION
## Summary

- Apply Milky Way dereddening to spectral fluxes and errors when `apply_mw_deredden=True`.
- Use the same Fitzpatrick99 attenuation curve as the broadband photometry path, evaluated per observed-frame spectral pixel.
- Build JAXQSOFit smart priors after dereddening so priors and likelihood inputs use the same corrected spectrum.
- Add a regression test that mocked SFD E(B-V) corrects both photometry and spectra.

## Why

Broadband fluxes were dereddened but spectra were left in observed MW-reddened units. In joint photometry+spectroscopy fits, this made the two datasets inconsistent in color; `log_spectrum_scale` could absorb only a mean offset, not the wavelength-dependent MW curve.

## Validation

```bash
PYTHONPATH=src:../jaxqsofit/src conda run -n jaxcpu pytest tests/test_model_helpers.py::test_mw_dereddening_applies_to_photometry_and_spectra -q
PYTHONPATH=src:../jaxqsofit/src conda run -n jaxcpu pytest tests/test_model_helpers.py -q
```

Results: `1 passed` and `42 passed`.
