### PR TITLE
speed up jaxsedfit prediction and line projection

### DIFF
--- a/src/jaxsedfit/config.py
+++ b/src/jaxsedfit/config.py
@@ -33,7 +33,12 @@ class Observation:
 
 @dataclass
 class PhotometryData:
-    """Observed photometric measurements and associated metadata."""
+    """Observed photometric measurements and associated metadata.
+
+    ``photometry_method`` is provenance metadata only. Aperture/PSF corrections
+    are controlled by the explicit aperture/PSF fields and likelihood settings,
+    not by these labels.
+    """
     filter_names: Sequence[str]
     fluxes: Sequence[float]
     errors: Sequence[float]
@@ -55,6 +60,29 @@ class PhotometryData:
             raise ValueError("aperture_diameter_arcsec must match filter_names length.")
         if self.photometry_method is not None and len(self.photometry_method) != n:
             raise ValueError("photometry_method must match filter_names length.")
+        if self.photometry_method is not None:
+            allowed_methods = {
+                "aperture",
+                "auto",
+                "catalog",
+                "cmodel",
+                "fiber",
+                "model",
+                "petrosian",
+                "psf",
+                "unknown",
+            }
+            normalized_methods: list[str | None] = []
+            for method in self.photometry_method:
+                if method is None:
+                    normalized_methods.append(None)
+                    continue
+                normalized = str(method).strip().lower()
+                if normalized not in allowed_methods:
+                    allowed = ", ".join(sorted(allowed_methods))
+                    raise ValueError(f"Unknown photometry_method '{method}'. Allowed metadata labels: {allowed}.")
+                normalized_methods.append(normalized)
+            self.photometry_method = normalized_methods
 
 
 @dataclass
@@ -595,7 +623,12 @@ class AGNPriorConfig:
 
 @dataclass
 class NebularPriorConfig:
-    """Nebular-emission prior options."""
+    """Nebular-emission prior options.
+
+    ``f_dust`` controls the smooth fraction of non-escaping ionizing photons
+    absorbed by dust, so the physical dust fraction is
+    ``(1 - f_esc) * f_dust`` and always satisfies ``f_esc + f_dust_physical <= 1``.
+    """
     logU: Any | None = None
     zgas: Any | None = None
     ne: Any | None = None
@@ -613,7 +646,7 @@ class NebularPriorConfig:
                 "zgas": "nebular_zgas",
                 "ne": "nebular_ne",
                 "f_esc": "nebular_f_esc",
-                "f_dust": "nebular_f_dust",
+                "f_dust": "nebular_f_dust_fraction",
                 "lines_width": "nebular_lines_width",
                 "log_line_scale": "log_nebular_line_scale",
             },

--- a/src/jaxsedfit/core.py
+++ b/src/jaxsedfit/core.py
@@ -92,7 +92,9 @@ class JAXSEDFit:
 
     @predictive.setter
     def predictive(self, value: dict[str, Any] | None) -> None:
-        self._ensure_fit_state().predictive = value
+        state = self._ensure_fit_state()
+        state.predictive = value
+        state.predictive_cache = None if value is None else {"plot:all": value}
 
     @property
     def _plot_cache(self) -> dict[str, Any] | None:
@@ -159,6 +161,156 @@ class JAXSEDFit:
         """Return the bound NumPyro model used for posterior predictive products."""
         return grahsp_photometric_model(self.context, include_components=True)
 
+    @staticmethod
+    def _prediction_kind(kind: str) -> str:
+        """Normalize the prediction product set name."""
+        normalized = str(kind).lower()
+        aliases = {"full": "plot", "all": "plot", "sed": "plot", "photo": "photometry"}
+        normalized = aliases.get(normalized, normalized)
+        if normalized not in {"plot", "photometry"}:
+            raise ValueError("predict(kind=...) must be either 'plot' or 'photometry'.")
+        return normalized
+
+    @staticmethod
+    def _subset_prediction_samples(samples: Mapping[str, Any], max_draws: int | None) -> dict[str, Any]:
+        """Return posterior samples optionally limited along the leading draw axis."""
+        out: dict[str, Any] = {}
+        n = None if max_draws is None else max(int(max_draws), 1)
+        for key, value in samples.items():
+            arr = np.asarray(value)
+            out[key] = arr if n is None or arr.ndim == 0 else arr[:n]
+        return out
+
+    @staticmethod
+    def _median_prediction_samples(samples: Mapping[str, Any]) -> dict[str, Any]:
+        """Return one posterior draw built from per-site medians."""
+        return {key: np.expand_dims(np.asarray(value), axis=0) for key, value in median_mapping(samples).items()}
+
+    @staticmethod
+    def _predictive_return_sites(kind: str) -> list[str]:
+        """Return deterministic sites needed for a prediction product set."""
+        photometry_sites = [
+            "pred_fluxes",
+            "pred_spectrum_fluxes",
+            "spec_continuum_model_fluxes",
+            "spec_host_model_fluxes",
+            "spec_disk_model_fluxes",
+            "spec_torus_model_fluxes",
+            "spec_wave_obs",
+            "spec_spectrum_index",
+            "spectrum_scale_fit",
+            "log_spectrum_scale_fit",
+            "spectrum_host_capture_fraction",
+            "spectroscopy_loglike",
+            "spectroscopy_likelihood_weight",
+            "jqf_continuum_model",
+            "jqf_line_model",
+            "jqf_line_model_aperture",
+            "jqf_line_model_broad",
+            "jqf_line_model_narrow",
+            "jqf_line_model_narrow_aperture",
+            "jqf_line_amp_per_component",
+            "jqf_line_mu_per_component",
+            "jqf_line_sig_per_component",
+            "jqf_line_narrow_fwhm_kms",
+            "jqf_line_narrow_amp_scale",
+            "jqf_feii_model",
+            "jqf_balmer_model",
+            "jqf_total_model",
+            "rest_wave",
+            "obs_wave",
+            "redshift_fit",
+            "nebular_line_scale_fit",
+            "log_dust_luminosity_fit",
+            "dust_alpha_fit",
+            "nebular_logU_fit",
+            "nebular_zgas_fit",
+            "nebular_ne_fit",
+            "nebular_f_esc_fit",
+            "nebular_f_dust_fit",
+            "nebular_f_dust_fraction_fit",
+            "nebular_lines_width_fit",
+            "nebular_corr_fit",
+            "nebular_n_ly_young_fit",
+            "nebular_n_ly_old_fit",
+            "fracAGN_5100_fit",
+            "log_agn_bol_luminosity_fit",
+            "log_disk_luminosity_fit",
+            "agn_variability_nev",
+            "host_total_fluxes",
+            "host_capture_source_fluxes",
+            "agn_narrow_line_fluxes_total",
+            "captured_agn_narrow_line_fluxes",
+            "extended_capture_source_fluxes",
+            "captured_extended_source_fluxes",
+            "host_capture_fraction_fluxes",
+            "log_host_capture_scale_arcsec_fit",
+            "host_capture_slope_fit",
+            "transmitted_fraction_fluxes",
+            "absolute_flux_scale_logprior",
+        ]
+        if kind == "photometry":
+            return photometry_sites
+        return photometry_sites + [
+            "agn_fluxes",
+            "host_fluxes",
+            "dust_fluxes",
+            "nebular_fluxes",
+            "nebular_lines_fluxes",
+            "nebular_continuum_fluxes",
+            "disk_fluxes",
+            "torus_fluxes",
+            "feii_fluxes",
+            "line_fluxes",
+            "line_bl_fluxes",
+            "line_nl_fluxes",
+            "line_liner_fluxes",
+            "balmer_fluxes",
+            "host_age_weights",
+            "host_lgmet_weights",
+            "host_ssp_weights",
+            "gal_sfr_table",
+            "gal_smh_table",
+            "total_rest_sed",
+            "agn_rest_sed",
+            "host_rest_sed",
+            "host_total_rest_sed",
+            "host_absorbed_rest_sed",
+            "dust_rest_sed",
+            "nebular_rest_sed",
+            "nebular_lines_rest_sed",
+            "nebular_continuum_rest_sed",
+            "nebular_absorption_rest_sed",
+            "disk_rest_sed",
+            "torus_rest_sed",
+            "feii_rest_sed",
+            "line_rest_sed",
+            "line_bl_rest_sed",
+            "line_nl_rest_sed",
+            "line_liner_rest_sed",
+            "balmer_rest_sed",
+            "total_obs_sed",
+            "total_local_lines_obs_wave",
+            "total_local_lines_obs_sed",
+            "agn_obs_sed",
+            "host_obs_sed",
+            "host_total_obs_sed",
+            "dust_obs_sed",
+            "nebular_obs_sed",
+            "nebular_lines_obs_sed",
+            "nebular_lines_local_obs_wave",
+            "nebular_lines_local_obs_sed",
+            "nebular_continuum_obs_sed",
+            "disk_obs_sed",
+            "torus_obs_sed",
+            "feii_obs_sed",
+            "line_obs_sed",
+            "line_bl_obs_sed",
+            "line_nl_obs_sed",
+            "line_liner_obs_sed",
+            "balmer_obs_sed",
+        ]
+
     def _make_result(
         self,
         *,
@@ -198,133 +350,40 @@ class JAXSEDFit:
             _state=state,
         )
 
