### PR TITLE
[codex] Interpolate nebular template grids

### DIFF
--- a/src/jaxsedfit/model.py
+++ b/src/jaxsedfit/model.py
@@ -487,9 +487,42 @@ def _flux_conserving_line_gaussians(wave, line_wave, line_lumin, width_kms):
     return jnp.sum(line_lumin[None, :] * profile, axis=1)
 
 
-def _nearest_index(grid, value):
-    """Return the index of the nearest tabulated grid value."""
-    return jnp.argmin(jnp.abs(grid - jnp.asarray(value, dtype=jnp.float64)))
+def _interp_grid_axis(grid, value, *, log_scale: bool = False):
+    """Return bracketing indices and interpolation weight for one template axis."""
+    grid = jnp.asarray(grid, dtype=jnp.float64)
+    x_grid = jnp.log10(jnp.maximum(grid, 1.0e-300)) if log_scale else grid
+    x = jnp.log10(jnp.maximum(value, 1.0e-300)) if log_scale else jnp.asarray(value, dtype=jnp.float64)
+    x = jnp.clip(x, x_grid[0], x_grid[-1])
+    upper = jnp.clip(jnp.searchsorted(x_grid, x, side="right"), 1, grid.shape[0] - 1)
+    lower = upper - 1
+    x0 = x_grid[lower]
+    x1 = x_grid[upper]
+    weight = jnp.clip((x - x0) / jnp.maximum(x1 - x0, 1.0e-300), 0.0, 1.0)
+    return lower, upper, weight
+
+
+def _trilinear_nebular_grid(values, z_grid, logu_grid, ne_grid, zgas, logu, ne):
+    """Interpolate a nebular template grid in log Z, log U, and log density."""
+    z0, z1, wz = _interp_grid_axis(z_grid, zgas, log_scale=True)
+    u0, u1, wu = _interp_grid_axis(logu_grid, logu, log_scale=False)
+    n0, n1, wn = _interp_grid_axis(ne_grid, ne, log_scale=True)
+
+    c000 = values[z0, u0, n0]
+    c001 = values[z0, u0, n1]
+    c010 = values[z0, u1, n0]
+    c011 = values[z0, u1, n1]
+    c100 = values[z1, u0, n0]
+    c101 = values[z1, u0, n1]
+    c110 = values[z1, u1, n0]
+    c111 = values[z1, u1, n1]
+
+    c00 = c000 * (1.0 - wn) + c001 * wn
+    c01 = c010 * (1.0 - wn) + c011 * wn
+    c10 = c100 * (1.0 - wn) + c101 * wn
+    c11 = c110 * (1.0 - wn) + c111 * wn
+    c0 = c00 * (1.0 - wu) + c01 * wu
+    c1 = c10 * (1.0 - wu) + c11 * wu
+    return c0 * (1.0 - wz) + c1 * wz
 
 
 def _cigale_nebular_correction(f_esc, f_dust):
