### PR TITLE
[codex] add jaxsedfit posterior sample loading

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -20,4 +20,5 @@ API Reference
    jaxsedfit.plot_fit_sed
    jaxsedfit.plot_corner
    jaxsedfit.plot_trace
+   jaxsedfit.load_from_samples
    jaxsedfit.style_path

--- a/src/jaxsedfit/__init__.py
+++ b/src/jaxsedfit/__init__.py
@@ -39,6 +39,7 @@ __all__ = [
     "build_host_basis_jax",
     "build_host_state",
     "host_rest_on_basis",
+    "load_from_samples",
     "load_filter_curve",
     "load_filter_curves",
     "plot_corner",
@@ -57,6 +58,10 @@ def __getattr__(name):
         from .core import JAXSEDFit
 
         return JAXSEDFit
+    if name == "load_from_samples":
+        from .core import JAXSEDFit
+
+        return JAXSEDFit.load_from_samples
     if name == "plot_fit_sed":
         from .plotting import plot_fit_sed
 

--- a/src/jaxsedfit/core.py
+++ b/src/jaxsedfit/core.py
@@ -9,7 +9,7 @@ import numpy as np
 from numpyro.infer import MCMC, NUTS, Predictive, SVI, Trace_ELBO, init_to_value
 from numpyro.infer.autoguide import AutoDelta
 
-from .config import FitConfig, serialize_config
+from .config import FitConfig, fit_config_from_mapping, serialize_config
 from .model import grahsp_photometric_model
 from .preload import ModelContext, build_model_context
 
@@ -658,6 +658,60 @@ class JAXSEDFit:
         with open(out, "wb") as fh:
             pickle.dump(payload, fh, protocol=pickle.HIGHEST_PROTOCOL)
         return out
+
+    @staticmethod
+    def _resolve_posterior_path(path: str | Path | None = None) -> Path:
+        """Resolve a saved posterior pickle path or unique posterior in a directory."""
+        if path is None:
+            path = "."
+        resolved = Path(path)
+        if resolved.is_dir():
+            matches = sorted(resolved.glob("*_posterior.pkl"))
+            if not matches:
+                raise FileNotFoundError(f"No *_posterior.pkl file found under: {resolved}")
+            if len(matches) > 1:
+                raise FileNotFoundError(
+                    f"Multiple *_posterior.pkl files found under: {resolved}. "
+                    "Pass an explicit posterior file path."
+                )
+            resolved = matches[0]
+        if not resolved.exists():
+            raise FileNotFoundError(f"Posterior bundle not found: {resolved}")
+        return resolved
+
+    @classmethod
+    def load_from_samples(cls, path: str | Path | None = None) -> "JAXSEDFit":
+        """Load a posterior bundle written by :meth:`save`.
+
+        Parameters
+        ----------
+        path
+            Path to a ``*_posterior.pkl`` file, or a directory containing exactly
+            one such file. Defaults to the current directory.
+
+        Returns
+        -------
+        JAXSEDFit
+            A configured fitter with posterior samples and cached predictive
+            outputs restored from disk.
+        """
+        posterior_path = cls._resolve_posterior_path(path)
+        with open(posterior_path, "rb") as fh:
+            payload = pickle.load(fh)
+        if not isinstance(payload, dict) or "config" not in payload:
+            raise ValueError(f"Unsupported posterior bundle schema: {posterior_path}")
+
+        config = payload["config"]
+        if not isinstance(config, FitConfig):
+            config = fit_config_from_mapping(config)
+        fitter = cls(config)
+        samples = payload.get("samples")
+        fitter.samples = None if samples is None else {k: np.asarray(v) for k, v in samples.items()}
+        predictive = payload.get("predictive")
+        fitter.predictive = None if predictive is None else {k: np.asarray(v) for k, v in predictive.items()}
+        fitter._saved_summary = payload.get("summary")
+        fitter._loaded_posterior_path = posterior_path
+        return fitter
 
     def plot_sed(
         self,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,70 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+import jaxsedfit
+from jaxsedfit.config import (
+    FilterCurve,
+    FilterSet,
+    FitConfig,
+    GalaxyConfig,
+    Observation,
+    PhotometryData,
+)
+from jaxsedfit.core import JAXSEDFit
+
+
+def _minimal_config() -> FitConfig:
+    return FitConfig(
+        observation=Observation(object_id="roundtrip", redshift=0.2),
+        photometry=PhotometryData(filter_names=["toy"], fluxes=[1.0], errors=[0.1]),
+        filters=FilterSet(
+            curves=[
+                FilterCurve(
+                    name="toy",
+                    wave=[1000.0, 2000.0, 3000.0],
+                    transmission=[0.0, 1.0, 0.0],
+                )
+            ]
+        ),
+        galaxy=GalaxyConfig(dsps_ssp_fn="fake.h5", n_wave=32, sfh_n_steps=8),
+    )
+
+
+def test_load_from_samples_roundtrip(monkeypatch, tmp_path):
+    monkeypatch.setattr("jaxsedfit.core.build_model_context", lambda config: SimpleNamespace(mw_ebv=0.03))
+    fitter = JAXSEDFit(_minimal_config())
+    fitter.samples = {"log_stellar_mass": np.array([10.0, 10.2, 10.4])}
+    fitter.predictive = {"pred_fluxes": np.array([[0.9], [1.0], [1.1]])}
+
+    saved_path = fitter.save(tmp_path)
+    loaded = JAXSEDFit.load_from_samples(saved_path)
+
+    assert loaded.config.observation.object_id == "roundtrip"
+    assert loaded.config.observation.redshift == 0.2
+    assert loaded._loaded_posterior_path == saved_path
+    np.testing.assert_allclose(loaded.samples["log_stellar_mass"], [10.0, 10.2, 10.4])
+    np.testing.assert_allclose(loaded.predictive["pred_fluxes"], [[0.9], [1.0], [1.1]])
+
+
+def test_top_level_load_from_samples_accepts_unique_directory(monkeypatch, tmp_path):
+    monkeypatch.setattr("jaxsedfit.core.build_model_context", lambda config: SimpleNamespace(mw_ebv=0.0))
+    fitter = JAXSEDFit(_minimal_config())
+    fitter.samples = {"log_stellar_mass": np.array([9.9])}
+    fitter.predictive = {"pred_fluxes": np.array([[1.0]])}
+    fitter.save(tmp_path)
+
+    loaded = jaxsedfit.load_from_samples(tmp_path)
+
+    assert isinstance(loaded, JAXSEDFit)
+    np.testing.assert_allclose(loaded.samples["log_stellar_mass"], [9.9])
+
+
+def test_load_from_samples_requires_unique_posterior_file(monkeypatch, tmp_path):
+    monkeypatch.setattr("jaxsedfit.core.build_model_context", lambda config: SimpleNamespace(mw_ebv=0.0))
+    (tmp_path / "a_posterior.pkl").write_bytes(b"")
+    (tmp_path / "b_posterior.pkl").write_bytes(b"")
+
+    with pytest.raises(FileNotFoundError, match="Multiple"):
+        JAXSEDFit.load_from_samples(tmp_path)


### PR DESCRIPTION
## Summary

Adds a public posterior reload path for saved jaxsedfit results.

## Changes

- Add `JAXSEDFit.load_from_samples(path=None)` for loading `*_posterior.pkl` bundles written by `JAXSEDFit.save()`.
- Add the top-level convenience export `jaxsedfit.load_from_samples`.
- Support loading either an explicit posterior pickle file or a directory containing exactly one posterior pickle.
- Restore config, posterior samples, cached predictive outputs, saved summary metadata, and the loaded bundle path.
- Document the helper in the API reference and add round-trip IO tests.

## Validation

- `PYTHONPATH=src:/Users/colinburke/research/jaxqsofit/src conda run -n jaxcpu python -m pytest tests/test_io.py -q`