### PR TITLE
[codex] Remove speclite filter handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,13 +126,12 @@ Bundled third-party resources under [src/grahspj/resources](/Users/colinburke/re
 
 ## Filters
 
-`grahspj` routes all filter handling through `speclite`.
+`grahspj` uses vendored GRAHSP/pcigale-style filter curves for synthetic photometry.
 
-- Built-in mappings cover common names such as `u_sdss -> sdss2010-u` and `J_2mass -> twomass-J`
-- You can override any mapping with `filters.speclite_names`
-- Vendored IRAC benchmark filters are bundled with the package and wrapped into `speclite` objects automatically
-- If a filter is not available in `speclite` or in the vendored package resources, the optional GRAHSP database fallback is still supported, but it is no longer required for the benchmark/default supported subset
-- Inline curves are also wrapped into `speclite` objects before synthetic photometry is computed
+- Built-in aliases cover common legacy names such as `u_sdss -> sloan.sdss.u`, `J_2mass -> 2mass.J`, and `W1 -> wise.W1`
+- Vendored photon-response filters are converted to the internal energy-response convention before projection
+- If a filter is not available inline or in the vendored package resources, the optional GRAHSP database fallback is still supported
+- Inline curves are used directly as internal filter curves before synthetic photometry is computed
 
 ## Survey PSF Sizes In The Likelihood
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
   "setuptools>=68,<81",
   "astropy",
   "tqdm",
-  "speclite",
   "extinction",
   "matplotlib",
   "corner",

--- a/src/grahspj/benchmark.py
+++ b/src/grahspj/benchmark.py
@@ -53,15 +53,6 @@ _CHIMERA_FILTER_COLUMN_MAP = {
     "spitzer.irac.I1": "IRAC1",
     "spitzer.irac.I2": "IRAC2",
 }
-_CHIMERA_SPECLITE_NAME_MAP = {
-    "u_sdss": "sdss2010-u",
-    "r_sdss": "sdss2010-r",
-    "i_sdss": "sdss2010-i",
-    "z_sdss": "sdss2010-z",
-    "J_2mass": "twomass-J",
-    "H_2mass": "twomass-H",
-    "Ks_2mass": "twomass-Ks",
-}
 _BENCHMARK_RESOURCE_CACHE: dict[str, Any] = {}
 _CHIMERA_EFFECTIVE_WAVELENGTHS_A = {
     "u_sdss": 3543.0,
@@ -144,7 +135,6 @@ def _build_chimera_filter_set() -> FilterSet:
     ]
     return FilterSet(
         curves=curves,
-        speclite_names=dict(_CHIMERA_SPECLITE_NAME_MAP),
         use_grahsp_database=False,
     )
 

--- a/src/grahspj/config.py
+++ b/src/grahspj/config.py
@@ -79,7 +79,6 @@ class FilterCurve:
 class FilterSet:
     """Filter configuration used to construct synthetic photometry."""
     curves: Sequence[FilterCurve] = field(default_factory=list)
-    speclite_names: Mapping[str, str] = field(default_factory=dict)
     use_grahsp_database: bool = True
 
 
@@ -375,7 +374,6 @@ def fit_config_from_mapping(data: Mapping[str, Any]) -> FitConfig:
         curves_raw = filters_raw.get("curves", [])
         filters_obj = FilterSet(
             curves=[_coerce_dataclass(FilterCurve, curve) if isinstance(curve, Mapping) else curve for curve in curves_raw],
-            speclite_names=dict(filters_raw.get("speclite_names", {})),
             use_grahsp_database=bool(filters_raw.get("use_grahsp_database", True)),
         )
     else:

--- a/src/grahspj/model.py
+++ b/src/grahspj/model.py
@@ -481,7 +481,13 @@ def _redshift_scalar_to_obs(rest_wave, rest_value, obs_wave, redshift):
 
 
 def _project_filters(obs_flux, packed_filters):
-    """Project an observed-frame spectrum through all prepared filters at once."""
+    """Project an observed-frame spectrum through prepared filters.
+
+    The final f_lambda-to-mJy conversion intentionally follows the
+    GRAHSP/pcigale convention of using each filter's effective wavelength
+    squared. This is not an exact pivot-wavelength conversion, so very broad
+    filters can retain small convention-level systematics.
+    """
     interp_indices = packed_filters.interp_indices
     interp_weight = packed_filters.interp_weight
     transmission = packed_filters.transmission

--- a/src/grahspj/preload.py
+++ b/src/grahspj/preload.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import importlib.util
 from importlib import resources
-import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -22,7 +21,6 @@ from astropy.cosmology import FlatLambdaCDM
 from astropy import units as u
 from dustmaps.sfd import SFDQuery
 import extinction
-from speclite import filters as speclite_filters
 
 from .config import EmissionLineTemplate, FeIITemplate, FilterCurve, FitConfig
 
@@ -272,19 +270,23 @@ _NEBULAR_REST_TEMPLATE_CACHE: dict[tuple[Any, ...], tuple[np.ndarray | None, np.
 _FIXED_NEBULAR_LINE_PROFILE_CACHE: dict[tuple[Any, ...], np.ndarray] = {}
 _REDSHIFT_PROJECTION_CACHE: dict[tuple[Any, ...], tuple[np.ndarray, np.ndarray, np.ndarray]] = {}
 _FIXED_LOCAL_LINE_PROJECTION_CACHE: dict[tuple[Any, ...], tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]] = {}
-_DEFAULT_SPECLITE_NAME_MAP = {
-    "u_sdss": "sdss2010-u",
-    "g_sdss": "sdss2010-g",
-    "r_sdss": "sdss2010-r",
-    "i_sdss": "sdss2010-i",
-    "z_sdss": "sdss2010-z",
-    "J_2mass": "twomass-J",
-    "H_2mass": "twomass-H",
-    "Ks_2mass": "twomass-Ks",
-    "W1": "wise2010-W1",
-    "W2": "wise2010-W2",
-    "W3": "wise2010-W3",
-    "W4": "wise2010-W4",
+_FILTER_NAME_ALIASES = {
+    "FUV_galex": "galex.FUV",
+    "NUV_galex": "galex.NUV",
+    "B_johnson": "generic.johnson.B",
+    "V_johnson": "generic.johnson.V",
+    "u_sdss": "sloan.sdss.u",
+    "g_sdss": "sloan.sdss.g",
+    "r_sdss": "sloan.sdss.r",
+    "i_sdss": "sloan.sdss.i",
+    "z_sdss": "sloan.sdss.z",
+    "J_2mass": "2mass.J",
+    "H_2mass": "2mass.H",
+    "Ks_2mass": "2mass.Ks",
+    "W1": "wise.W1",
+    "W2": "wise.W2",
+    "W3": "wise.W3",
+    "W4": "wise.W4",
 }
 def _package_resource_path(relpath: str) -> Path:
     """Return an absolute path to a packaged grahspj resource."""
@@ -308,16 +310,6 @@ def _get_sfd_query():
     if cache_key not in _SFD_QUERY_CACHE:
         _SFD_QUERY_CACHE[cache_key] = SFDQuery()
     return _SFD_QUERY_CACHE[cache_key]
-
-
-def _sanitize_speclite_token(value: str, prefix: str) -> str:
-    """Normalize a token for safe use in generated speclite filter names."""
-    token = re.sub(r"[^0-9A-Za-z_]+", "_", str(value)).strip("_")
-    if not token:
-        token = prefix
-    if token[0].isdigit():
-        token = f"{prefix}_{token}"
-    return token
 
 
 def _as_angstrom_values(values) -> np.ndarray:
@@ -424,27 +416,42 @@ def _get_pcigale_database_cls():
             return None
 
 
-def _curve_to_speclite_filter(curve: FilterCurve, group_name: str) -> speclite_filters.FilterResponse:
-    """Wrap an inline filter curve into a speclite FilterResponse."""
+def _filter_effective_wavelength(wave: np.ndarray, trans: np.ndarray) -> float:
+    """Compute a pcigale-style effective wavelength for an internal filter curve."""
+    denom = float(np.trapezoid(trans, wave))
+    if denom <= 0.0:
+        return float(np.nanmean(wave))
+    return float(np.trapezoid(wave * trans, wave) / denom)
+
+
+def _normalize_filter_curve(curve: FilterCurve, name: str | None = None) -> FilterCurve:
+    """Return a sorted, unique, non-negative internal filter curve."""
     wave = np.asarray(curve.wave, dtype=float)
     trans = np.clip(np.asarray(curve.transmission, dtype=float), 0.0, None)
     if wave.ndim != 1 or trans.ndim != 1 or wave.size != trans.size:
         raise ValueError(f"Filter curve {curve.name!r} must have 1D wave/transmission arrays of equal length.")
     if wave.size < 3:
         raise ValueError(f"Filter curve {curve.name!r} must have at least 3 wavelength samples.")
-    if trans[0] != 0.0 or trans[-1] != 0.0:
-        wave = wave.copy()
-        trans = trans.copy()
-        trans[0] = 0.0
-        trans[-1] = 0.0
-    meta = {
-        "group_name": _sanitize_speclite_token(group_name, "filter"),
-        "band_name": _sanitize_speclite_token(curve.name, "band"),
-    }
-    return speclite_filters.FilterResponse(
-        wavelength=wave * u.AA,
-        response=trans,
-        meta=meta,
+    finite = np.isfinite(wave) & np.isfinite(trans)
+    wave = wave[finite]
+    trans = trans[finite]
+    if wave.size < 3:
+        raise ValueError(f"Filter curve {curve.name!r} must have at least 3 finite wavelength samples.")
+    order = np.argsort(wave, kind="stable")
+    wave, trans = wave[order], trans[order]
+    unique = np.concatenate(([True], np.diff(wave) > 0))
+    wave, trans = wave[unique], trans[unique]
+    if wave.size < 3:
+        raise ValueError(f"Filter curve {curve.name!r} must have at least 3 unique wavelength samples.")
+    wave = wave.copy()
+    trans = trans.copy()
+    trans[0] = 0.0
+    trans[-1] = 0.0
+    return FilterCurve(
+        name=name if name is not None else curve.name,
+        wave=wave,
+        transmission=trans,
+        effective_wavelength=_filter_effective_wavelength(wave, trans),
     )
 
 
@@ -490,28 +497,7 @@ def _load_vendored_filter_curve(filter_name: str) -> FilterCurve | None:
         trans *= wave
     trans = np.clip(trans, 0.0, None)
 
-    # ensure strictly increasing wavelength (speclite requirement)
-    order = np.argsort(wave, kind="stable")
-    wave, trans = wave[order], trans[order]
-    unique = np.concatenate(([True], np.diff(wave) > 0))
-    wave, trans = wave[unique], trans[unique]
-
-    trans[0] = 0.0
-    trans[-1] = 0.0
-
-    return FilterCurve(name=filter_name, wave=wave, transmission=trans)
-
-
-def _load_named_speclite_filter(filter_name: str, cfg: FitConfig):
-    """Resolve a configured filter name to a built-in speclite response."""
-    speclite_name = cfg.filters.speclite_names.get(filter_name, _DEFAULT_SPECLITE_NAME_MAP.get(filter_name, filter_name))
-    try:
-        loaded = speclite_filters.load_filters(speclite_name)
-    except Exception:
-        return None
-    if len(loaded) != 1:
-        raise ValueError(f"Expected a single speclite filter for {filter_name!r}, got {len(loaded)} from {speclite_name!r}.")
-    return loaded[0]
+    return _normalize_filter_curve(FilterCurve(name=filter_name, wave=wave, transmission=trans), name=filter_name)
 
 
 def _filter_response_cache_key(cfg: FitConfig) -> tuple[Any, ...]:
@@ -519,13 +505,12 @@ def _filter_response_cache_key(cfg: FitConfig) -> tuple[Any, ...]:
     return (
         tuple(str(name) for name in cfg.photometry.filter_names),
         tuple((curve.name, id(curve.wave), id(curve.transmission), curve.effective_wavelength) for curve in cfg.filters.curves),
-        tuple(sorted((str(k), str(v)) for k, v in cfg.filters.speclite_names.items())),
         bool(cfg.filters.use_grahsp_database),
     )
 
 
 def _load_filter_responses(cfg: FitConfig):
-    """Resolve configured filters to speclite responses, using caching."""
+    """Resolve configured filters to internal filter curves, using caching."""
     cache_key = _filter_response_cache_key(cfg)
     cached = _FILTER_RESPONSE_CACHE.get(cache_key)
     if cached is not None:
@@ -534,22 +519,19 @@ def _load_filter_responses(cfg: FitConfig):
     responses = []
     for filter_name in cfg.photometry.filter_names:
         if filter_name in inline_curves:
-            responses.append(_curve_to_speclite_filter(inline_curves[filter_name], group_name="inline"))
+            responses.append(_normalize_filter_curve(inline_curves[filter_name], name=filter_name))
             continue
-        builtin = _load_named_speclite_filter(filter_name, cfg)
-        if builtin is not None:
-            responses.append(builtin)
-            continue
-        vendored = _load_vendored_filter_curve(filter_name)
+        resolved_name = _FILTER_NAME_ALIASES.get(filter_name, filter_name)
+        vendored = _load_vendored_filter_curve(resolved_name)
         if vendored is not None:
-            responses.append(_curve_to_speclite_filter(vendored, group_name="grahspj"))
+            responses.append(_normalize_filter_curve(vendored, name=filter_name))
             continue
         if not cfg.filters.use_grahsp_database:
             raise ValueError(
-                f"Filter {filter_name!r} was not provided inline and could not be loaded by speclite; "
+                f"Filter {filter_name!r} was not provided inline and is not available in vendored filters; "
                 "GRAHSP database fallback is disabled."
             )
-        responses.append(_curve_to_speclite_filter(_fetch_database_filter_curve(filter_name), group_name="grahsp"))
+        responses.append(_normalize_filter_curve(_fetch_database_filter_curve(resolved_name), name=filter_name))
     _FILTER_RESPONSE_CACHE[cache_key] = responses
     return responses
 
@@ -727,11 +709,15 @@ def _load_vendored_dale2014_templates() -> tuple[np.ndarray, np.ndarray, np.ndar
     return loaded
 
 
-def _prepare_loaded_filter(obs_wave: np.ndarray, response: speclite_filters.FilterResponse) -> LoadedFilter:
+def _prepare_loaded_filter(obs_wave: np.ndarray, response: FilterCurve) -> LoadedFilter:
     """Precompute interpolation metadata for one filter on the model grid."""
-    filt_wave = _as_angstrom_values(response.wavelength)
-    trans = np.clip(np.asarray(response.response, dtype=float), 0.0, None)
-    effective = _scalar_angstrom_value(response.effective_wavelength)
+    filt_wave = _as_angstrom_values(response.wave)
+    trans = np.clip(np.asarray(response.transmission, dtype=float), 0.0, None)
+    effective = (
+        _filter_effective_wavelength(filt_wave, trans)
+        if response.effective_wavelength is None
+        else _scalar_angstrom_value(response.effective_wavelength)
+    )
     mask = (obs_wave >= filt_wave[0]) & (obs_wave <= filt_wave[-1])
     work_wave = obs_wave[mask]
     if work_wave.size < 2:

--- a/src/utils.py
+++ b/src/utils.py
@@ -19,23 +19,23 @@ from astropy.table import Table
 #
 # These are survey-level nominal values, not per-source PSFs from the VizieR SED service.
 FILTER_MAP = {
-    "GALEX:FUV": {"grahsp_filter": "FUV_galex", "speclite_name": "galex-fuv", "psf_fwhm_arcsec": 4.3},
-    "GALEX:NUV": {"grahsp_filter": "NUV_galex", "speclite_name": "galex-nuv", "psf_fwhm_arcsec": 5.3},
-    "Johnson:B": {"grahsp_filter": "B_johnson", "speclite_name": "bessell-B", "psf_fwhm_arcsec": None},
-    "Johnson:V": {"grahsp_filter": "V_johnson", "speclite_name": "bessell-V", "psf_fwhm_arcsec": None},
-    "SDSS:u": {"grahsp_filter": "u_sdss", "speclite_name": "sdss2010-u", "psf_fwhm_arcsec": 1.53},
-    "SDSS:g": {"grahsp_filter": "g_sdss", "speclite_name": "sdss2010-g", "psf_fwhm_arcsec": 1.44},
-    "SDSS:r": {"grahsp_filter": "r_sdss", "speclite_name": "sdss2010-r", "psf_fwhm_arcsec": 1.32},
-    "SDSS:i": {"grahsp_filter": "i_sdss", "speclite_name": "sdss2010-i", "psf_fwhm_arcsec": 1.26},
-    "SDSS:z": {"grahsp_filter": "z_sdss", "speclite_name": "sdss2010-z", "psf_fwhm_arcsec": 1.29},
-    "2MASS:J": {"grahsp_filter": "J_2mass", "speclite_name": "twomass-J", "psf_fwhm_arcsec": 2.5},
-    "2MASS:H": {"grahsp_filter": "H_2mass", "speclite_name": "twomass-H", "psf_fwhm_arcsec": 2.5},
-    "2MASS:Ks": {"grahsp_filter": "Ks_2mass", "speclite_name": "twomass-Ks", "psf_fwhm_arcsec": 2.5},
-    "2MASS:K": {"grahsp_filter": "Ks_2mass", "speclite_name": "twomass-Ks", "psf_fwhm_arcsec": 2.5},
-    "WISE:W1": {"grahsp_filter": "W1", "speclite_name": "wise2010-W1", "psf_fwhm_arcsec": 6.08},
-    "WISE:W2": {"grahsp_filter": "W2", "speclite_name": "wise2010-W2", "psf_fwhm_arcsec": 6.84},
-    "WISE:W3": {"grahsp_filter": "W3", "speclite_name": "wise2010-W3", "psf_fwhm_arcsec": 7.36},
-    "WISE:W4": {"grahsp_filter": "W4", "speclite_name": "wise2010-W4", "psf_fwhm_arcsec": 11.99},
+    "GALEX:FUV": {"grahsp_filter": "FUV_galex", "psf_fwhm_arcsec": 4.3},
+    "GALEX:NUV": {"grahsp_filter": "NUV_galex", "psf_fwhm_arcsec": 5.3},
+    "Johnson:B": {"grahsp_filter": "B_johnson", "psf_fwhm_arcsec": None},
+    "Johnson:V": {"grahsp_filter": "V_johnson", "psf_fwhm_arcsec": None},
+    "SDSS:u": {"grahsp_filter": "u_sdss", "psf_fwhm_arcsec": 1.53},
+    "SDSS:g": {"grahsp_filter": "g_sdss", "psf_fwhm_arcsec": 1.44},
+    "SDSS:r": {"grahsp_filter": "r_sdss", "psf_fwhm_arcsec": 1.32},
+    "SDSS:i": {"grahsp_filter": "i_sdss", "psf_fwhm_arcsec": 1.26},
+    "SDSS:z": {"grahsp_filter": "z_sdss", "psf_fwhm_arcsec": 1.29},
+    "2MASS:J": {"grahsp_filter": "J_2mass", "psf_fwhm_arcsec": 2.5},
+    "2MASS:H": {"grahsp_filter": "H_2mass", "psf_fwhm_arcsec": 2.5},
+    "2MASS:Ks": {"grahsp_filter": "Ks_2mass", "psf_fwhm_arcsec": 2.5},
+    "2MASS:K": {"grahsp_filter": "Ks_2mass", "psf_fwhm_arcsec": 2.5},
+    "WISE:W1": {"grahsp_filter": "W1", "psf_fwhm_arcsec": 6.08},
+    "WISE:W2": {"grahsp_filter": "W2", "psf_fwhm_arcsec": 6.84},
+    "WISE:W3": {"grahsp_filter": "W3", "psf_fwhm_arcsec": 7.36},
+    "WISE:W4": {"grahsp_filter": "W4", "psf_fwhm_arcsec": 11.99},
 }
 
 
@@ -111,12 +111,10 @@ def query_vizier_sed(
                     continue
                 filter_info = FILTER_MAP[sed_filter]
                 grahsp_name = str(filter_info["grahsp_filter"])
-                speclite_name = str(filter_info["speclite_name"])
                 frac_err = err_jy / flux_jy
                 candidate = {
                     "vizier_filter": sed_filter,
                     "grahsp_filter": grahsp_name,
-                    "speclite_name": speclite_name,
                     "psf_fwhm_arcsec": filter_info["psf_fwhm_arcsec"],
                     "freq_ghz": freq_ghz,
                     "flux_mjy": 1.0e3 * flux_jy,

--- a/tests/benchmark_fairall9_likelihood.py
+++ b/tests/benchmark_fairall9_likelihood.py
@@ -65,7 +65,6 @@ def build_fairall9_fixedz_config() -> FitConfig:
             psf_fwhm_arcsec=[None if row["psf_fwhm_arcsec"] is None else float(row["psf_fwhm_arcsec"]) for row in phot_rows],
         ),
         filters=FilterSet(
-            speclite_names={str(row["grahsp_filter"]): str(row["speclite_name"]) for row in phot_rows},
             use_grahsp_database=False,
         ),
         galaxy=GalaxyConfig(dsps_ssp_fn=str(dsps_ssp_fn)),

--- a/tests/test_model_helpers.py
+++ b/tests/test_model_helpers.py
@@ -62,6 +62,7 @@ from grahspj.preload import (
     _build_fixed_filter_projection_matrices,
     _build_host_basis,
     _lnu_lsun_per_hz_to_llambda_w_per_a_np,
+    _load_filter_responses,
     _mw_band_attenuation_factor,
     _mw_pixel_attenuation_factor,
     _load_vendored_filter_curve,
@@ -543,6 +544,32 @@ def test_ukidss_dr11plus_vendored_filters_load_in_angstroms():
         assert np.nanmax(trans) > 0.0
 
 
+def test_legacy_filter_aliases_resolve_to_vendored_curves():
+    cfg = FitConfig(
+        observation=Observation(object_id="obj", redshift=0.1),
+        photometry=PhotometryData(
+            filter_names=["u_sdss", "J_2mass", "W1"],
+            fluxes=[1.0, 1.0, 1.0],
+            errors=[0.1, 0.1, 0.1],
+        ),
+        filters=FilterSet(use_grahsp_database=False),
+        galaxy=GalaxyConfig(dsps_ssp_fn="fake.h5"),
+        inference=InferenceConfig(map_steps=2),
+    )
+
+    curves = _load_filter_responses(cfg)
+
+    assert [curve.name for curve in curves] == ["u_sdss", "J_2mass", "W1"]
+    for curve in curves:
+        wave = np.asarray(curve.wave, dtype=float)
+        trans = np.asarray(curve.transmission, dtype=float)
+        assert wave.ndim == 1
+        assert wave.size == trans.size
+        assert wave.size > 3
+        assert np.nanmax(trans) > 0.0
+        assert np.isfinite(curve.effective_wavelength)
+
+
 def test_build_context_with_inline_templates(monkeypatch):
     class _SSPData:
         ssp_lgmet = np.array([-1.0, 0.0])
@@ -582,7 +609,7 @@ def test_build_context_with_inline_templates(monkeypatch):
     assert context.gal_t_table.shape == (cfg.galaxy.sfh_n_steps,)
     assert context.t_obs_gyr > 0.0
     assert len(context.filters) == 1
-    assert context.filters[0].name == "inline-f1"
+    assert context.filters[0].name == "f1"
     assert context.templates.feii_wave.shape[0] == 2
     assert context.templates.dust_alpha_grid.size > 0
     assert context.templates.dust_wave.size > 0


### PR DESCRIPTION
## Summary

- Remove speclite from the filter-loading path and package dependencies.
- Resolve legacy filter names such as `u_sdss`, `J_2mass`, and `W1` directly to vendored GRAHSP/pcigale filter curves.
- Use internal `FilterCurve` objects for inline, vendored, and optional GRAHSP database filters.
- Recompute effective wavelengths from the internal response curves and document the pcigale-style `lambda_eff**2` conversion convention.
- Update README, benchmark config, VizieR utility output, and tests to remove `speclite_names`.

## Why

The previous loader mixed conventions: vendored photon-response filters were converted to the internal energy-response convention, while speclite built-ins were used directly. Removing speclite from this path makes default photometry reproducible and GRAHSP/pcigale-faithful.

## Validation

```bash
PYTHONPATH=src:../jaxqsofit/src conda run -n jaxcpu pytest tests/test_model_helpers.py::test_legacy_filter_aliases_resolve_to_vendored_curves -q
PYTHONPATH=src:../jaxqsofit/src conda run -n jaxcpu pytest tests/test_model_helpers.py -q
PYTHONPATH=src:../jaxqsofit/src conda run -n jaxcpu pytest tests/test_benchmark.py tests/benchmark_fairall9_likelihood.py -q
PYTHONPATH=src:../jaxqsofit/src conda run -n jaxcpu pytest tests/test_model_assembly.py -q
PYTHONPATH=src:../jaxqsofit/src conda run -n jaxcpu pytest tests/test_model_helpers.py::test_filter_projection_flat_flambda_to_mjy_units tests/test_model_helpers.py::test_filter_projection_padded_rows_do_not_add_spurious_trapezoid_segment -q
git diff --check
```

Results: `1 passed`, `43 passed`, `6 passed`, `22 passed`, `2 passed`, and diff check clean.
