### PR TITLE
[codex] Add Read the Docs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,15 @@
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements.txt
+    - method: pip
+      path: .


### PR DESCRIPTION
## Summary
- Add .readthedocs.yaml using the same Read the Docs v2 template as jaxqsofit.
- Configure Ubuntu 24.04, Python 3.11, Sphinx via docs/conf.py, docs/requirements.txt, and local package install.

## Notes
- This PR only adds the RTD config file.
- The repository still needs docs/conf.py and docs/requirements.txt on main for the RTD build to pass with this template.