-    def _compute_predictive(self, *, _state: _FitState | None = None) -> dict[str, Any]:
+    def _compute_predictive(
+        self,
+        *,
+        _state: _FitState | None = None,
+        kind: str = "plot",
+        max_draws: int | None = None,
+        posterior_samples: Mapping[str, Any] | None = None,
+        cache: bool = True,
+    ) -> dict[str, Any]:
         """Generate and cache predictive outputs from posterior samples."""
         state = self._ensure_fit_state() if _state is None else _state
-        if state.samples is None:
+        kind = self._prediction_kind(kind)
+        samples = state.samples if posterior_samples is None else posterior_samples
+        if samples is None:
             raise RuntimeError("No fitted posterior available. Run fit_map(), fit_nuts(), or fit_ns() first.")
+        cache_key = f"{kind}:{'all' if max_draws is None else int(max_draws)}"
+        if cache and posterior_samples is None and state.predictive_cache is not None and cache_key in state.predictive_cache:
+            return dict(state.predictive_cache[cache_key])
+        include_components = kind == "plot"
+        draw_samples = self._subset_prediction_samples(samples, max_draws)
         rng_key = jax.random.PRNGKey(self.config.inference.seed + 17)
         pred = Predictive(
-            self._predictive_model,
-            posterior_samples=state.samples,
-            return_sites=[
-                "pred_fluxes",
-                "pred_spectrum_fluxes",
-                "spec_continuum_model_fluxes",
-                "spec_host_model_fluxes",
-                "spec_disk_model_fluxes",
-                "spec_torus_model_fluxes",
-                "spec_wave_obs",
-                "spec_spectrum_index",
-                "spectrum_scale_fit",
-                "log_spectrum_scale_fit",
-                "spectrum_host_capture_fraction",
-                "spectroscopy_loglike",
-                "jqf_continuum_model",
-                "jqf_line_model",
-                "jqf_line_model_aperture",
-                "jqf_line_model_broad",
-                "jqf_line_model_narrow",
-                "jqf_line_model_narrow_aperture",
-                "jqf_line_amp_per_component",
-                "jqf_line_mu_per_component",
-                "jqf_line_sig_per_component",
-                "jqf_line_narrow_fwhm_kms",
-                "jqf_line_narrow_amp_scale",
-                "jqf_feii_model",
-                "jqf_balmer_model",
-                "jqf_total_model",
-                "agn_fluxes",
-                "host_fluxes",
-                "dust_fluxes",
-                "nebular_fluxes",
-                "nebular_lines_fluxes",
-                "nebular_continuum_fluxes",
-                "disk_fluxes",
-                "torus_fluxes",
-                "feii_fluxes",
-                "line_fluxes",
-                "line_bl_fluxes",
-                "line_nl_fluxes",
-                "line_liner_fluxes",
-                "balmer_fluxes",
-                "host_age_weights",
-                "host_lgmet_weights",
-                "host_ssp_weights",
-                "gal_sfr_table",
-                "gal_smh_table",
-                "rest_wave",
-                "obs_wave",
-                "redshift_fit",
-                "nebular_line_scale_fit",
-                "total_rest_sed",
-                "agn_rest_sed",
-                "host_rest_sed",
-                "host_total_rest_sed",
-                "host_absorbed_rest_sed",
-                "dust_rest_sed",
-                "nebular_rest_sed",
-                "nebular_lines_rest_sed",
-                "nebular_continuum_rest_sed",
-                "nebular_absorption_rest_sed",
-                "disk_rest_sed",
-                "torus_rest_sed",
-                "feii_rest_sed",
-                "line_rest_sed",
-                "line_bl_rest_sed",
-                "line_nl_rest_sed",
-                "line_liner_rest_sed",
-                "balmer_rest_sed",
-                "total_obs_sed",
-                "total_local_lines_obs_wave",
-                "total_local_lines_obs_sed",
-                "agn_obs_sed",
-                "host_obs_sed",
-                "host_total_obs_sed",
-                "dust_obs_sed",
-                "nebular_obs_sed",
-                "nebular_lines_obs_sed",
-                "nebular_lines_local_obs_wave",
-                "nebular_lines_local_obs_sed",
-                "nebular_continuum_obs_sed",
-                "disk_obs_sed",
-                "torus_obs_sed",
-                "feii_obs_sed",
-                "line_obs_sed",
-                "line_bl_obs_sed",
-                "line_nl_obs_sed",
-                "line_liner_obs_sed",
-                "balmer_obs_sed",
-                "log_dust_luminosity_fit",
-                "dust_alpha_fit",
-                "nebular_logU_fit",
-                "nebular_zgas_fit",
-                "nebular_ne_fit",
-                "nebular_f_esc_fit",
-                "nebular_f_dust_fit",
-                "nebular_lines_width_fit",
-                "nebular_corr_fit",
-                "nebular_n_ly_young_fit",
-                "nebular_n_ly_old_fit",
-                "fracAGN_5100_fit",
-                "log_agn_bol_luminosity_fit",
-                "log_disk_luminosity_fit",
-                "agn_variability_nev",
-                "host_total_fluxes",
-                "host_capture_source_fluxes",
-                "agn_narrow_line_fluxes_total",
-                "captured_agn_narrow_line_fluxes",
-                "extended_capture_source_fluxes",
-                "captured_extended_source_fluxes",
-                "host_capture_fraction_fluxes",
-                "log_host_capture_scale_arcsec_fit",
-                "host_capture_slope_fit",
-                "transmitted_fraction_fluxes",
-                "absolute_flux_scale_logprior",
-            ],
+            lambda: grahsp_photometric_model(self.context, include_components=include_components),
+            posterior_samples=draw_samples,
+            return_sites=self._predictive_return_sites(kind),
         )(rng_key)
