### PR TITLE
[codex] Expose model APIs in docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -26,3 +26,69 @@ API Reference
    jaxsedfit.plot_trace
    jaxsedfit.load_from_samples
    jaxsedfit.style_path
+
+Model Internals
+---------------
+
+Most users should interact with :class:`jaxsedfit.JAXSEDFit` and
+:class:`jaxsedfit.FitConfig`. The modules below expose the lower-level
+NumPyro model, static preload context, and reusable host-galaxy helpers used by
+advanced integrations and tests.
+
+Forward model
+~~~~~~~~~~~~~
+
+.. currentmodule:: jaxsedfit.model
+
+.. autofunction:: grahsp_photometric_model
+
+.. autofunction:: evaluate_photometric_state
+
+.. autofunction:: photometric_loglike
+
+.. autofunction:: spectroscopic_loglike
+
+Host helpers
+~~~~~~~~~~~~
+
+.. currentmodule:: jaxsedfit.host
+
+.. autofunction:: build_host_basis_jax
+
+.. autofunction:: build_host_state
+
+.. autofunction:: host_rest_on_basis
+
+Preload context
+~~~~~~~~~~~~~~~
+
+.. currentmodule:: jaxsedfit.preload
+
+.. autoclass:: ModelContext
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: LoadedFilter
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: LoadedTemplates
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: SSPData
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: HostBasis
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autofunction:: build_model_context
+
+.. autofunction:: load_cached_ssp_data

--- a/src/jaxsedfit/benchmark.py
+++ b/src/jaxsedfit/benchmark.py
@@ -416,6 +416,8 @@ def _reduced_chi2_for_fit(fitter: Any) -> float:
     cfg = getattr(fitter.config, "likelihood", None)
     if cfg is None:
         class _FallbackLikelihood:
+            """Minimal likelihood configuration used when old fitter objects lack one."""
+
             systematics_width = 0.0
             variability_uncertainty = False
             attenuation_model_uncertainty = False

--- a/src/jaxsedfit/config.py
+++ b/src/jaxsedfit/config.py
@@ -24,6 +24,7 @@ class Observation:
         return str(self.redshift_mode).lower() == "fit"
 
     def validate(self) -> None:
+        """Normalize and validate the redshift fitting mode."""
         mode = str(self.redshift_mode).lower()
         if mode not in {"fixed", "fit"}:
             raise ValueError("observation.redshift_mode must be either 'fixed' or 'fit'.")
@@ -149,6 +150,7 @@ class NebularConfig:
     young_age_cut_myr: float = 10.0
 
     def validate(self) -> None:
+        """Validate nebular-emission parameters and physical fractions."""
         if self.zgas is not None and (not np.isfinite(float(self.zgas)) or float(self.zgas) <= 0.0):
             raise ValueError("nebular.zgas must be a positive finite metallicity when set.")
         if not np.isfinite(float(self.logU)):
@@ -265,9 +267,11 @@ class RedshiftPriorConfig:
 
     @property
     def enabled(self) -> bool:
+        """Return True when a tabulated redshift prior is configured."""
         return self.z_grid is not None or self.pdf is not None
 
     def validate(self) -> None:
+        """Validate the tabulated redshift PDF shape, ordering, and normalization."""
         if not self.enabled:
             return
         if self.z_grid is None or self.pdf is None:
@@ -287,6 +291,7 @@ class RedshiftPriorConfig:
             raise ValueError("redshift prior must integrate to a positive finite value.")
 
     def to_mapping(self) -> dict[str, Any]:
+        """Convert the redshift prior into the low-level model mapping."""
         if not self.enabled:
             return {}
         return {"redshift_pdf": {"z_grid": self.z_grid, "pdf": self.pdf}}
@@ -304,9 +309,11 @@ class StellarMassPriorConfig:
 
     @property
     def enabled(self) -> bool:
