### PR TITLE
[codex] document jaxqsofit broad component configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Agent Instructions
+
+## GitHub and PR Workflow
+
+- The user's normal terminal has a working `gh` setup, but Codex runs in a sandbox where `gh` auth and network access may fail.
+- Do not spend repeated attempts debugging `gh` authentication or GitHub network failures inside the sandbox.
+- For PR requests, first inspect the worktree with `git status --short` and identify the intended scope.
+- If the worktree has unrelated modified files, stage only the files that belong to the requested change. Do not use `git add -A` unless the user explicitly confirms the whole worktree is in scope.
+- Prefer this workflow:
+  1. Make or verify the requested local changes.
+  2. Create a branch if needed.
+  3. Commit only the intended files.
+  4. Provide the exact `git push` and `gh pr create` commands for the user to run in their own terminal.
+- If the user explicitly wants Codex to push or open the PR, request sandbox escalation for `git push` or `gh pr create` once. If that fails due to auth or network restrictions, stop and give the terminal commands instead of retrying repeatedly.
+- Open PRs as drafts unless the user explicitly asks for ready-for-review.
+
+## Repository Safety
+
+- Assume uncommitted changes may be the user's work. Do not revert or overwrite them without explicit instruction.
+- Keep documentation-only changes scoped to the relevant docs files.
+- For notebook changes, avoid clearing or rewriting outputs unless the task explicitly requires it.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -37,6 +37,33 @@ the config first, pass it to :class:`jaxsedfit.JAXSEDFit`, and then call
    result.summary
    result.plot_corner()
 
+Changing jaxqsofit broad-line components
+----------------------------------------
+
+When spectroscopy uses the ``jaxqsofit`` backend, the number of broad
+Gaussian components is set by the line-table ``ngauss`` field. The default
+``jaxqsofit`` line table uses names such as ``Ha_br``, ``Hb_br``, ``MgII_br``,
+``CIV_br``, and ``Lya_br`` for broad components. Copy the table, adjust
+``ngauss`` for the rows you want, and assign it before constructing
+:class:`jaxsedfit.JAXSEDFit`.
+
+.. code-block:: python
+
+   from copy import deepcopy
+
+   from jaxqsofit.defaults import DEFAULT_LINE_PRIOR_ROWS
+
+   line_table = deepcopy(DEFAULT_LINE_PRIOR_ROWS)
+
+   for row in line_table:
+       if row["linename"] in {"Ha_br", "Hb_br", "MgII_br"}:
+           row["ngauss"] = 3
+       if row["linename"] in {"CIV_br", "Lya_br"}:
+           row["ngauss"] = 2
+
+   cfg.spectroscopy_config.backend = "jaxqsofit"
+   cfg.spectroscopy_config.jaxqsofit.line_table = line_table
+
 When ``save_result=True`` or :meth:`jaxsedfit.FitResult.save` is used,
 ``jaxsedfit`` writes an HDF5 posterior bundle named
 ``<object_id>_samples.h5``. The bundle contains the fit config, posterior


### PR DESCRIPTION
## Summary

- Add repo-level `AGENTS.md` with GitHub PR workflow guidance for Codex in this sandboxed environment.
- Document how to change jaxqsofit broad Gaussian component counts from jaxsedfit by overriding the line-table `ngauss` values.

## Impact

This gives future agent sessions explicit instructions to avoid repeated sandboxed `gh` failures and gives users a quickstart example for changing broad-line component counts.

## Validation

- Docs-only change; tests were not run.