@@ -1124,18 +1157,42 @@ def _build_nebular_components(context: ModelContext, host_state: dict[str, Any],
     n_ly_total = jnp.clip(n_ly_young + n_ly_old, 0.0, 1.0e300)
     ly_lum_total = jnp.clip(ly_lum_young + ly_lum_old, 0.0, 1.0e300)
 
-    templates = context.nebular_templates_jax
-    z_idx = _nearest_index(templates.z_grid, zgas)
-    u_idx = _nearest_index(templates.logu_grid, logu)
-    ne_idx = _nearest_index(templates.ne_grid, ne)
     corr = _cigale_nebular_correction(f_esc, f_dust)
+    templates = context.nebular_templates_jax
     rest_templates = context.nebular_rest_templates_jax
-    continuum_rest = rest_templates.continuum_lumin_per_a_per_photon[z_idx, u_idx, ne_idx] * n_ly_total * corr
-    line_lumin = templates.line_lumin_per_photon[z_idx, u_idx, ne_idx] * n_ly_total * corr
+    continuum_per_photon = _trilinear_nebular_grid(
+        rest_templates.continuum_lumin_per_a_per_photon,
+        templates.z_grid,
+        templates.logu_grid,
+        templates.ne_grid,
+        zgas,
+        logu,
+        ne,
+    )
+    line_lumin_per_photon = _trilinear_nebular_grid(
+        templates.line_lumin_per_photon,
+        templates.z_grid,
+        templates.logu_grid,
+        templates.ne_grid,
+        zgas,
+        logu,
+        ne,
+    )
+    continuum_rest = continuum_per_photon * n_ly_total * corr
+    line_lumin = line_lumin_per_photon * n_ly_total * corr
     if context.fixed_nebular_line_profile_jax is not None:
         lines_rest = context.fixed_nebular_line_profile_jax * n_ly_total * corr
     elif rest_templates.line_profile_per_photon is not None:
-        lines_rest = rest_templates.line_profile_per_photon[z_idx, u_idx, ne_idx] * n_ly_total * corr
+        line_profile_per_photon = _trilinear_nebular_grid(
+            rest_templates.line_profile_per_photon,
+            templates.z_grid,
+            templates.logu_grid,
+            templates.ne_grid,
+            zgas,
+            logu,
+            ne,
+        )
+        lines_rest = line_profile_per_photon * n_ly_total * corr
     else:
         lines_rest = _flux_conserving_line_gaussians(rest_wave, templates.line_wave_a, line_lumin, lines_width)
     emission_scale = jnp.asarray(1.0 if cfg.emission else 0.0, dtype=jnp.float64)

--- a/src/jaxsedfit/preload.py
+++ b/src/jaxsedfit/preload.py
@@ -972,9 +972,49 @@ def _load_nebular_templates_jax(enabled: bool) -> NebularTemplatesJax:
     return loaded
 
 
-def _nearest_index_np(grid: np.ndarray, value: float) -> int:
-    """Return the index of the nearest tabulated grid value."""
-    return int(np.argmin(np.abs(np.asarray(grid, dtype=float) - float(value))))
+def _interp_grid_axis_np(grid: np.ndarray, value: float, *, log_scale: bool = False) -> tuple[int, int, float]:
+    """Return bracketing indices and interpolation weight for one template axis."""
+    grid = np.asarray(grid, dtype=float)
+    x_grid = np.log10(np.clip(grid, 1.0e-300, None)) if log_scale else grid
+    x = np.log10(max(float(value), 1.0e-300)) if log_scale else float(value)
+    x = float(np.clip(x, x_grid[0], x_grid[-1]))
+    upper = int(np.clip(np.searchsorted(x_grid, x, side="right"), 1, grid.size - 1))
+    lower = upper - 1
+    denom = max(float(x_grid[upper] - x_grid[lower]), 1.0e-300)
+    weight = float(np.clip((x - x_grid[lower]) / denom, 0.0, 1.0))
+    return lower, upper, weight
+
+
+def _trilinear_nebular_grid_np(
+    values: np.ndarray,
+    z_grid: np.ndarray,
+    logu_grid: np.ndarray,
+    ne_grid: np.ndarray,
+    zgas: float,
+    logu: float,
+    ne: float,
+) -> np.ndarray:
+    """Interpolate a nebular template grid in log Z, log U, and log density."""
+    z0, z1, wz = _interp_grid_axis_np(z_grid, zgas, log_scale=True)
+    u0, u1, wu = _interp_grid_axis_np(logu_grid, logu, log_scale=False)
+    n0, n1, wn = _interp_grid_axis_np(ne_grid, ne, log_scale=True)
+
+    c000 = values[z0, u0, n0]
+    c001 = values[z0, u0, n1]
+    c010 = values[z0, u1, n0]
+    c011 = values[z0, u1, n1]
+    c100 = values[z1, u0, n0]
+    c101 = values[z1, u0, n1]
+    c110 = values[z1, u1, n0]
+    c111 = values[z1, u1, n1]
+
+    c00 = c000 * (1.0 - wn) + c001 * wn
+    c01 = c010 * (1.0 - wn) + c011 * wn
+    c10 = c100 * (1.0 - wn) + c101 * wn
+    c11 = c110 * (1.0 - wn) + c111 * wn
+    c0 = c00 * (1.0 - wu) + c01 * wu
+    c1 = c10 * (1.0 - wu) + c11 * wu
+    return c0 * (1.0 - wz) + c1 * wz
 
 
 def _flux_conserving_line_gaussians_np(
@@ -1015,25 +1055,31 @@ def _build_fixed_nebular_line_profile(
     ne_grid = np.asarray(templates.ne_grid, dtype=float)
     line_wave = np.asarray(templates.line_wave_a, dtype=float)
     line_lumin_per_photon = np.asarray(templates.line_lumin_per_photon, dtype=float)
-    z_idx = _nearest_index_np(z_grid, float(neb.zgas))
-    u_idx = _nearest_index_np(logu_grid, float(neb.logU))
-    ne_idx = _nearest_index_np(ne_grid, float(neb.ne))
     cache_key = (
         float(rest_wave[0]),
         float(rest_wave[-1]),
         int(rest_wave.size),
-        z_idx,
-        u_idx,
-        ne_idx,
+        float(neb.zgas),
+        float(neb.logU),
+        float(neb.ne),
         float(neb.lines_width),
     )
     cached = _FIXED_NEBULAR_LINE_PROFILE_CACHE.get(cache_key)
     if cached is not None:
         return cached
+    line_lumin_interp = _trilinear_nebular_grid_np(
+        line_lumin_per_photon,
+        z_grid,
+        logu_grid,
+        ne_grid,
+        float(neb.zgas),
+        float(neb.logU),
+        float(neb.ne),
+    )
     profile = _flux_conserving_line_gaussians_np(
         rest_wave,
         line_wave,
-        line_lumin_per_photon[z_idx, u_idx, ne_idx],
+        line_lumin_interp,
         float(neb.lines_width),
     ).astype(float)
     _FIXED_NEBULAR_LINE_PROFILE_CACHE[cache_key] = profile

--- a/tests/test_nebular.py
+++ b/tests/test_nebular.py
@@ -1,4 +1,6 @@
 import numpy as np
+import jax
+import jax.numpy as jnp
 import numpyro.distributions as dist
 from numpyro.handlers import seed, substitute, trace
 from pathlib import Path
@@ -16,7 +18,7 @@ from jaxsedfit.config import (
     Observation,
     PhotometryData,
 )
-from jaxsedfit.model import _cigale_nebular_correction, grahsp_photometric_model
+from jaxsedfit.model import _cigale_nebular_correction, _trilinear_nebular_grid, grahsp_photometric_model
 from jaxsedfit.preload import _load_nebular_templates_jax, build_model_context
 
 
@@ -123,6 +125,35 @@ def test_nebular_template_loader_uses_v2025_1_grid():
     assert np.isclose(np.asarray(templates.ne_grid), 100.0).any()
     assert templates.line_lumin_per_photon.shape == (26, 31, 3, 129)
     assert templates.continuum_lumin_per_a_per_photon.shape == (26, 31, 3, 1600)
+
+
+def test_nebular_trilinear_interpolation_preserves_grid_points():
+    z_grid = jnp.asarray([0.004, 0.02, 0.05])
+    logu_grid = jnp.asarray([-3.0, -2.0, -1.0])
+    ne_grid = jnp.asarray([10.0, 100.0, 1000.0])
+    values = jnp.arange(3 * 3 * 3 * 2, dtype=jnp.float64).reshape(3, 3, 3, 2)
+
+    out = _trilinear_nebular_grid(values, z_grid, logu_grid, ne_grid, 0.02, -2.0, 100.0)
+
+    np.testing.assert_allclose(np.asarray(out), np.asarray(values[1, 1, 1]), rtol=0.0, atol=0.0)
+
+
+def test_nebular_trilinear_interpolation_has_parameter_gradients():
+    z_grid = jnp.asarray([0.004, 0.02, 0.05])
+    logu_grid = jnp.asarray([-3.0, -2.0, -1.0])
+    ne_grid = jnp.asarray([10.0, 100.0, 1000.0])
+    logz = jnp.log10(z_grid)[:, None, None]
+    logu = logu_grid[None, :, None]
+    logne = jnp.log10(ne_grid)[None, None, :]
+    values = logz + 2.0 * logu + 3.0 * logne
+
+    def interp_sum(zgas, nebular_logu, ne):
+        return jnp.sum(_trilinear_nebular_grid(values, z_grid, logu_grid, ne_grid, zgas, nebular_logu, ne))
+
+    grads = jax.grad(interp_sum, argnums=(0, 1, 2))(0.01, -2.5, 30.0)
+
+    assert all(np.isfinite(float(g)) for g in grads)
+    assert all(abs(float(g)) > 0.0 for g in grads)
 
 
 def test_host_basis_lyman_rates_are_finite(monkeypatch):


### PR DESCRIPTION
## Summary
- replace nearest-neighbor nebular template lookup with differentiable trilinear interpolation over log Z, log U, and log density
- apply the same interpolation to the fixed nebular line-profile preload cache
- add tests that grid-point values are preserved and off-grid nebular parameters have nonzero gradients

## Validation
- `conda run -n jaxcpu python -m pytest -q tests/test_nebular.py`