+        """Return True when any stellar-mass prior field is configured."""
         return any(getattr(self, name) is not None for name in ("dist", "loc", "scale", "df", "low", "high"))
 
     def to_mapping(self) -> dict[str, Any]:
+        """Convert the stellar-mass prior into the low-level model mapping."""
         if not self.enabled:
             return {}
         out = {
@@ -342,6 +349,7 @@ class MassMetallicityPriorConfig:
     max_lgmet: float | None = None
 
     def to_mapping(self) -> dict[str, Any]:
+        """Convert the mass-metallicity relation prior into model settings."""
         if not self.configured:
             return {}
         out: dict[str, Any] = {
@@ -378,9 +386,11 @@ class PriorConfig(MutableMapping[str, Any]):
     overrides: dict[str, Any] = field(default_factory=dict)
 
     def validate(self) -> None:
+        """Validate nested semantic prior objects."""
         self.redshift.validate()
 
     def to_mapping(self) -> dict[str, Any]:
+        """Return the flat prior mapping consumed by the NumPyro model."""
         out: dict[str, Any] = dict(self.overrides)
         out.update(self.redshift.to_mapping())
         out.update(self.stellar_mass.to_mapping())
@@ -388,30 +398,38 @@ class PriorConfig(MutableMapping[str, Any]):
         return out
 
     def __getitem__(self, key: str) -> Any:
+        """Return one prior entry from the flat mapping view."""
         return self.to_mapping()[key]
 
     def __setitem__(self, key: str, value: Any) -> None:
+        """Store a low-level prior override by model-site key."""
         self.overrides[str(key)] = value
 
     def __delitem__(self, key: str) -> None:
+        """Remove a low-level override entry."""
         if key in self.overrides:
             del self.overrides[key]
             return
         raise KeyError(key)
 
     def __iter__(self):
+        """Iterate over keys in the flat mapping view."""
         return iter(self.to_mapping())
 
     def __len__(self) -> int:
+        """Return the number of entries in the flat mapping view."""
         return len(self.to_mapping())
 
     def __contains__(self, key: object) -> bool:
+        """Return True when a key exists in the flat mapping view."""
         return key in self.to_mapping()
 
     def get(self, key: str, default: Any = None) -> Any:
+        """Return a prior entry or default from the flat mapping view."""
         return self.to_mapping().get(key, default)
 
     def setdefault(self, key: str, default: Any = None) -> Any:
+        """Set and return a low-level override when the key is absent."""
         if key not in self:
             self[key] = default
         return self[key]
@@ -433,6 +451,7 @@ class FitConfig:
     prior_config: PriorConfig = field(default_factory=PriorConfig)
 
     def __post_init__(self) -> None:
+        """Coerce mapping-style prior configs into :class:`PriorConfig`."""
         self.prior_config = _coerce_prior_config(self.prior_config)
 
     def validate(self) -> None:

--- a/src/jaxsedfit/core.py
+++ b/src/jaxsedfit/core.py
@@ -849,6 +849,7 @@ class JAXSEDFit:
             host_capture = float(np.asarray(capture_fraction, dtype=float))
 
         def component(name: str, apply_scale: bool = True) -> np.ndarray:
+            """Return one posterior-median spectral component on the rest grid."""
             if name not in pred:
                 return np.zeros_like(wave_rest)
             comp_mjy = self._posterior_median_array(pred[name])[selected]
@@ -857,6 +858,7 @@ class JAXSEDFit:
             return self._mjy_to_rest_flambda_1e17(wave_obs, comp_mjy, z)
 
         def obs_sed_component(name: str, multiplier: float = 1.0) -> np.ndarray:
+            """Return one posterior-median observed SED component on the spectrum grid."""
             if name not in pred or "obs_wave" not in pred:
                 return np.zeros_like(wave_rest)
             source_wave = np.asarray(self._posterior_median_array(pred["obs_wave"]), dtype=float)
@@ -867,6 +869,7 @@ class JAXSEDFit:
             return self._obs_flambda_to_rest_flambda_1e17(scale_factor * multiplier * flux_lambda, z)
 
         def keep_component(arr: np.ndarray) -> bool:
+            """Return True for finite, nonzero component arrays worth plotting."""
             finite = np.asarray(arr, dtype=float)
             finite = finite[np.isfinite(finite)]
             return finite.size > 0 and float(np.nanmax(np.abs(finite))) > 0.0

--- a/src/jaxsedfit/model.py
+++ b/src/jaxsedfit/model.py
@@ -624,6 +624,7 @@ def _project_local_line_filters(
     curves = context.packed_filter_curves_jax
 
     def _one_filter(filt_wave, filt_trans, denom, eff_wave):
+        """Project the local AGN line grid through one packed filter curve."""
         trans = jnp.interp(obs_line_wave, filt_wave, filt_trans, left=0.0, right=0.0)
         numer = jnp.sum(jnp.trapezoid(trans * flux_lambda, obs_line_wave, axis=1))
         f_lambda = numer / jnp.maximum(denom, 1.0e-30)
@@ -660,6 +661,7 @@ def _project_local_nebular_line_filters(
     curves = context.packed_filter_curves_jax
 
     def _one_filter(filt_wave, filt_trans, denom, eff_wave):
+        """Project the local nebular line grid through one packed filter curve."""
         trans = jnp.interp(obs_line_wave, filt_wave, filt_trans, left=0.0, right=0.0)
         numer = jnp.sum(jnp.trapezoid(trans * flux_lambda, obs_line_wave, axis=1))
         f_lambda = numer / jnp.maximum(denom, 1.0e-30)
@@ -1159,6 +1161,7 @@ def _absolute_flux_scale_logprior(pred_fluxes, obs_fluxes, valid_mask, sigma_dex
     n_valid = jnp.sum(valid_mask.astype(jnp.int32))
 
     def _compute():
+        """Evaluate the Gaussian prior on log10 model/data flux scale."""
         obs_scale = _robust_flux_scale(obs_fluxes, valid_mask)
         pred_scale = _robust_flux_scale(pred_fluxes, valid_mask)
         log_ratio = jnp.log10(jnp.maximum(pred_scale, 1.0e-30) / jnp.maximum(obs_scale, 1.0e-30))

--- a/src/jaxsedfit/plotting.py
+++ b/src/jaxsedfit/plotting.py
@@ -27,6 +27,7 @@ _CORNER_ONE_SIGMA_QUANTILES = (0.16, 0.5, 0.84)
 
 
 def _posterior_samples(fitter_or_samples: Any) -> Mapping[str, Any]:
+    """Return posterior samples from either a fitter object or sample mapping."""
     if isinstance(fitter_or_samples, Mapping):
         samples = fitter_or_samples
     else:
@@ -37,6 +38,7 @@ def _posterior_samples(fitter_or_samples: Any) -> Mapping[str, Any]:
 
 
 def _grouped_trace_samples(fitter_or_samples: Any) -> tuple[Mapping[str, Any], bool]:
+    """Return trace samples and whether they are grouped by MCMC chain."""
     if not isinstance(fitter_or_samples, Mapping):
         nuts_result = getattr(fitter_or_samples, "nuts_result", None)
         if isinstance(nuts_result, Mapping):
@@ -47,6 +49,7 @@ def _grouped_trace_samples(fitter_or_samples: Any) -> tuple[Mapping[str, Any], b
 
 
 def _finite_scalar_sample_array(value: Any, *, grouped: bool) -> np.ndarray | None:
+    """Return a finite scalar sample array with the expected trace shape."""
     arr = np.asarray(value, dtype=float)
     if grouped:
         if arr.ndim != 2:
@@ -59,6 +62,7 @@ def _finite_scalar_sample_array(value: Any, *, grouped: bool) -> np.ndarray | No
 
 
 def _has_dynamic_range(value: Any, *, grouped: bool) -> bool:
+    """Return whether a scalar sample site spans more than one value."""
     arr = _finite_scalar_sample_array(value, grouped=grouped)
     if arr is None:
         return False
@@ -73,6 +77,7 @@ def _select_scalar_params(
     max_params: int | None,
     grouped: bool,
 ) -> list[str]:
+    """Select finite scalar sample sites for trace plotting."""
     if params is not None:
         selected = [str(param) for param in params]
         for param in selected:
@@ -101,6 +106,7 @@ def _select_corner_params(
     max_params: int | None,
     grouped: bool,
 ) -> list[str]:
+    """Select finite scalar sample sites with dynamic range for corner plots."""
     if params is not None:
         selected = [str(param) for param in params]
         for param in selected:
@@ -125,6 +131,7 @@ def _select_corner_params(
 
 
 def _labels_for_params(params: list[str], labels: Mapping[str, str] | list[str] | tuple[str, ...] | None) -> list[str]:
+    """Return display labels aligned with the selected parameter names."""
     if labels is None:
         return params
     if isinstance(labels, Mapping):
@@ -136,6 +143,7 @@ def _labels_for_params(params: list[str], labels: Mapping[str, str] | list[str] 
 
 
 def _truths_for_params(params: list[str], truths: Mapping[str, float | None] | list[float | None] | tuple[float | None, ...] | None):
+    """Return optional truth markers aligned with the selected parameter names."""
     if truths is None:
         return None
     if isinstance(truths, Mapping):
@@ -147,6 +155,7 @@ def _truths_for_params(params: list[str], truths: Mapping[str, float | None] | l
 
 
 def _sample_matrix(samples: Mapping[str, Any], params: list[str], *, grouped: bool) -> np.ndarray:
+    """Stack selected scalar posterior sample sites into a two-dimensional matrix."""
     columns = []
     draw_count = None
     for param in params:
@@ -311,6 +320,8 @@ def _median_effective_variance(fitter, pred: dict[str, Any]) -> np.ndarray:
     cfg = getattr(fitter.config, "likelihood", None)
     if cfg is None:
         class _FallbackLikelihood:
+            """Minimal likelihood configuration used when old fitter objects lack one."""
+
             systematics_width = 0.0
             variability_uncertainty = False
             attenuation_model_uncertainty = False

--- a/src/jaxsedfit/preload.py
+++ b/src/jaxsedfit/preload.py
@@ -349,6 +349,7 @@ def _map_logzsol_to_dsps_lgmet(logzsol_grid: Sequence[float], ssp_lgmet: np.ndar
     cand_shifted = logzsol_grid + np.log10(0.019)
 
     def mismatch(cand):
+        """Return the mean nearest-grid mismatch for one metallicity convention."""
         return np.mean([np.min(np.abs(ssp_lgmet - val)) for val in cand])
 
     return cand_direct if mismatch(cand_direct) <= mismatch(cand_shifted) else cand_shifted

--- a/src/utils.py
+++ b/src/utils.py
@@ -40,6 +40,7 @@ FILTER_MAP = {
 
 
 def _as_float(value):
+    """Convert a table cell to float, using NaN for masked or invalid values."""
     if np.ma.is_masked(value):
         return np.nan
     try:


### PR DESCRIPTION
## Summary
- expand the API reference with model internals, host helpers, and preload context objects
- add missing docstrings across source-level functions/classes so generated docs have complete method descriptions
- keep generated API pages clean by avoiding duplicate internals autosummary entries

## Validation
- `conda run -n jaxcpu python -m compileall -q src`
- package-wide AST docstring audit over `src/**/*.py`
- `MPLCONFIGDIR=/private/tmp/mplconfig-jaxsedfit PYTHONPATH=/Users/colinburke/research/jaxsedfit/src:/Users/colinburke/research/jaxqsofit/src conda run -n jaxcpu python -m sphinx -b html docs docs/_build/html`

Note: Sphinx emitted notebook `MissingIDFieldWarning` messages from nbformat, but the docs build completed successfully with no Sphinx warnings.
