### PR TITLE
[codex] Expose shared physical host API

### DIFF
--- a/src/jaxsedfit/__init__.py
+++ b/src/jaxsedfit/__init__.py
@@ -26,6 +26,7 @@ __all__ = [
     "FilterSet",
     "FitConfig",
     "GalaxyConfig",
+    "HostBasisJax",
     "JAXSEDFit",
     "InferenceConfig",
     "JaxQSOFitConfig",
@@ -35,6 +36,9 @@ __all__ = [
     "PhotometryData",
     "SpectroscopyConfig",
     "SpectroscopyData",
+    "build_host_basis_jax",
+    "build_host_state",
+    "host_rest_on_basis",
     "plot_corner",
     "plot_fit_sed",
     "plot_trace",
@@ -77,4 +81,8 @@ def __getattr__(name):
         from . import benchmark as _benchmark
 
         return getattr(_benchmark, name)
+    if name in {"HostBasisJax", "build_host_basis_jax", "build_host_state", "host_rest_on_basis"}:
+        from . import host as _host
+
+        return getattr(_host, name)
     raise AttributeError(name)

--- a/src/jaxsedfit/host.py
+++ b/src/jaxsedfit/host.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+
+from .model import _build_host_state, _host_rest_on_basis
+from .preload import (
+    HostBasisJax,
+    _build_host_basis,
+    _build_host_basis_jax,
+    load_cached_ssp_data,
+)
+
+
+def build_host_basis_jax(
+    rest_wave: np.ndarray,
+    *,
+    dsps_ssp_fn: str = "tempdata.h5",
+    t_obs_gyr: float,
+    sfh_n_steps: int = 64,
+    sfh_t_min_gyr: float = 0.01,
+) -> HostBasisJax:
+    """Build the JAXSEDFit physical SSP host basis on a rest-frame grid.
+
+    The returned basis preserves the DSPS physical SSP luminosity and mass
+    normalization used by JAXSEDFit. It is intended for reuse by spectral
+    fitting code that needs host-galaxy SFH parity with JAXSEDFit.
+    """
+    rest_wave = np.asarray(rest_wave, dtype=float)
+    if rest_wave.ndim != 1 or rest_wave.size < 2:
+        raise ValueError("rest_wave must be a one-dimensional wavelength grid.")
+    ssp_data = load_cached_ssp_data(dsps_ssp_fn)
+    gal_t_table = np.geomspace(
+        max(float(sfh_t_min_gyr), 1e-3),
+        max(float(t_obs_gyr), float(sfh_t_min_gyr) * 1.01),
+        int(sfh_n_steps),
+    )
+    host_basis = _build_host_basis(rest_wave, ssp_data)
+    return _build_host_basis_jax(ssp_data, host_basis, gal_t_table)
+
+
+def build_host_state(
+    host_basis_jax: HostBasisJax,
+    prior_config: dict[str, Any],
+    *,
+    host_sfh_model: str = "delayed",
+    t_obs_gyr: float,
+    redshift: float = 0.0,
+    sfh_t_min_gyr: float = 0.01,
+    tau_host_prior_scale: float = 1.0,
+    full_output: bool = True,
+) -> dict[str, Any]:
+    """Sample/build the JAXSEDFit physical host state from a host basis.
+
+    This is a lightweight public wrapper around the same delayed-tau and
+    Diffstar host implementation used internally by JAXSEDFit. The returned
+    state contains the physical SSP weights, host rest-frame luminosity SED,
+    stellar mass, surviving mass fraction, SFH diagnostics, and metallicity
+    diagnostics produced by the underlying JAXSEDFit host model.
+    """
+    galaxy = SimpleNamespace(
+        host_sfh_model=str(host_sfh_model),
+        sfh_t_min_gyr=float(sfh_t_min_gyr),
+        tau_host_prior_scale=float(tau_host_prior_scale),
+    )
+    observation = SimpleNamespace(redshift=float(redshift))
+    context = SimpleNamespace(
+        host_basis_jax=host_basis_jax,
+        t_obs_gyr=float(t_obs_gyr),
+        fit_config=SimpleNamespace(galaxy=galaxy, observation=observation),
+    )
+    return _build_host_state(context, prior_config, full_output=full_output)
+
+
+def host_rest_on_basis(host_state: dict[str, Any], host_basis_jax: HostBasisJax):
+    """Evaluate a sampled JAXSEDFit host state on a compatible host basis."""
+    return _host_rest_on_basis(host_state, host_basis_jax)
+
+
+__all__ = [
+    "HostBasisJax",
+    "build_host_basis_jax",
+    "build_host_state",
+    "host_rest_on_basis",
+]

--- a/tests/test_host_api.py
+++ b/tests/test_host_api.py
@@ -1,0 +1,92 @@
+import numpy as np
+import jax.numpy as jnp
+import numpyro
+from numpyro.handlers import seed, trace
+
+from jaxsedfit.host import HostBasisJax, build_host_state, host_rest_on_basis
+
+
+def _toy_host_basis(rest_scale=1.0):
+    return HostBasisJax(
+        ssp_lgmet=jnp.array([-1.5, -1.0, -0.5, 0.0], dtype=jnp.float64),
+        ssp_lg_age_gyr=jnp.log10(jnp.array([0.1, 0.5, 1.0], dtype=jnp.float64)),
+        rest_llambda=rest_scale
+        * jnp.arange(1, 1 + 4 * 3 * 5, dtype=jnp.float64).reshape(4, 3, 5),
+        surviving_frac_by_age=jnp.array([0.9, 0.75, 0.6], dtype=jnp.float64),
+        n_ly_per_msun=jnp.zeros((4, 3), dtype=jnp.float64),
+        ly_lum_per_msun=jnp.zeros((4, 3), dtype=jnp.float64),
+        gal_t_table=jnp.geomspace(0.01, 1.2, 16),
+    )
+
+
+def test_public_delayed_host_api_builds_physical_host_state():
+    basis = _toy_host_basis()
+    prior_config = {
+        "log_stellar_mass": {"dist": "normal", "loc": 9.0, "scale": 0.1},
+        "mass_metallicity_relation": {"enabled": True, "scale": 5.0},
+    }
+
+    def model():
+        state = build_host_state(
+            basis,
+            prior_config,
+            host_sfh_model="delayed",
+            t_obs_gyr=1.2,
+            redshift=0.3,
+        )
+        for key in [
+            "host_rest",
+            "host_ssp_weights",
+            "host_age_weights",
+            "host_lgmet_weights",
+            "formed_mass",
+        ]:
+            numpyro.deterministic(f"public_{key}", state[key])
+
+    tr = trace(
+        seed(
+            model,
+            11,
+        )
+    ).get_trace()
+    state = {
+        "host_rest": tr["public_host_rest"]["value"],
+        "host_ssp_weights": tr["public_host_ssp_weights"]["value"],
+        "host_age_weights": tr["public_host_age_weights"]["value"],
+        "host_lgmet_weights": tr["public_host_lgmet_weights"]["value"],
+        "formed_mass": tr["public_formed_mass"]["value"],
+    }
+
+    assert state["host_rest"].shape == (5,)
+    assert state["host_ssp_weights"].shape == (4, 3)
+    assert state["host_age_weights"].shape == (3,)
+    assert state["host_lgmet_weights"].shape == (4,)
+    assert np.isfinite(np.asarray(state["host_rest"], dtype=float)).all()
+    assert np.isfinite(float(np.asarray(state["formed_mass"], dtype=float)))
+    assert np.isclose(float(np.asarray(jnp.sum(state["host_ssp_weights"]))), 1.0)
+    assert "mass_metallicity_relation_prior" in tr
+    assert "log_sfh_age_gyr" in tr
+    assert "log_sfh_tau_gyr" in tr
+
+
+def test_public_host_rest_on_basis_reuses_sampled_weights():
+    basis = _toy_host_basis(rest_scale=1.0)
+    alternate_basis = _toy_host_basis(rest_scale=2.0)
+
+    def model():
+        state = build_host_state(
+            basis,
+            {"mass_metallicity_relation": {"enabled": False}},
+            host_sfh_model="delayed",
+            t_obs_gyr=1.2,
+        )
+        numpyro.deterministic("public_host_rest", state["host_rest"])
+        numpyro.deterministic("public_host_rest_alternate", host_rest_on_basis(state, alternate_basis))
+
+    tr = trace(seed(model, 13)).get_trace()
+
+    host_rest = tr["public_host_rest_alternate"]["value"]
+
+    assert host_rest.shape == (5,)
+    assert np.isfinite(np.asarray(host_rest, dtype=float)).all()
+    assert np.allclose(np.asarray(host_rest), 2.0 * np.asarray(tr["public_host_rest"]["value"]))


### PR DESCRIPTION
## Summary
- add public jaxsedfit.host helpers for physical SSP host basis/state construction
- expose the helpers lazily from jaxsedfit.__init__
- add tests for delayed host state construction and alternate-basis reconstruction

## Validation
- PYTHONPATH=src conda run -n jaxcpu python -m pytest tests/test_host_api.py tests/test_diffstar_host.py -q

Draft until reviewed with the dependent JAXQSOFit physical host integration.