### PR TITLE
[codex] Smooth AGN slope ordering prior

### DIFF
--- a/src/grahspj/model.py
+++ b/src/grahspj/model.py
@@ -1388,8 +1388,9 @@ def evaluate_photometric_state(
     if fit_agn:
         pl_loc, pl_scale, pl_low, pl_high = _cfg_truncnorm(prior_config, "pl_slope", -1.8, 0.4, -3.0, -1.0)
         pl_slope = numpyro.sample("pl_slope", dist.TruncatedNormal(pl_loc, pl_scale, low=pl_low, high=pl_high))
-        uv_slope = numpyro.sample("uv_slope", dist.Normal(*_cfg_norm(prior_config, "uv_slope", 0.0, 0.05)))
-        numpyro.factor("uv_slope_gt_pl_slope", jnp.where(uv_slope > pl_slope, 0.0, -jnp.inf))
+        uv_slope_delta = numpyro.sample("uv_slope_delta", dist.LogNormal(*_cfg_norm(prior_config, "log_uv_slope_delta", np.log(1.8), 0.4)))
+        uv_slope = pl_slope + uv_slope_delta
+        numpyro.deterministic("uv_slope", uv_slope)
         pl_bend_loc = numpyro.sample("pl_bend_loc", dist.LogNormal(*_cfg_norm(prior_config, "log_pl_bend_loc", np.log(GRAHSP_PL_BEND_LOC_A), 0.3)))
         pl_bend_width = numpyro.sample("pl_bend_width", dist.LogNormal(*_cfg_norm(prior_config, "log_pl_bend_width", np.log(GRAHSP_PL_BEND_WIDTH), 0.4)))
         pl_cutoff = numpyro.sample("pl_cutoff", dist.LogNormal(*_cfg_norm(prior_config, "log_pl_cutoff", np.log(GRAHSP_PL_CUTOFF_A), 0.6)))

--- a/tests/test_model_assembly.py
+++ b/tests/test_model_assembly.py
@@ -289,6 +289,17 @@ def test_host_off_mode_has_zero_host_components_and_no_total_leak(monkeypatch):
     assert np.allclose(_site(tr, "pred_fluxes"), _site(tr, "agn_fluxes"))
 
 
+def test_agn_slope_ordering_uses_positive_delta_without_hard_factor(monkeypatch):
+    _patch_ssp(monkeypatch)
+    context = build_model_context(_cfg(fit_host=False))
+    tr = _deterministic_trace(context, {"log_agn_amp": np.array(np.log(1.0e34)), "fcov": np.array(0.2), "si": np.array(0.0)})
+
+    assert "uv_slope_gt_pl_slope" not in tr
+    assert "uv_slope_delta" in tr
+    assert _site(tr, "uv_slope_delta") > 0.0
+    assert _site(tr, "uv_slope") > _site(tr, "pl_slope")
+
+
 def test_host_kinematics_default_off_skips_broadening_call(monkeypatch):
     _patch_ssp(monkeypatch)
 


### PR DESCRIPTION
## Summary

- Replace the hard `uv_slope > pl_slope` factor with a smooth positive-offset parametrization.
- Sample `uv_slope_delta ~ LogNormal(...)` and set `uv_slope = pl_slope + uv_slope_delta` deterministically.
- Add a regression test confirming the hard factor is gone and the sampled ordering is still enforced.

## Why

The previous `numpyro.factor(..., -inf)` created a discontinuous posterior boundary. That can produce NaN SVI losses when the guide crosses the boundary and can make NUTS spend work near a hard edge. Sampling a positive slope offset encodes the same ordering through the parameter support.

## Validation

```bash
PYTHONPATH=src:../jaxqsofit/src conda run -n jaxcpu pytest tests/test_model_assembly.py::test_agn_slope_ordering_uses_positive_delta_without_hard_factor -q
PYTHONPATH=src:../jaxqsofit/src conda run -n jaxcpu pytest tests/test_model_assembly.py -q
PYTHONPATH=src:../jaxqsofit/src conda run -n jaxcpu pytest tests/test_model_helpers.py -q
```

Results: `1 passed`, `22 passed`, and `41 passed`.
