### PR TITLE
[codex] Add result object API

### DIFF
--- a/docs/api/fitting.rst
+++ b/docs/api/fitting.rst
@@ -4,7 +4,13 @@ Fitting Interface
 .. currentmodule:: jaxsedfit
 
 .. autoclass:: JAXSEDFit
-   :members: fit, fit_map, fit_nuts, fit_ns, predict, save, load, plot_sed, plot_corner, plot_trace, plot_jaxqsofit_spectrum
+   :members: fit, fit_map, fit_nuts, fit_ns, predict, save, load, load_result, plot_sed, plot_corner, plot_trace, plot_jaxqsofit_spectrum
    :show-inheritance:
+
+.. autoclass:: FitResult
+   :members: predict, save, plot_corner, plot_trace
+
+.. autoclass:: PredictionResult
+   :members: median, keys, items, get
 
 .. autofunction:: load_from_samples

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -10,6 +10,7 @@ Primary Interface
 
 - :class:`jaxsedfit.JAXSEDFit`
 - :class:`jaxsedfit.FitConfig`
+- :class:`jaxsedfit.FitResult`
 - :func:`jaxsedfit.load_from_samples`
 
 API Sections

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -23,7 +23,7 @@ the config first, pass it to :class:`jaxsedfit.JAXSEDFit`, and then call
 
    cfg.inference.method = "optax+nuts"
    fitter = JAXSEDFit(cfg)