-        state.predictive = {k: np.asarray(v) for k, v in pred.items()}
-        return state.predictive
+        predictive = {k: np.asarray(v) for k, v in pred.items()}
+        if cache and posterior_samples is None:
+            if state.predictive_cache is None:
+                state.predictive_cache = {}
+            state.predictive_cache[cache_key] = predictive
+            if kind == "plot" and max_draws is None:
+                state.predictive = predictive
+        return predictive
 
     def fit(
         self,
@@ -663,14 +722,45 @@ class JAXSEDFit:
         self.predictive = None
         return self._make_result(method="ns")
 
-    def predict(self, posterior: str = "latest", *, _state: _FitState | None = None) -> dict[str, Any]:
-        """Return cached predictive outputs or generate them on demand."""
+    def predict(
+        self,
+        posterior: str = "latest",
+        *,
+        kind: str = "plot",
+        max_draws: int | None = None,
+        _state: _FitState | None = None,
+    ) -> dict[str, Any]:
+        """Return cached predictive outputs or generate them on demand.
+
+        ``kind="photometry"`` returns lightweight photometry/spectrum products.
+        ``kind="plot"`` returns the full component SED products used by plotting.
+        """
         state = self._ensure_fit_state() if _state is None else _state
-        if state.predictive is None:
-            if state is self._ensure_fit_state():
-                return self._compute_predictive()
-            return self._compute_predictive(_state=state)
-        return state.predictive
+        kind = self._prediction_kind(kind)
+        if kind == "plot" and max_draws is None and state.predictive is not None:
+            return dict(state.predictive)
+        if kind == "plot" and max_draws is None and state is self._ensure_fit_state():
+            return self._compute_predictive()
+        return self._compute_predictive(_state=state, kind=kind, max_draws=max_draws)
+
+    def predict_median(
+        self,
+        posterior: str = "latest",
+        *,
+        kind: str = "plot",
+        _state: _FitState | None = None,
+    ) -> dict[str, Any]:
+        """Evaluate predictive products once at the posterior median parameters."""
+        state = self._ensure_fit_state() if _state is None else _state
+        if state.samples is None:
+            raise RuntimeError("No fitted posterior available. Run fit_map(), fit_nuts(), or fit_ns() first.")
+        median_samples = self._median_prediction_samples(state.samples)
+        return self._compute_predictive(
+            _state=state,
+            kind=kind,
+            posterior_samples=median_samples,
+            cache=False,
+        )
 
     def recovered_log_stellar_mass(self, *, _state: _FitState | None = None) -> float:
         """Return the median recovered stellar mass from the fitted posterior."""

--- a/src/jaxsedfit/model.py
+++ b/src/jaxsedfit/model.py
@@ -826,6 +826,15 @@ def _project_fixed_cached_local_line_filters(context: ModelContext, line_lumin, 
     return jnp.sum(projection_weight * line_flux_density[None, :, :], axis=(1, 2))
 
 
+def _project_fixed_cached_local_nebular_line_filters(context: ModelContext, line_lumin, width_kms, ebv_total):
+    """Project local nebular lines with fixed-z cached filter overlap terms."""
+    cache = context.fixed_local_nebular_line_projection_cache_jax
+    profile_norm, attenuation_curve, projection_weight = _interp_fixed_local_line_terms(width_kms, cache)
+    attenuation_factor = 10 ** (jnp.asarray(ebv_total, dtype=jnp.float64) * attenuation_curve / -2.5)
+    line_flux_density = jnp.asarray(line_lumin, dtype=jnp.float64)[:, None] * profile_norm * attenuation_factor
+    return jnp.sum(projection_weight * line_flux_density[None, :, :], axis=(1, 2))
+
+
 def _interp_rest_sed(target_wave, source_wave, source_sed):
     """Interpolate one rest-frame SED onto a new wavelength grid."""
     return jnp.interp(target_wave, source_wave, source_sed, left=0.0, right=0.0)
@@ -1131,8 +1140,17 @@ def _build_nebular_components(context: ModelContext, host_state: dict[str, Any],
     zgas = jnp.where(default_zgas is None and "nebular_zgas" not in prior_config, zgas_default, jnp.clip(zgas, 1.0e-6, 1.0))
     ne = jnp.clip(_sample_optional_normal(prior_config, "nebular_ne", float(cfg.ne), 100.0), 1.0e-6, 1.0e8)
     f_esc = _sample_optional_truncnorm(prior_config, "nebular_f_esc", float(cfg.f_esc), 0.1, 0.0, 1.0)
-    f_dust_raw = _sample_optional_truncnorm(prior_config, "nebular_f_dust", float(cfg.f_dust), 0.1, 0.0, 1.0)
-    f_dust = jnp.minimum(f_dust_raw, jnp.maximum(1.0 - f_esc, 0.0))
+    default_remaining = max(1.0 - float(cfg.f_esc), 1.0e-12)
+    default_f_dust_fraction = float(np.clip(float(cfg.f_dust) / default_remaining, 0.0, 1.0))
+    f_dust_fraction = _sample_optional_truncnorm(
+        prior_config,
+        "nebular_f_dust_fraction",
+        default_f_dust_fraction,
+        0.1,
+        0.0,
+        1.0,
+    )
+    f_dust = jnp.maximum(1.0 - f_esc, 0.0) * f_dust_fraction
     lines_width = jnp.clip(_sample_optional_normal(prior_config, "nebular_lines_width", float(cfg.lines_width), 100.0), 0.0, 1.0e5)
     if "log_nebular_line_scale" in prior_config:
         line_scale = _sample_log_positive_from_distribution(
@@ -1215,6 +1233,7 @@ def _build_nebular_components(context: ModelContext, host_state: dict[str, Any],
         "ne": ne,
         "f_esc": f_esc,
         "f_dust": f_dust,
+        "f_dust_fraction": f_dust_fraction,
         "lines_width": lines_width,
         "line_scale": line_scale,
         "corr": corr,
@@ -2035,14 +2054,15 @@ def evaluate_photometric_state(
         gal_att_rest + agn_attenuated_rest,
         host_with_nebular_rest + agn_attenuated_input_rest,
     )
-    fast_projection_enabled = _can_use_fixed_filter_projection(context, cfg) and not include_components
+    fast_projection_enabled = _can_use_fixed_filter_projection(context, cfg)
     redshift_projection_enabled = (
         _can_use_redshift_filter_projection(context, cfg)
         and not include_components
         and not spectroscopy_enabled
     )
+    needs_obs_sed = bool(include_components or spectroscopy_enabled)
     if fast_projection_enabled:
-        total_obs = _redshift_to_obs(rest_wave, total_rest * igm, obs_wave, redshift, luminosity_distance_m) if spectroscopy_enabled else jnp.zeros_like(obs_wave)
+        total_obs = _redshift_to_obs(rest_wave, total_rest * igm, obs_wave, redshift, luminosity_distance_m) if needs_obs_sed else jnp.zeros_like(obs_wave)
         pred_fluxes_raw = _project_rest_luminosity_filters(context, total_rest)
     elif redshift_projection_enabled:
         total_obs = jnp.zeros_like(obs_wave)
@@ -2127,16 +2147,24 @@ def evaluate_photometric_state(
         and bool(cfg.likelihood.use_local_line_photometry)
     )
     if correct_nebular_line_photometry:
-        local_nebular_line_fluxes = _project_local_nebular_line_filters(
-            context,
-            context.nebular_templates_jax.line_wave_a,
-            nebular["line_lumin"],
-            nebular["lines_width"],
-            ebv_gal,
-            redshift,
-            luminosity_distance_m,
-            igm,
-        )
+        if context.fixed_local_nebular_line_projection_cache_jax is not None and not cfg.observation.fits_redshift:
+            local_nebular_line_fluxes = _project_fixed_cached_local_nebular_line_filters(
+                context,
+                nebular["line_lumin"],
+                nebular["lines_width"],
+                ebv_gal,
+            )
+        else:
+            local_nebular_line_fluxes = _project_local_nebular_line_filters(
+                context,
+                context.nebular_templates_jax.line_wave_a,
+                nebular["line_lumin"],
+                nebular["lines_width"],
+                ebv_gal,
+                redshift,
+                luminosity_distance_m,
+                igm,
+            )
         if fast_projection_enabled:
             coarse_nebular_line_fluxes = _project_rest_luminosity_filters(context, nebular_lines_att_rest)
         elif redshift_projection_enabled:
@@ -2527,23 +2555,39 @@ def evaluate_photometric_state(
         line_liner_obs = _redshift_to_obs(rest_wave, line_liner_att_rest * igm, obs_wave, redshift, luminosity_distance_m)
         balmer_obs = _redshift_to_obs(rest_wave, balmer_att_rest * igm, obs_wave, redshift, luminosity_distance_m)
         transmitted_fraction_obs = _redshift_scalar_to_obs(rest_wave, transmitted_fraction, obs_wave, redshift)
-        agn_fluxes = _project_filters(agn_obs, context.packed_filters_jax)
-        dust_fluxes = _project_filters(dust_obs, context.packed_filters_jax)
-        nebular_fluxes = _project_filters(nebular_obs, context.packed_filters_jax)
-        nebular_lines_fluxes = _project_filters(nebular_lines_obs, context.packed_filters_jax)
-        nebular_continuum_fluxes = _project_filters(nebular_continuum_obs, context.packed_filters_jax)
+        if fast_projection_enabled:
+            agn_fluxes = _project_rest_luminosity_filters(context, agn_rest)
+            dust_fluxes = _project_rest_luminosity_filters(context, dust_rest)
+            nebular_fluxes = _project_rest_luminosity_filters(context, nebular_att_rest)
+            nebular_lines_fluxes = _project_rest_luminosity_filters(context, nebular_lines_att_rest)
+            nebular_continuum_fluxes = _project_rest_luminosity_filters(context, nebular_continuum_att_rest)
+            disk_fluxes = _project_rest_luminosity_filters(context, disk_att_rest)
+            torus_fluxes = _project_rest_luminosity_filters(context, torus_att_rest)
+            feii_fluxes = _project_rest_luminosity_filters(context, feii_att_rest)
+            line_fluxes = _project_rest_luminosity_filters(context, line_att_rest)
+            line_bl_fluxes = _project_rest_luminosity_filters(context, line_bl_att_rest)
+            line_nl_fluxes = _project_rest_luminosity_filters(context, line_nl_att_rest)
+            line_liner_fluxes = _project_rest_luminosity_filters(context, line_liner_att_rest)
+            balmer_fluxes = _project_rest_luminosity_filters(context, balmer_att_rest)
+            trans_fluxes = _project_rest_scalar_filters(context, transmitted_fraction)
+        else:
+            agn_fluxes = _project_filters(agn_obs, context.packed_filters_jax)
+            dust_fluxes = _project_filters(dust_obs, context.packed_filters_jax)
+            nebular_fluxes = _project_filters(nebular_obs, context.packed_filters_jax)
+            nebular_lines_fluxes = _project_filters(nebular_lines_obs, context.packed_filters_jax)
+            nebular_continuum_fluxes = _project_filters(nebular_continuum_obs, context.packed_filters_jax)
+            disk_fluxes = _project_filters(disk_obs, context.packed_filters_jax)
+            torus_fluxes = _project_filters(torus_obs, context.packed_filters_jax)
+            feii_fluxes = _project_filters(feii_obs, context.packed_filters_jax)
+            line_fluxes = _project_filters(line_obs, context.packed_filters_jax)
+            line_bl_fluxes = _project_filters(line_bl_obs, context.packed_filters_jax)
+            line_nl_fluxes = _project_filters(line_nl_obs, context.packed_filters_jax)
+            line_liner_fluxes = _project_filters(line_liner_obs, context.packed_filters_jax)
+            balmer_fluxes = _project_filters(balmer_obs, context.packed_filters_jax)
+            trans_fluxes = _project_filters(transmitted_fraction_obs, context.packed_filters_jax)
         if correct_nebular_line_photometry:
             nebular_lines_fluxes = local_nebular_line_fluxes
             nebular_fluxes = nebular_continuum_fluxes + local_nebular_line_fluxes
-        disk_fluxes = _project_filters(disk_obs, context.packed_filters_jax)
-        torus_fluxes = _project_filters(torus_obs, context.packed_filters_jax)
-        feii_fluxes = _project_filters(feii_obs, context.packed_filters_jax)
-        line_fluxes = _project_filters(line_obs, context.packed_filters_jax)
-        line_bl_fluxes = _project_filters(line_bl_obs, context.packed_filters_jax)
-        line_nl_fluxes = _project_filters(line_nl_obs, context.packed_filters_jax)
-        line_liner_fluxes = _project_filters(line_liner_obs, context.packed_filters_jax)
-        balmer_fluxes = _project_filters(balmer_obs, context.packed_filters_jax)
-        trans_fluxes = _project_filters(transmitted_fraction_obs, context.packed_filters_jax)
         if correct_agn_line_photometry:
             agn_fluxes = agn_fluxes - coarse_agn_line_fluxes + local_agn_line_fluxes
             line_bl_fluxes = local_broad_line_fluxes
@@ -2661,6 +2705,7 @@ def evaluate_photometric_state(
     numpyro.deterministic("nebular_ne_fit", nebular["ne"])
     numpyro.deterministic("nebular_f_esc_fit", nebular["f_esc"])
     numpyro.deterministic("nebular_f_dust_fit", nebular["f_dust"])
+    numpyro.deterministic("nebular_f_dust_fraction_fit", nebular.get("f_dust_fraction", nebular["f_dust"]))
     numpyro.deterministic("nebular_lines_width_fit", nebular["lines_width"])
     numpyro.deterministic("nebular_line_scale_fit", nebular["line_scale"])
     numpyro.deterministic("nebular_corr_fit", nebular["corr"])

--- a/src/jaxsedfit/preload.py
+++ b/src/jaxsedfit/preload.py
@@ -143,6 +143,15 @@ class FixedLocalLineProjectionCacheJax:
 
 
 @dataclass
+class FixedLocalNebularLineProjectionCacheJax:
+    """Fixed-z local nebular line projection terms tabulated over line width."""
+    log_width_grid: jnp.ndarray
+    profile_norm: jnp.ndarray
+    attenuation_curve: jnp.ndarray
+    projection_weight: jnp.ndarray
+
+
+@dataclass
 class SSPData:
     """Raw DSPS SSP grids cached for repeated host-model construction."""
     ssp_lgmet: np.ndarray
@@ -244,6 +253,7 @@ class ModelContext:
     fixed_filter_projection_jax: jnp.ndarray | None
     fixed_scalar_filter_projection_jax: jnp.ndarray | None
     fixed_local_line_projection_cache_jax: FixedLocalLineProjectionCacheJax | None
+    fixed_local_nebular_line_projection_cache_jax: FixedLocalNebularLineProjectionCacheJax | None
     redshift_projection_cache_jax: RedshiftProjectionCacheJax | None
     fluxes: np.ndarray
     errors: np.ndarray
@@ -275,6 +285,7 @@ _NEBULAR_REST_TEMPLATE_CACHE: dict[tuple[Any, ...], tuple[np.ndarray | None, np.
 _FIXED_NEBULAR_LINE_PROFILE_CACHE: dict[tuple[Any, ...], np.ndarray] = {}
 _REDSHIFT_PROJECTION_CACHE: dict[tuple[Any, ...], tuple[np.ndarray, np.ndarray, np.ndarray]] = {}
 _FIXED_LOCAL_LINE_PROJECTION_CACHE: dict[tuple[Any, ...], tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]] = {}
+_FIXED_LOCAL_NEBULAR_LINE_PROJECTION_CACHE: dict[tuple[Any, ...], tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]] = {}
 
 
 def _package_resource_path(relpath: str) -> Path:
@@ -1319,6 +1330,89 @@ def _build_fixed_local_line_projection_cache_jax(
     )
 
 
+def _build_fixed_local_nebular_line_projection_cache_jax(
+    cfg: FitConfig,
+    nebular_templates: NebularTemplatesJax,
+    filters: Sequence[LoadedFilter],
+    redshift: float,
+    luminosity_distance_m: float,
+    fixed_igm: np.ndarray,
+) -> FixedLocalNebularLineProjectionCacheJax | None:
+    """Precompute fixed-z local nebular line filter projection terms over width."""
+    if not (
+        cfg.likelihood.use_local_line_photometry
+        and cfg.likelihood.use_fixed_local_line_cache
+        and cfg.galaxy.fit_host
+        and cfg.nebular.enabled
+        and cfg.nebular.emission
+        and nebular_templates.line_wave_a.size > 0
+    ):
+        return None
+    n_width = max(int(cfg.likelihood.fixed_local_line_cache_n_width), 2)
+    width_min = max(float(cfg.likelihood.fixed_local_line_cache_min_width_kms), 1.0e-6)
+    width_max = max(float(cfg.likelihood.fixed_local_line_cache_max_width_kms), width_min * (1.0 + 1.0e-6))
+    width_grid = np.geomspace(width_min, width_max, n_width).astype(float)
+    log_width_grid = np.log(width_grid)
+    line_wave = np.asarray(nebular_templates.line_wave_a, dtype=float)
+    offsets = np.linspace(-3.0, 3.0, 9, dtype=float)
+    cache_key = (
+        tuple(np.round(line_wave, 8).tolist()),
+        tuple(np.round(width_grid, 8).tolist()),
+        float(redshift),
+        float(luminosity_distance_m),
+        tuple(float(f.effective_wavelength) for f in filters),
+        tuple(tuple(np.round(np.asarray(f.wave, dtype=float), 8).tolist()) for f in filters),
+        tuple(tuple(np.round(np.asarray(f.native_transmission, dtype=float), 12).tolist()) for f in filters),
+        tuple(np.round(np.asarray(fixed_igm, dtype=float), 12).tolist()),
+    )
+    cached = _FIXED_LOCAL_NEBULAR_LINE_PROJECTION_CACHE.get(cache_key)
+    if cached is not None:
+        cached_log_width, profile_norm, attenuation_curve, projection_weight = cached
+        return FixedLocalNebularLineProjectionCacheJax(
+            log_width_grid=jnp.asarray(cached_log_width, dtype=jnp.float64),
+            profile_norm=jnp.asarray(profile_norm, dtype=jnp.float64),
+            attenuation_curve=jnp.asarray(attenuation_curve, dtype=jnp.float64),
+            projection_weight=jnp.asarray(projection_weight, dtype=jnp.float64),
+        )
+
+    n_lines = line_wave.size
+    n_local = offsets.size
+    n_filters = len(filters)
+    profile_norm = np.empty((n_width, n_lines, n_local), dtype=float)
+    attenuation_curve = np.empty_like(profile_norm)
+    projection_weight = np.empty((n_width, n_filters, n_lines, n_local), dtype=float)
+    distance_scale = 4.0 * np.pi * max(float(luminosity_distance_m), 1.0e-12) ** 2 * max(1.0 + float(redshift), 1.0e-8)
+    fixed_igm = np.asarray(fixed_igm, dtype=float)
+    rest_wave = np.geomspace(cfg.galaxy.rest_wave_min, cfg.galaxy.rest_wave_max, cfg.galaxy.n_wave).astype(float)
+
+    for iw, width in enumerate(width_grid):
+        fwhm_wave = np.maximum(line_wave * float(width) / 299792.458, 1.0e-8)
+        sigma = fwhm_wave / (2.0 * np.sqrt(2.0 * np.log(2.0)))
+        rest_line_wave = np.maximum(line_wave[:, None] + offsets[None, :] * fwhm_wave[:, None], 1.0e-6)
+        z = (rest_line_wave - line_wave[:, None]) / np.maximum(sigma[:, None], 1.0e-12)
+        norm = 1.0 / np.maximum(sigma * np.sqrt(2.0 * np.pi), 1.0e-30)
+        profile_norm[iw] = np.exp(-0.5 * z * z) * norm[:, None]
+        attenuation_curve[iw] = _attenuation_curve_np(rest_line_wave, -1.2, -3.0, 1.2, 11000.0)
+        igm_local = np.interp(rest_line_wave, rest_wave, fixed_igm, left=0.0, right=0.0)
+        obs_line_wave = rest_line_wave * (1.0 + float(redshift))
+        trap_weights = _trapezoid_weights_axis1(obs_line_wave)
+        for ifilt, filt in enumerate(filters):
+            filt_wave = np.asarray(filt.wave, dtype=float)
+            filt_trans = np.clip(np.asarray(filt.native_transmission, dtype=float), 0.0, None)
+            denom = max(float(np.trapezoid(filt_trans, filt_wave)), 1.0e-30)
+            trans = np.interp(obs_line_wave, filt_wave, filt_trans, left=0.0, right=0.0)
+            conv = 1.0e-10 / 299792458.0 * 1.0e29 * float(filt.effective_wavelength) ** 2
+            projection_weight[iw, ifilt] = conv * trap_weights * trans * igm_local / denom / distance_scale
+
+    _FIXED_LOCAL_NEBULAR_LINE_PROJECTION_CACHE[cache_key] = (log_width_grid, profile_norm, attenuation_curve, projection_weight)
+    return FixedLocalNebularLineProjectionCacheJax(
+        log_width_grid=jnp.asarray(log_width_grid, dtype=jnp.float64),
+        profile_norm=jnp.asarray(profile_norm, dtype=jnp.float64),
+        attenuation_curve=jnp.asarray(attenuation_curve, dtype=jnp.float64),
+        projection_weight=jnp.asarray(projection_weight, dtype=jnp.float64),
+    )
+
+
 def build_model_context(cfg: FitConfig) -> ModelContext:
     """Construct the static context consumed by the jaxsedfit NumPyro model."""
     cfg.validate()
@@ -1441,7 +1535,14 @@ def build_model_context(cfg: FitConfig) -> ModelContext:
 
     spec_rest_wave = np.array([], dtype=float)
     spec_host_basis_jax = None
-    if cfg.galaxy.fit_host and spec_wave_obs.size > 0 and not cfg.observation.fits_redshift:
+    needs_spec_host_basis = bool(
+        cfg.galaxy.fit_host
+        and cfg.spectroscopy_config.enabled
+        and str(cfg.spectroscopy_config.backend).lower() == "jaxqsofit"
+        and spec_wave_obs.size > 0
+        and not cfg.observation.fits_redshift
+    )
+    if needs_spec_host_basis:
         spec_rest_wave = (spec_wave_obs / (1.0 + max(cfg.observation.redshift, 0.0))).astype(float)
         spec_host_basis = _build_host_basis(spec_rest_wave, ssp_data)
         spec_host_basis_jax = _build_host_basis_jax(ssp_data, spec_host_basis, gal_t_table)
@@ -1475,6 +1576,7 @@ def build_model_context(cfg: FitConfig) -> ModelContext:
         fixed_filter_projection_jax = None
         fixed_scalar_filter_projection_jax = None
         fixed_local_line_projection_cache_jax = None
+        fixed_local_nebular_line_projection_cache_jax = None
         redshift_projection_cache_jax = _build_redshift_projection_cache_jax(
             rest_wave,
             packed_filters,
@@ -1498,6 +1600,14 @@ def build_model_context(cfg: FitConfig) -> ModelContext:
         fixed_local_line_projection_cache_jax = _build_fixed_local_line_projection_cache_jax(
             cfg,
             templates,
+            loaded_filters,
+            float(cfg.observation.redshift),
+            luminosity_distance_m,
+            np.asarray(fixed_igm_jax, dtype=float),
+        )
+        fixed_local_nebular_line_projection_cache_jax = _build_fixed_local_nebular_line_projection_cache_jax(
+            cfg,
+            nebular_templates_jax,
             loaded_filters,
             float(cfg.observation.redshift),
             luminosity_distance_m,
@@ -1555,6 +1665,7 @@ def build_model_context(cfg: FitConfig) -> ModelContext:
         fixed_filter_projection_jax=fixed_filter_projection_jax,
         fixed_scalar_filter_projection_jax=fixed_scalar_filter_projection_jax,
         fixed_local_line_projection_cache_jax=fixed_local_line_projection_cache_jax,
+        fixed_local_nebular_line_projection_cache_jax=fixed_local_nebular_line_projection_cache_jax,
         redshift_projection_cache_jax=redshift_projection_cache_jax,
         fluxes=fluxes,
         errors=errors,

--- a/src/jaxsedfit/results.py
+++ b/src/jaxsedfit/results.py
@@ -31,6 +31,7 @@ class _FitState:
     ns_result: dict[str, Any] | None = None
     samples: Mapping[str, Any] | None = None
     predictive: Mapping[str, Any] | None = None
+    predictive_cache: dict[str, Mapping[str, Any]] | None = None
     summary: Mapping[str, Any] | None = None
     path: Path | None = None
     figure: Any = None

--- a/tests/test_model_assembly.py
+++ b/tests/test_model_assembly.py
@@ -20,6 +20,7 @@ from jaxsedfit.config import (
     SpectroscopyConfig,
     SpectroscopyData,
 )
+from jaxsedfit.core import JAXSEDFit
 from jaxsedfit.model import GRAHSP_PL_BEND_LOC_A, GRAHSP_PL_BEND_WIDTH, GRAHSP_PL_CUTOFF_A, _project_filters, _redshift_to_obs, evaluate_photometric_state, grahsp_photometric_model
 from jaxsedfit.preload import build_model_context
 
@@ -728,6 +729,84 @@ def test_fast_fixed_filter_projection_matches_legacy_photometry(monkeypatch):
     slow_tr = _deterministic_likelihood_trace(slow_context, _fixed_component_data())
 
     np.testing.assert_allclose(_site(fast_tr, "pred_fluxes"), _site(slow_tr, "pred_fluxes"), rtol=2.0e-12, atol=1.0e-30)
+
+
+def test_component_prediction_uses_fast_fixed_filter_projection(monkeypatch):
+    _patch_ssp(monkeypatch)
+    cfg = _cfg(n_wave=256)
+    cfg.likelihood.use_fast_photometry_projection = True
+    cfg.likelihood.use_local_line_photometry = False
+    context = build_model_context(cfg)
+    data = _fixed_component_data()
+
+    def _raise_project_filters(*args, **kwargs):
+        raise AssertionError("Component photometry should use fixed projection matrices.")
+
+    monkeypatch.setattr("jaxsedfit.model._project_filters", _raise_project_filters)
+    tr = _deterministic_trace(context, data)
+
+    assert np.all(np.isfinite(_site(tr, "pred_fluxes")))
+    assert np.all(np.isfinite(_site(tr, "agn_fluxes")))
+    assert np.all(np.isfinite(_site(tr, "host_fluxes")))
+
+
+def test_fixed_local_nebular_line_cache_matches_exact_projection(monkeypatch):
+    _patch_ssp(monkeypatch)
+
+    def _nebular_cfg(*, use_cache):
+        cfg = _cfg(fit_agn=False, n_wave=128, rest_wave_max=10000.0)
+        cfg.photometry = PhotometryData(filter_names=["ha"], fluxes=[1.0], errors=[0.1])
+        cfg.filters = FilterSet(
+            curves=[
+                FilterCurve(
+                    name="ha",
+                    wave=[620.0, 690.0, 760.0],
+                    transmission=[0.0, 1.0, 0.0],
+                )
+            ],
+        )
+        cfg.likelihood.use_fast_photometry_projection = True
+        cfg.likelihood.use_local_line_photometry = True
+        cfg.likelihood.use_fixed_local_line_cache = use_cache
+        cfg.likelihood.variability_uncertainty = False
+        cfg.nebular = NebularConfig(enabled=True, f_esc=0.0, f_dust=0.0, zgas=0.02, logU=-2.0, ne=100.0, lines_width=300.0)
+        return cfg
+
+    data = _fixed_component_data()
+    cached_context = build_model_context(_nebular_cfg(use_cache=True))
+    exact_context = build_model_context(_nebular_cfg(use_cache=False))
+    assert cached_context.fixed_local_nebular_line_projection_cache_jax is not None
+    assert exact_context.fixed_local_nebular_line_projection_cache_jax is None
+
+    cached = _site(_deterministic_likelihood_trace(cached_context, data), "pred_fluxes")
+    exact = _site(_deterministic_likelihood_trace(exact_context, data), "pred_fluxes")
+
+    np.testing.assert_allclose(cached, exact, rtol=5.0e-4, atol=1.0e-30)
+
+
+def test_predict_supports_lightweight_and_median_modes(monkeypatch):
+    _patch_ssp(monkeypatch)
+    cfg = _cfg(n_wave=64)
+    cfg.likelihood.use_fast_photometry_projection = True
+    cfg.likelihood.use_local_line_photometry = False
+    fitter = JAXSEDFit(cfg)
+    init_trace = trace(seed(lambda: grahsp_photometric_model(fitter.context, include_components=False), 0)).get_trace()
+    fitter.samples = {
+        name: np.repeat(np.asarray(site["value"])[None, ...], 3, axis=0)
+        for name, site in init_trace.items()
+        if site.get("type") == "sample" and not site.get("is_observed", False)
+    }
+
+    phot = fitter.predict(kind="photometry", max_draws=2)
+    full = fitter.predict(kind="plot", max_draws=1)
+    median = fitter.predict_median(kind="photometry")
+
+    assert "pred_fluxes" in phot
+    assert "total_obs_sed" not in phot
+    assert phot["pred_fluxes"].shape[0] == 2
+    assert "total_obs_sed" in full
+    assert full["pred_fluxes"].shape[0] == 1
+    assert median["pred_fluxes"].shape[0] == 1
 
 
 def test_local_line_photometry_improves_coarse_grid_line_projection(monkeypatch):

--- a/tests/test_model_helpers.py
+++ b/tests/test_model_helpers.py
@@ -51,6 +51,7 @@ from jaxsedfit.model import (
     _line_gaussians,
     _evaluate_jaxqsofit_backend,
     _powerlaw_jax,
+    _project_local_nebular_line_filters,
     _project_filters,
     _redshift_to_obs,
     _torus_component,
@@ -66,6 +67,7 @@ from jaxsedfit.preload import _build_fixed_igm_jax, _build_igm_cache_jax, build_
 from jaxsedfit.filters import load_filter_curve
 from jaxsedfit.preload import (
     ModelContext,
+    PackedFilterCurvesJax,
     PackedFilters,
     PackedFiltersJax,
     SSPData,
@@ -88,6 +90,136 @@ def test_likelihood_defaults_include_absolute_flux_scale_prior():
     assert cfg.absolute_flux_scale_prior_sigma_dex > 0.0
     assert cfg.use_local_line_photometry is True
     assert cfg.local_nebular_line_uncertainty_dex == pytest.approx(0.3)
+
+
+def test_photometry_method_is_normalized_metadata_only():
+    phot = PhotometryData(
+        filter_names=["u", "g", "r"],
+        fluxes=[1.0, 2.0, 3.0],
+        errors=[0.1, 0.1, 0.1],
+        photometry_method=["PSF", " catalog ", None],
+    )
+    phot.validate()
+
+    assert phot.photometry_method == ["psf", "catalog", None]
+
+    bad = PhotometryData(
+        filter_names=["u"],
+        fluxes=[1.0],
+        errors=[0.1],
+        photometry_method=["adaptive-secret-method"],
+    )
+    with pytest.raises(ValueError, match="Unknown photometry_method"):
+        bad.validate()
+
+
+def _local_projection_context(filter_wave, filter_trans):
+    filter_wave = np.asarray(filter_wave, dtype=float)
+    filter_trans = np.asarray(filter_trans, dtype=float)
+    denom = np.trapezoid(filter_trans, filter_wave)
+    eff_wave = np.trapezoid(filter_wave * filter_trans, filter_wave) / denom
+    return SimpleNamespace(
+        rest_wave_jax=jax.numpy.asarray(np.linspace(1000.0, 10000.0, 512), dtype=jax.numpy.float64),
+        packed_filter_curves_jax=PackedFilterCurvesJax(
+            wave=jax.numpy.asarray(filter_wave[None, :], dtype=jax.numpy.float64),
+            transmission=jax.numpy.asarray(filter_trans[None, :], dtype=jax.numpy.float64),
+            denom=jax.numpy.asarray([denom], dtype=jax.numpy.float64),
+            valid_mask=jax.numpy.asarray(np.ones((1, filter_wave.size), dtype=bool)),
+        ),
+        filter_effective_wavelength_jax=jax.numpy.asarray([eff_wave], dtype=jax.numpy.float64),
+    )
+
+
+def _dense_nebular_line_filter_flux(context, *, line_wave, line_lumin, width_kms, luminosity_distance_m=1.0e20):
+    line_wave = float(line_wave)
+    line_lumin = float(line_lumin)
+    width_kms = float(width_kms)
+    fwhm_wave = max(line_wave * width_kms / 299792.458, 1.0e-8)
+    sigma = fwhm_wave / (2.0 * np.sqrt(2.0 * np.log(2.0)))
+    rest_wave = line_wave + np.linspace(-8.0, 8.0, 20001) * fwhm_wave
+    z = (rest_wave - line_wave) / sigma
+    rest_lumin = line_lumin * np.exp(-0.5 * z * z) / (sigma * np.sqrt(2.0 * np.pi))
+    filt_wave = np.asarray(context.packed_filter_curves_jax.wave[0])
+    filt_trans = np.asarray(context.packed_filter_curves_jax.transmission[0])
+    trans = np.interp(rest_wave, filt_wave, filt_trans, left=0.0, right=0.0)
+    distance_scale = 4.0 * np.pi * luminosity_distance_m**2
+    numer = np.trapezoid(trans * rest_lumin / distance_scale, rest_wave)
+    f_lambda = numer / float(context.packed_filter_curves_jax.denom[0])
+    eff_wave = float(context.filter_effective_wavelength_jax[0])
+    return 1.0e-10 / 299792458.0 * 1.0e29 * eff_wave * eff_wave * f_lambda
+
+
+@pytest.mark.parametrize(
+    ("case", "filter_wave", "filter_trans", "line_wave", "line_lumin", "width_kms", "rtol"),
+    [
+        (
+            "very narrow filter",
+            np.linspace(4998.0, 5002.0, 401),
+            np.ones(401),
+            5000.0,
+            100.0,
+            500.0,
+            3.0e-2,
+        ),
+        (
+            "line near filter edge",
+            np.linspace(5000.0, 5100.0, 501),
+            np.ones(501),
+            5002.0,
+            100.0,
+            300.0,
+            3.0e-2,
+        ),
+        (
+            "high equivalent width scaling",
+            np.linspace(4900.0, 5100.0, 501),
+            np.maximum(1.0 - np.abs(np.linspace(4900.0, 5100.0, 501) - 5000.0) / 100.0, 0.0),
+            5000.0,
+            1.0e6,
+            1000.0,
+            3.0e-2,
+        ),
+        (
+            "very narrow line width",
+            np.linspace(4990.0, 5010.0, 1001),
+            np.ones(1001),
+            5000.0,
+            100.0,
+            20.0,
+            3.0e-2,
+        ),
+    ],
+)
+def test_local_nebular_line_projection_matches_dense_edge_cases(
+    case,
+    filter_wave,
+    filter_trans,
+    line_wave,
+    line_lumin,
+    width_kms,
+    rtol,
+):
+    context = _local_projection_context(filter_wave, filter_trans)
+    local = float(
+        _project_local_nebular_line_filters(
+            context,
+            jax.numpy.asarray([line_wave], dtype=jax.numpy.float64),
+            jax.numpy.asarray([line_lumin], dtype=jax.numpy.float64),
+            width_kms,
+            0.0,
+            0.0,
+            1.0e20,
+            jax.numpy.ones_like(context.rest_wave_jax),
+        )[0]
+    )
+    dense = _dense_nebular_line_filter_flux(
+        context,
+        line_wave=line_wave,
+        line_lumin=line_lumin,
+        width_kms=width_kms,
+    )
+
+    assert local == pytest.approx(dense, rel=rtol), case
 
 
 def test_jaxqsofit_config_broadening_convolution_default_and_validation():
@@ -1118,6 +1250,37 @@ def test_context_builds_spectrum_resolution_host_basis(monkeypatch):
     assert context.spec_host_basis_jax is not None
     assert np.asarray(context.spec_rest_wave_jax).tolist() == pytest.approx(np.asarray(cfg.spectroscopy.wave_obs) / 1.1)
     assert context.spec_host_basis_jax.rest_llambda.shape[-1] == len(cfg.spectroscopy.wave_obs)
+
+
+def test_context_skips_spectrum_resolution_host_basis_when_backend_does_not_need_it(monkeypatch):
+    class _SSPData:
+        ssp_lgmet = np.array([-1.0, 0.0])
+        ssp_lg_age_gyr = np.array([-1.0, 0.0])
+        ssp_wave = np.array([900.0, 2000.0, 5000.0, 10000.0])
+        ssp_flux = np.ones((2, 2, 4))
+
+    monkeypatch.setattr("jaxsedfit.preload._load_ssp_templates", lambda fn: _SSPData())
+
+    cfg = FitConfig(
+        observation=Observation(object_id="obj", redshift=0.1),
+        photometry=PhotometryData(filter_names=["f1"], fluxes=[1.0], errors=[0.1]),
+        filters=FilterSet(curves=[FilterCurve(name="f1", wave=[1000.0, 2000.0, 3000.0], transmission=[0.0, 1.0, 0.0])]),
+        galaxy=GalaxyConfig(dsps_ssp_fn="fake.h5", n_wave=16, fit_host=True),
+        agn=AGNConfig(),
+        spectroscopy=SpectroscopyData(
+            wave_obs=[5000.0, 5100.0, 5200.0],
+            fluxes=[2.0, 4.0, 5.0],
+            errors=[0.1, 0.1, 0.1],
+            instrument="sdss",
+        ),
+        spectroscopy_config=SpectroscopyConfig(enabled=True, backend="jaxsedfit"),
+        inference=InferenceConfig(map_steps=2),
+    )
+
+    context = build_model_context(cfg)
+
+    assert context.spec_host_basis_jax is None
+    assert np.asarray(context.spec_rest_wave_jax).size == 0
 
 
 def test_jaxqsofit_spectrum_resolution_host_basis_uses_host_kinematics(monkeypatch):

--- a/tests/test_nebular.py
+++ b/tests/test_nebular.py
@@ -192,6 +192,25 @@ def test_nebular_enabled_adds_finite_component(monkeypatch):
     assert "nebular_logU_fit" in tr
 
 
+def test_nebular_dust_fraction_uses_smooth_remaining_budget(monkeypatch):
+    _patch_ssp(monkeypatch)
+    cfg = _mock_config()
+    cfg.nebular = NebularConfig(enabled=True, f_esc=0.6, f_dust=0.2, zgas=0.02)
+    cfg.prior_config.nebular.f_esc = dist.TruncatedNormal(0.6, 0.1, low=0.0, high=1.0)
+    cfg.prior_config.nebular.f_dust = dist.TruncatedNormal(0.5, 0.1, low=0.0, high=1.0)
+    context = build_model_context(cfg)
+    model = substitute(
+        lambda: grahsp_photometric_model(context, include_components=True),
+        data={"nebular_f_esc": np.array(0.7), "nebular_f_dust_fraction": np.array(0.5)},
+    )
+    tr = trace(seed(model, 5)).get_trace()
+
+    assert "nebular_f_dust_fraction" in tr
+    assert np.isclose(float(tr["nebular_f_dust_fit"]["value"]), 0.15)
+    assert np.isclose(float(tr["nebular_f_dust_fraction_fit"]["value"]), 0.5)
+    assert float(tr["nebular_f_esc_fit"]["value"]) + float(tr["nebular_f_dust_fit"]["value"]) <= 1.0
+
+
 def test_fixed_nebular_line_profile_cache_matches_dynamic_path(monkeypatch):
     _patch_ssp(monkeypatch)
     fixed_cfg = _mock_config()


### PR DESCRIPTION
## Summary

- Add lightweight `predict(kind="photometry")` and `predict_median()` paths while keeping full plot-ready prediction as the default.
- Use fixed filter projection for component photometry during plot prediction instead of falling back to slower observed-grid filter integration.
- Add a fixed local nebular-line projection cache for fixed-redshift local line photometry.
- Avoid building the spectrum-resolution host basis unless spectroscopy is enabled with the `jaxqsofit` backend.
- Clarify/validate `photometry_method` metadata and replace the nebular dust hard clip with a smooth remaining-budget parameterization.

## Validation

- `conda run -n jaxcpu pytest -q tests -m "not integration"`
- Result: `150 passed`