-   fitter.fit(
+   result = fitter.fit(
        optax_steps=600,
        optax_lr=1e-2,
        nuts_warmup=50,
@@ -34,13 +34,15 @@ the config first, pass it to :class:`jaxsedfit.JAXSEDFit`, and then call
        save_result=True,
        output_dir="fit_outputs",
    )
+   result.summary
+   result.plot_corner()
 
 Nested sampling is available through NumPyro's ``jaxns`` wrapper:
 
 .. code-block:: python
 
    cfg.inference.method = "ns"
-   fitter.fit(
+   result = fitter.fit(
        ns_live_points=200,
        ns_dlogz=0.1,
    )
@@ -49,4 +51,5 @@ The component SED plot can also be generated directly:
 
 .. code-block:: python
 
+   prediction = result.predict()
    fitter.plot_sed(output_path="sed_fit.png")

--- a/notebooks/01_example.ipynb
+++ b/notebooks/01_example.ipynb
@@ -138,7 +138,7 @@
     "    progress_bar=True,\n",
     ")\n",
     "\n",
-    "summary = fit_result[\"summary\"]\n",
+    "summary = fit_result.summary\n",
     "logm_samples = np.asarray(fitter.samples[\"log_stellar_mass\"], dtype=float).reshape(-1)\n",
     "logm16, recovered_logm, logm84 = np.percentile(logm_samples, [16.0, 50.0, 84.0])\n",
     "truth_logm = row[\"log_stellar_mass_truth\"]\n",

--- a/notebooks/04_fairall9_fake_photoz.ipynb
+++ b/notebooks/04_fairall9_fake_photoz.ipynb
@@ -292,7 +292,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "samples = fit_result[\"fit\"][\"results\"].samples\n",
+    "samples = fitter.ns_result[\"results\"].samples\n",
     "\n",
     "if \"redshift_fit\" not in samples:\n",
     "    raise KeyError(f\"redshift_fit not found. Available sample keys include: {list(samples)[:20]}\")\n",

--- a/notebooks/11_full_chimera_example.ipynb
+++ b/notebooks/11_full_chimera_example.ipynb
@@ -283,7 +283,7 @@
     ")\n",
     "\n",
     "\n",
-    "summary = fit_result[\"summary\"]\n",
+    "summary = fit_result.summary\n",
     "logm_samples = np.asarray(fitter.samples[\"log_stellar_mass\"], dtype=float).reshape(-1)\n",
     "logm16, recovered_logm, logm84 = np.percentile(logm_samples, [16.0, 50.0, 84.0])\n",
     "truth_logm = row[\"log_stellar_mass_truth\"]\n",

--- a/src/jaxsedfit/__init__.py
+++ b/src/jaxsedfit/__init__.py
@@ -29,6 +29,7 @@ __all__ = [
     "FilterCurve",
     "FilterSet",
     "FitConfig",
+    "FitResult",
     "GalaxyConfig",
     "HostBasisJax",
     "JAXSEDFit",
@@ -38,6 +39,7 @@ __all__ = [
     "NebularConfig",
     "Observation",
     "PhotometryData",
+    "PredictionResult",
     "PriorConfig",
     "RedshiftPriorConfig",
     "StellarMassPriorConfig",
@@ -67,6 +69,10 @@ def __getattr__(name):
         from .core import JAXSEDFit
 
         return JAXSEDFit
+    if name in {"FitResult", "PredictionResult"}:
+        from . import results as _results
+
+        return getattr(_results, name)
     if name in {"load_from_samples", "load"}:
         from .core import JAXSEDFit
 

--- a/src/jaxsedfit/core.py
+++ b/src/jaxsedfit/core.py
@@ -12,6 +12,7 @@ from numpyro.infer.autoguide import AutoDelta
 from .config import FitConfig, _coerce_prior_config, fit_config_from_mapping, serialize_config
 from .model import grahsp_photometric_model
 from .preload import ModelContext, build_model_context
+from .results import FitResult, median_mapping
 
 
 def _get_nested_sampler_cls():
@@ -76,6 +77,36 @@ class JAXSEDFit:
     def _predictive_model(self):
         """Return the bound NumPyro model used for posterior predictive products."""
         return grahsp_photometric_model(self.context, include_components=True)
+
+    def _make_result(
+        self,
+        *,
+        method: str,
+        path: str | Path | None = None,
+        figure: Any = None,
+        summary: dict[str, Any] | None = None,
+    ) -> FitResult:
+        """Build a public result object from the current mirrored fit state."""
+        samples = getattr(self, "samples", None)
+        map_result = getattr(self, "map_result", None)
+        if method == "map" and map_result is not None and "median" in map_result:
+            median = dict(map_result["median"])
+        else:
+            median = median_mapping(samples)
+        if summary is None and samples is not None:
+            try:
+                summary = self.summary()
+            except AttributeError:
+                summary = None
+        return FitResult(
+            fitter=self,
+            samples=samples,
+            median=median,
+            method=method,
+            summary=summary,
+            path=None if path is None else Path(path),
+            figure=figure,
+        )
 
     def _compute_predictive(self) -> dict[str, Any]:
         """Generate and cache predictive outputs from posterior samples."""
@@ -389,18 +420,16 @@ class JAXSEDFit:
             if save_fig:
                 saved_fig_path = Path(fig_path) if fig_path is not None else None
 
-        samples = getattr(self, "samples", None)
         # Lightweight test doubles may call fit() on a partially constructed object
         # without config/context. Preserve the direct fit payload for that case only.
         if not hasattr(self, "config"):
             return fit_output
-        return {
-            "fit": fit_output,
-            "summary": self.summary() if samples is not None else None,
-            "figure": fig,
-            "figure_path": saved_fig_path,
-            "result_path": saved_result_path,
-        }
+        return self._make_result(
+            method=method,
+            path=saved_result_path,
+            figure=fig,
+            summary=self.summary() if getattr(self, "samples", None) is not None else None,
+        )
 
     def _run_map_svi(
         self,
@@ -474,7 +503,7 @@ class JAXSEDFit:
             }
         self.samples = {k: np.asarray(v)[None, ...] for k, v in median.items()}
         self.predictive = None
-        return self.map_result
+        return self._make_result(method="map")
 
     def fit_nuts(
         self,
@@ -503,7 +532,7 @@ class JAXSEDFit:
         self.nuts_result = {"mcmc": mcmc}
         self.samples = {k: np.asarray(v) for k, v in samples.items()}
         self.predictive = None
-        return self.nuts_result
+        return self._make_result(method="nuts")
 
     def fit_ns(
         self,
@@ -587,7 +616,7 @@ class JAXSEDFit:
         }
         self.samples = {k: np.asarray(v) for k, v in samples.items()}
         self.predictive = None
-        return self.ns_result
+        return self._make_result(method="ns")
 
     def predict(self, posterior: str = "latest") -> dict[str, Any]:
         """Return cached predictive outputs or generate them on demand."""
@@ -714,6 +743,16 @@ class JAXSEDFit:
         return fitter
 
     load_from_samples = load
+
+    @classmethod
+    def load_result(cls, path: str | Path | None = None) -> FitResult:
+        """Load a posterior bundle and wrap it in a :class:`FitResult`."""
+        fitter = cls.load(path)
+        return fitter._make_result(
+            method="loaded",
+            path=getattr(fitter, "_loaded_posterior_path", None),
+            summary=getattr(fitter, "_saved_summary", None),
+        )
 
     def plot_sed(
         self,

--- a/src/jaxsedfit/results.py
+++ b/src/jaxsedfit/results.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping
+
+import numpy as np
+
+
+def median_mapping(values: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Return posterior medians for every value in a sample-like mapping."""
+    out: dict[str, Any] = {}
+    for key, value in (values or {}).items():
+        arr = np.asarray(value)
+        if arr.ndim == 0:
+            out[key] = arr.item()
+        elif arr.size == 0:
+            out[key] = arr
+        else:
+            out[key] = np.nanmedian(arr, axis=0)
+    return out
+
+
+@dataclass
+class PredictionResult:
+    """Dict-like posterior predictive result with lazy median summaries."""
+
+    data: Mapping[str, Any]
+    fitter: Any
+    _median: dict[str, Any] | None = field(default=None, init=False, repr=False)
+
+    @property
+    def median(self) -> dict[str, Any]:
+        """Median predictive values over the leading posterior axis."""
+        if self._median is None:
+            self._median = median_mapping(self.data)
+        return self._median
+
+    def __getitem__(self, key: str) -> Any:
+        return self.data[key]
+
+    def keys(self):
+        return self.data.keys()
+
+    def items(self):
+        return self.data.items()
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self.data.get(key, default)
+
+
+@dataclass
+class FitResult:
+    """High-level result object returned by ``jaxsedfit`` fit methods."""
+
+    fitter: Any
+    samples: Mapping[str, Any] | None
+    median: Mapping[str, Any]
+    method: str
+    summary: Mapping[str, Any] | None = None
+    path: Path | None = None
+    figure: Any = None
+
+    def predict(self, **kwargs) -> PredictionResult:
+        """Run or return posterior predictive products for this fit."""
+        return PredictionResult(self.fitter.predict(**kwargs), fitter=self.fitter)
+
+    def save(self, path: str | Path | None = None, **kwargs) -> Path:
+        """Save the result with the fitter's native persistence format."""
+        output_path = Path("." if path is None else path)
+        self.path = Path(self.fitter.save(output_path, **kwargs))
+        return self.path
+
+    def plot_corner(self, **kwargs):
+        """Plot posterior samples with the fitter's corner-plot helper."""
+        return self.fitter.plot_corner(**kwargs)
+
+    def plot_trace(self, **kwargs):
+        """Plot posterior samples with the fitter's trace-plot helper."""
+        return self.fitter.plot_trace(**kwargs)

--- a/tests/test_diffstar_host.py
+++ b/tests/test_diffstar_host.py
@@ -17,6 +17,7 @@ from jaxsedfit.config import (
 from jaxsedfit.core import JAXSEDFit
 from jaxsedfit.model import _default_gal_lgmet_loc, _mass_metallicity_relation_logprior, _luminosity_distance_m_jax, grahsp_photometric_model
 from jaxsedfit.preload import build_model_context
+from jaxsedfit.results import FitResult
 
 
 def _mock_config():
@@ -353,7 +354,8 @@ def test_fit_dispatch_methods(monkeypatch):
     fitter.config = type("_Cfg", (), {"inference": InferenceConfig(method="optax+nuts")})()
 
     out = JAXSEDFit.fit(fitter, progress_bar=True, steps=7, learning_rate=1e-2, num_warmup=3, num_samples=4)
-    assert list(out["fit"]) == ["map", "nuts"]
+    assert isinstance(out, FitResult)
+    assert out.method == "optax+nuts"
     assert calls[0][0] == "optax"
     assert calls[0][1]["steps"] == 7
     assert calls[0][1]["progress_bar"] is True
@@ -366,19 +368,22 @@ def test_fit_dispatch_methods(monkeypatch):
     calls.clear()
     fitter.config.inference.method = "optax"
     out = JAXSEDFit.fit(fitter, progress_bar=False, steps=2)
-    assert out["fit"] == {"median": {"log_stellar_mass": 10.0}}
+    assert isinstance(out, FitResult)
+    assert out.method == "optax"
     assert calls == [("optax", {"steps": 2, "progress_bar": False, "staged": True})]
 
     calls.clear()
     fitter.config.inference.method = "optax"
     out = JAXSEDFit.fit(fitter, progress_bar=False, steps=2, staged_map=False)
-    assert out["fit"] == {"median": {"log_stellar_mass": 10.0}}
+    assert isinstance(out, FitResult)
+    assert out.method == "optax"
     assert calls == [("optax", {"steps": 2, "progress_bar": False, "staged": False})]
 
     calls.clear()
     fitter.config.inference.method = "nuts"
     out = JAXSEDFit.fit(fitter, progress_bar=False, num_warmup=2)
-    assert out["fit"] == {"mcmc": "ok"}
+    assert isinstance(out, FitResult)
+    assert out.method == "nuts"
     assert calls == [("nuts", {"num_warmup": 2, "progress_bar": False})]
 
     calls.clear()
@@ -397,7 +402,8 @@ def test_fit_dispatch_methods(monkeypatch):
         ns_max_likelihood_evals=5000,
         ns_efficiency_threshold=0.001,
     )
-    assert out["fit"] == {"nested": "ok"}
+    assert isinstance(out, FitResult)
+    assert out.method == "ns"
     assert calls == [
         (
             "ns",
@@ -462,19 +468,21 @@ def test_fit_ns_populates_samples(monkeypatch):
         progress_bar=False,
     )
 
-    assert result["results"] == {"status": "ok"}
-    assert result["constructor_kwargs"]["num_live_points"] == 17
-    assert result["constructor_kwargs"]["max_samples"] == 123
-    assert result["constructor_kwargs"]["verbose"] is False
-    assert result["constructor_kwargs"]["difficult_model"] is True
-    assert result["constructor_kwargs"]["parameter_estimation"] is True
-    assert result["constructor_kwargs"]["num_parallel_workers"] == 2
-    assert result["constructor_kwargs"]["init_efficiency_threshold"] == 0.15
-    assert result["termination_kwargs"]["dlogZ"] == 0.05
-    assert result["termination_kwargs"]["max_num_likelihood_evaluations"] == 1000
-    assert result["termination_kwargs"]["efficiency_threshold"] == 0.01
-    assert result["num_resamples"] == 7
-    assert fitter.ns_result is result
+    assert isinstance(result, FitResult)
+    assert result.method == "ns"
+    assert result.samples is fitter.samples
+    assert fitter.ns_result["results"] == {"status": "ok"}
+    assert fitter.ns_result["constructor_kwargs"]["num_live_points"] == 17
+    assert fitter.ns_result["constructor_kwargs"]["max_samples"] == 123
+    assert fitter.ns_result["constructor_kwargs"]["verbose"] is False
+    assert fitter.ns_result["constructor_kwargs"]["difficult_model"] is True
+    assert fitter.ns_result["constructor_kwargs"]["parameter_estimation"] is True
+    assert fitter.ns_result["constructor_kwargs"]["num_parallel_workers"] == 2
+    assert fitter.ns_result["constructor_kwargs"]["init_efficiency_threshold"] == 0.15
+    assert fitter.ns_result["termination_kwargs"]["dlogZ"] == 0.05
+    assert fitter.ns_result["termination_kwargs"]["max_num_likelihood_evaluations"] == 1000
+    assert fitter.ns_result["termination_kwargs"]["efficiency_threshold"] == 0.01
+    assert fitter.ns_result["num_resamples"] == 7
     assert set(fitter.samples) == {"log_stellar_mass", "host_age_weights", "host_lgmet_weights"}
     assert fitter.samples["log_stellar_mass"].shape == (7,)
     assert fitter.predictive is None

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -13,6 +13,7 @@ from jaxsedfit.config import (
     PhotometryData,
 )
 from jaxsedfit.core import JAXSEDFit
+from jaxsedfit.results import FitResult
 
 
 def _minimal_config() -> FitConfig:
@@ -59,6 +60,35 @@ def test_top_level_load_from_samples_accepts_unique_directory(monkeypatch, tmp_p
 
     assert isinstance(loaded, JAXSEDFit)
     np.testing.assert_allclose(loaded.samples["log_stellar_mass"], [9.9])
+
+
+def test_load_result_wraps_loaded_fitter(monkeypatch, tmp_path):
+    monkeypatch.setattr("jaxsedfit.core.build_model_context", lambda config: SimpleNamespace(mw_ebv=0.0))
+    fitter = JAXSEDFit(_minimal_config())
+    fitter.samples = {"log_stellar_mass": np.array([9.8, 10.0])}
+    fitter.predictive = {"pred_fluxes": np.array([[1.0], [1.2]])}
+    saved_path = fitter.save(tmp_path)
+
+    result = JAXSEDFit.load_result(saved_path)
+
+    assert isinstance(result, FitResult)
+    assert isinstance(result.fitter, JAXSEDFit)
+    assert result.path == saved_path
+    np.testing.assert_allclose(result.samples["log_stellar_mass"], [9.8, 10.0])
+    assert np.isclose(result.median["log_stellar_mass"], 9.9)
+
+
+def test_fit_result_save_delegates_to_fitter(monkeypatch, tmp_path):
+    monkeypatch.setattr("jaxsedfit.core.build_model_context", lambda config: SimpleNamespace(mw_ebv=0.0))
+    fitter = JAXSEDFit(_minimal_config())
+    fitter.samples = {"log_stellar_mass": np.array([9.8, 10.0])}
+    fitter.predictive = {"pred_fluxes": np.array([[1.0], [1.2]])}
+    result = fitter._make_result(method="map")
+
+    saved_path = result.save(tmp_path)
+
+    assert result.path == saved_path
+    assert saved_path.exists()
 
 
 def test_load_from_samples_requires_unique_posterior_file(monkeypatch, tmp_path):

--- a/tests/test_model_helpers.py
+++ b/tests/test_model_helpers.py
@@ -1310,8 +1310,11 @@ def test_jaxsedfit_jaxqsofit_tied_line_backend_runs_svi_jit(monkeypatch):
     fitter = JAXSEDFit(cfg)
     result = fitter.fit_map(steps=1, progress_bar=False)
 
-    assert np.asarray(result["losses"]).shape == (1,)
-    assert np.isfinite(float(np.asarray(result["losses"])[0]))
+    assert result.samples is fitter.samples
+    assert result.method == "map"
+    assert "log_agn_amp" in result.median
+    assert np.asarray(fitter.map_result["losses"]).shape == (1,)
+    assert np.isfinite(float(np.asarray(fitter.map_result["losses"])[0]))
 
 
 def test_plot_jaxqsofit_spectrum_adapts_joint_predictive(monkeypatch):

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -301,22 +301,28 @@ def test_jaxsedfit_corner_and_trace_methods_delegate(monkeypatch):
 
     try:
         from jaxsedfit.core import JAXSEDFit
+        from jaxsedfit.results import FitResult, PredictionResult
 
         monkeypatch.setattr(plotting, "plot_corner", _plot_corner)
         monkeypatch.setattr(plotting, "plot_trace", _plot_trace)
         monkeypatch.setattr(plotting, "plot_fit_sed", _plot_fit_sed)
         fitter = object.__new__(JAXSEDFit)
+        fitter.predict = lambda **kwargs: {"pred_fluxes": np.array([[1.0], [3.0]])}
 
         assert fitter.plot_sed(output_path="sed.pdf") == "sed"
         assert fitter.plot_corner(output_path="corner.pdf", params=["alpha"]) == "corner"
         assert fitter.plot_trace(output_path="trace.pdf", params=["beta"]) == "trace"
+        result = FitResult(fitter=fitter, samples={}, median={}, method="map")
+        pred = result.predict()
+        assert isinstance(pred, PredictionResult)
+        np.testing.assert_allclose(pred.median["pred_fluxes"], [2.0])
+        assert result.plot_corner(output_path="result_corner.pdf") == "corner"
+        assert result.plot_trace(output_path="result_trace.pdf") == "trace"
         assert calls["sed"][0] is fitter
         assert calls["sed"][1]["output_path"] == "sed.pdf"
         assert calls["corner"][0] is fitter
-        assert calls["corner"][1]["output_path"] == "corner.pdf"
-        assert calls["corner"][1]["params"] == ["alpha"]
+        assert calls["corner"][1]["output_path"] == "result_corner.pdf"
         assert calls["trace"][0] is fitter
-        assert calls["trace"][1]["output_path"] == "trace.pdf"
-        assert calls["trace"][1]["params"] == ["beta"]
+        assert calls["trace"][1]["output_path"] == "result_trace.pdf"
     finally:
         sys.modules.pop("jaxsedfit.core", None)


### PR DESCRIPTION
## Summary

- Add FitResult and PredictionResult as first-class result objects.
- Return FitResult from fit paths while preserving mirrored fitter state.
- Add load_result plus result-level predict/save/plot helpers.
- Update quickstart/API docs, tests, and notebooks that used old fit-return dicts.

## Validation

- conda run -n jaxcpu pytest -> 120 passed
- Sphinx docs build -> passed
