### PR TITLE
[codex] Improve public API docstrings

### DIFF
--- a/src/jaxsedfit/config.py
+++ b/src/jaxsedfit/config.py
@@ -343,7 +343,8 @@ def _scalar_or_list(value: Any) -> Any:
     Parameters
     ----------
     value : object
-        value value.
+        NumPyro distribution parameter, scalar, or array-like value to
+        serialize.
     """
     arr = np.asarray(value)
     if arr.shape == ():
@@ -357,7 +358,8 @@ def _numpyro_distribution_to_mapping(value: Any) -> dict[str, Any] | None:
     Parameters
     ----------
     value : object
-        value value.
+        Candidate NumPyro distribution instance. Unsupported non-distribution
+        objects return ``None``.
     """
     module = getattr(value.__class__, "__module__", "")
     if not module.startswith("numpyro.distributions"):
@@ -415,7 +417,8 @@ def _prior_to_mapping(value: Any) -> Any:
     Parameters
     ----------
     value : object
-        value value.
+        Public prior field value. Must be a supported
+        ``numpyro.distributions`` object.
     """
     prior = _numpyro_distribution_to_mapping(value)
     if prior is not None:
@@ -727,7 +730,27 @@ def _section_to_mapping(section: Any, fields_to_keys: Mapping[str, str]) -> dict
 
 @dataclass
 class PriorConfig:
-    """Object-oriented prior configuration."""
+    """Object-oriented prior configuration for a jaxsedfit model.
+
+    Parameters
+    ----------
+    redshift : RedshiftPriorConfig or mapping, optional
+        Optional tabulated redshift prior used when
+        ``Observation.redshift_mode='fit'``.
+    stellar_mass : numpyro.distributions.Distribution, optional
+        Prior for ``log_stellar_mass``.
+    mass_metallicity : MassMetallicityPriorConfig or mapping, optional
+        Soft stellar mass-metallicity relation prior.
+    host : HostPriorConfig or mapping, optional
+        Host-galaxy priors for dust, metallicity, SFH, and stellar kinematics.
+    agn : AGNPriorConfig or mapping, optional
+        AGN continuum, torus, line-strength, Balmer continuum, and Fe II priors.
+    nebular : NebularPriorConfig or mapping, optional
+        Nebular gas, escape/dust fraction, line-width, and line-scale priors.
+    likelihood : LikelihoodPriorConfig or mapping, optional
+        Priors for nuisance likelihood terms such as photometric systematics,
+        host capture, and spectrum scale.
+    """
     redshift: RedshiftPriorConfig = field(default_factory=RedshiftPriorConfig)
     stellar_mass: Any | None = None
     mass_metallicity: MassMetallicityPriorConfig = field(default_factory=MassMetallicityPriorConfig)
@@ -765,7 +788,41 @@ class PriorConfig:
 
 @dataclass
 class FitConfig:
-    """Top-level configuration bundle for a single jaxsedfit fit."""
+    """Top-level configuration bundle for a single jaxsedfit fit.
+
+    Parameters
+    ----------
+    observation : Observation or mapping
+        Source metadata including redshift, object identifier, sky coordinates,
+        and redshift-fitting mode.
+    photometry : PhotometryData or mapping
+        Broadband fluxes, uncertainties, upper-limit flags, and optional
+        aperture/PSF metadata.
+    filters : FilterSet or mapping, optional
+        Explicit filter curves used for synthetic photometry. If omitted,
+        filters are loaded from known filter names.
+    galaxy : GalaxyConfig or mapping, optional
+        Host-galaxy model, SSP grid, dust, cosmology, and wavelength-grid
+        settings.
+    nebular : NebularConfig or mapping, optional
+        Host nebular-emission switches and fixed gas defaults.
+    agn : AGNConfig or mapping, optional
+        AGN continuum, torus, Fe II, Balmer continuum, and native line settings.
+    likelihood : LikelihoodConfig or mapping, optional
+        Photometric likelihood family, systematics, variability, local line
+        projection, and aperture-capture options.
+    spectroscopy : SpectroscopyData, sequence of SpectroscopyData, mapping, or None, optional
+        Optional observed spectra for joint SED+spectrum fitting.
+    spectroscopy_config : SpectroscopyConfig or mapping, optional
+        Spectroscopic likelihood, scale, resolution weighting, and jaxqsofit
+        backend options.
+    inference : InferenceConfig or mapping, optional
+        MAP, NUTS, and nested-sampling controls.
+    output : OutputConfig or mapping, optional
+        Plotting and persistence behavior.
+    prior_config : PriorConfig or mapping, optional
+        Priors consumed by the NumPyro model.
+    """
     observation: Observation
     photometry: PhotometryData
     filters: FilterSet = field(default_factory=FilterSet)
@@ -813,8 +870,10 @@ def _coerce_dataclass(cls, value: Any):
 
     Parameters
     ----------
+    cls : type
+        Dataclass type to construct.
     value : object
-        value value.
+        Existing instance or mapping of dataclass field names to values.
     """
     if isinstance(value, cls):
         return value
@@ -841,7 +900,7 @@ def _coerce_jaxqsofit_config(value: Any) -> JaxQSOFitConfig:
     Parameters
     ----------
     value : object
-        value value.
+        Existing :class:`JaxQSOFitConfig` instance or mapping.
     """
     return _coerce_dataclass(JaxQSOFitConfig, value)
 
@@ -852,7 +911,7 @@ def _coerce_spectroscopy_config(value: Any) -> SpectroscopyConfig:
     Parameters
     ----------
     value : object
-        value value.
+        Existing :class:`SpectroscopyConfig` instance or mapping.
     """
     if isinstance(value, SpectroscopyConfig):
         return value
@@ -879,7 +938,7 @@ def _coerce_prior_config(value: Any) -> PriorConfig:
     Parameters
     ----------
     value : object
-        value value.
+        Existing :class:`PriorConfig`, mapping, or ``None``.
     """
     if isinstance(value, PriorConfig):
         return value
@@ -968,7 +1027,8 @@ def serialize_config(value: Any) -> Any:
     Parameters
     ----------
     value : object
-        value value.
+        Dataclass, mapping, sequence, NumPy array, NumPyro distribution, or
+        scalar value to convert into JSON-compatible containers.
     """
     prior = _numpyro_distribution_to_mapping(value)
     if prior is not None:

--- a/src/jaxsedfit/core.py
+++ b/src/jaxsedfit/core.py
@@ -31,8 +31,9 @@ class JAXSEDFit:
 
         Parameters
         ----------
-        config : object
-            config value.
+        config : FitConfig
+            Complete model, data, prior, inference, and output configuration
+            for one fit.
         """
         self.config = config
         self.context: ModelContext = build_model_context(config)
@@ -57,8 +58,8 @@ class JAXSEDFit:
 
         Parameters
         ----------
-        value : object
-            value value.
+        value : mapping or None
+            MAP inference payload to mirror into the internal fit state.
         """
         state = self._ensure_fit_state()
         state.map_result = value
@@ -76,8 +77,8 @@ class JAXSEDFit:
 
         Parameters
         ----------
-        value : object
-            value value.
+        value : mapping or None
+            NUTS inference payload to mirror into the internal fit state.
         """
         state = self._ensure_fit_state()
         state.nuts_result = value
@@ -95,8 +96,8 @@ class JAXSEDFit:
 
         Parameters
         ----------
-        value : object
-            value value.
+        value : mapping or None
+            Nested-sampling payload to mirror into the internal fit state.
         """
         state = self._ensure_fit_state()
         state.ns_result = value
@@ -114,8 +115,8 @@ class JAXSEDFit:
 
         Parameters
         ----------
-        value : object
-            value value.
+        value : mapping or None
+            Posterior sample mapping keyed by sample-site name.
         """
         self._ensure_fit_state().samples = value
 
@@ -130,8 +131,8 @@ class JAXSEDFit:
 
         Parameters
         ----------
-        value : object
-            value value.
+        value : mapping or None
+            Posterior predictive arrays keyed by deterministic site name.
         """
         state = self._ensure_fit_state()
         state.predictive = value
@@ -148,8 +149,8 @@ class JAXSEDFit:
 
         Parameters
         ----------
-        value : object
-            value value.
+        value : mapping or None
+            Cached plotting payloads keyed by plot type.
         """
         self._ensure_fit_state().plot_cache = value
 
@@ -164,8 +165,8 @@ class JAXSEDFit:
 
         Parameters
         ----------
-        value : object
-            value value.
+        value : mapping or None
+            Summary statistics restored from a saved posterior bundle.
         """
         self._ensure_fit_state().summary = value
 
@@ -180,8 +181,8 @@ class JAXSEDFit:
 
         Parameters
         ----------
-        value : object
-            value value.
+        value : str, pathlib.Path, or None
+            Path to a restored posterior bundle.
         """
         self._ensure_fit_state().path = None if value is None else Path(value)
 
@@ -198,10 +199,11 @@ class JAXSEDFit:
 
         Parameters
         ----------
-        prior_config : object
-            prior_config value.
-        dsps_ssp_fn : object
-            dsps_ssp_fn value.
+        prior_config : mapping or PriorConfig, optional
+            Replacement prior configuration for this fit call.
+        dsps_ssp_fn : str, optional
+            Replacement SSP template path. Rebuilds the static model context
+            when it differs from the configured path.
         """
         rebuild_context = False
         if prior_config is not None:
@@ -515,8 +517,15 @@ class JAXSEDFit:
 
         Parameters
         ----------
-        progress_bar : object
-            progress_bar value.
+        progress_bar : bool, optional
+            If True, show progress bars for Optax, NUTS, or nested-sampling
+            backends when the backend supports them.
+
+        Returns
+        -------
+        FitResult
+            Result wrapper containing posterior samples or MAP values,
+            summaries, optional figure handles, and persistence helpers.
         """
         inference = self.config.inference
         output = self.config.output
@@ -955,14 +964,23 @@ class JAXSEDFit:
 
         Parameters
         ----------
-        posterior : object
-            posterior value.
-        kind : object
-            kind value.
-        max_draws : object
-            max_draws value.
-        _state : object
-            _state value.
+        posterior : {"latest"}, optional
+            Posterior selection. Currently ``"latest"`` uses the most recent
+            fit state attached to the fitter or result.
+        kind : {"plot", "photometry"}, optional
+            Prediction payload to compute. ``"photometry"`` skips expensive
+            full component SED arrays where possible; ``"plot"`` includes the
+            component arrays used by :meth:`plot_sed`.
+        max_draws : int, optional
+            Maximum number of posterior draws to evaluate. If omitted, all
+            available draws are used.
+        _state : _FitState, optional
+            Internal fit-state override used by :class:`FitResult`.
+
+        Returns
+        -------
+        dict
+            Posterior predictive arrays keyed by deterministic site name.
         """
         state = self._ensure_fit_state() if _state is None else _state
         kind = self._prediction_kind(kind)
@@ -983,12 +1001,18 @@ class JAXSEDFit:
 
         Parameters
         ----------
-        posterior : object
-            posterior value.
-        kind : object
-            kind value.
-        _state : object
-            _state value.
+        posterior : {"latest"}, optional
+            Posterior selection. Currently ``"latest"`` uses the most recent
+            fit state attached to the fitter or result.
+        kind : {"plot", "photometry"}, optional
+            Prediction payload to compute at the posterior median.
+        _state : _FitState, optional
+            Internal fit-state override used by :class:`FitResult`.
+
+        Returns
+        -------
+        dict
+            Predictive arrays evaluated once at posterior-median parameters.
         """
         state = self._ensure_fit_state() if _state is None else _state
         if state.samples is None:
@@ -1073,12 +1097,12 @@ class JAXSEDFit:
 
         Parameters
         ----------
-        parent : object
-            parent value.
-        name : object
-            name value.
+        parent : h5py.Group
+            Parent HDF5 group.
+        name : str
+            Child dataset or group name.
         value : object
-            value value.
+            Python scalar, array, mapping, sequence, or ``None`` to write.
         """
         if value is None:
             grp = parent.create_group(name)
@@ -1227,10 +1251,15 @@ class JAXSEDFit:
 
         Parameters
         ----------
-        output_dir : object
-            output_dir value.
-        _state : object
-            _state value.
+        output_dir : str or pathlib.Path, optional
+            Output directory or explicit ``*_samples.h5`` file path.
+        _state : _FitState, optional
+            Internal fit-state override used by :class:`FitResult`.
+
+        Returns
+        -------
+        pathlib.Path
+            Path to the written HDF5 posterior bundle.
         """
         state = self._ensure_fit_state() if _state is None else _state
         out = self._posterior_bundle_path(output_dir, self.config.observation.object_id)
@@ -1347,14 +1376,20 @@ class JAXSEDFit:
 
         Parameters
         ----------
-        output_path : object
-            output_path value.
-        posterior : object
-            posterior value.
-        show : object
-            show value.
-        annotate_band_names : object
-            annotate_band_names value.
+        output_path : str or pathlib.Path, optional
+            File path for saving the figure. If omitted, the figure is returned
+            without writing to disk.
+        posterior : {"latest"}, optional
+            Posterior selection passed to :meth:`predict`.
+        show : bool, optional
+            If True, display the Matplotlib figure interactively.
+        annotate_band_names : bool, optional
+            If True, label observed photometric points with their filter names.
+
+        Returns
+        -------
+        matplotlib.figure.Figure
+            The generated SED figure.
         """
         from .plotting import plot_fit_sed
 
@@ -1380,20 +1415,22 @@ class JAXSEDFit:
 
         Parameters
         ----------
-        output_path : object
-            output_path value.
-        params : object
-            params value.
-        max_params : object
-            max_params value.
-        labels : object
-            labels value.
-        truths : object
-            truths value.
-        show : object
-            show value.
+        output_path : str or pathlib.Path, optional
+            File path for saving the corner plot.
+        params : sequence of str, optional
+            Posterior sample names to include. If omitted, scalar sample sites
+            are selected automatically.
+        max_params : int, optional
+            Maximum number of automatically selected parameters to plot.
+        labels : mapping or sequence, optional
+            Axis labels keyed by parameter name, or labels in the same order as
+            ``params``.
+        truths : mapping or sequence, optional
+            Reference values to draw on the corner plot.
+        show : bool, optional
+            If True, display the figure interactively.
         **corner_kwargs : dict
-            Additional keyword arguments.
+            Additional keyword arguments forwarded to ``corner.corner``.
         """
         from .plotting import plot_corner
 
@@ -1419,14 +1456,15 @@ class JAXSEDFit:
 
         Parameters
         ----------
-        output_path : object
-            output_path value.
-        params : object
-            params value.
-        max_params : object
-            max_params value.
-        show : object
-            show value.
+        output_path : str or pathlib.Path, optional
+            File path for saving the trace plot.
+        params : sequence of str, optional
+            Posterior sample names to include. If omitted, scalar sample sites
+            are selected automatically.
+        max_params : int, optional
+            Maximum number of automatically selected parameters to plot.
+        show : bool, optional
+            If True, display the figure interactively.
         """
         from .plotting import plot_trace
 
@@ -1445,7 +1483,7 @@ class JAXSEDFit:
         Parameters
         ----------
         value : object
-            value value.
+            Scalar or array-like posterior predictive value.
         """
         arr = np.asarray(value, dtype=float)
         if arr.ndim == 0 or arr.size == 0:
@@ -1500,22 +1538,24 @@ class JAXSEDFit:
 
         Parameters
         ----------
-        spectrum_index : object
-            spectrum_index value.
-        posterior : object
-            posterior value.
-        show_nebular_lines : object
-            show_nebular_lines value.
-        show_plot : object
-            show_plot value.
-        plot_residual : object
-            plot_residual value.
-        plot_legend : object
-            plot_legend value.
-        ylims : object
-            ylims value.
+        spectrum_index : int, optional
+            Index of the spectrum to plot when multiple spectra are fitted.
+        posterior : {"latest"}, optional
+            Posterior selection passed to :meth:`predict`.
+        show_nebular_lines : bool, optional
+            If True, overlay the native jaxsedfit nebular-line diagnostic in
+            addition to the jaxqsofit spectral line model.
+        show_plot : bool, optional
+            If True, display the Matplotlib figure interactively.
+        plot_residual : bool, optional
+            If True, draw a residual panel below the spectrum.
+        plot_legend : bool, optional
+            If True, draw the component legend.
+        ylims : tuple of float, optional
+            Optional y-axis limits for the spectrum panel.
         **kwargs : dict
-            Additional keyword arguments.
+            Additional keyword arguments forwarded to jaxqsofit's spectrum
+            plotting function.
         """
         if str(self.config.spectroscopy_config.backend).lower() != "jaxqsofit":
             raise RuntimeError("plot_jaxqsofit_spectrum requires SpectroscopyConfig.backend='jaxqsofit'.")

--- a/src/jaxsedfit/plotting.py
+++ b/src/jaxsedfit/plotting.py
@@ -31,8 +31,8 @@ def _posterior_samples(fitter_or_samples: Any) -> Mapping[str, Any]:
 
     Parameters
     ----------
-    fitter_or_samples : object
-        fitter_or_samples value.
+    fitter_or_samples : JAXSEDFit or mapping
+        Fitter with a ``samples`` attribute, or a raw posterior sample mapping.
     """
     if isinstance(fitter_or_samples, Mapping):
         samples = fitter_or_samples
@@ -48,8 +48,9 @@ def _grouped_trace_samples(fitter_or_samples: Any) -> tuple[Mapping[str, Any], b
 
     Parameters
     ----------
-    fitter_or_samples : object
-        fitter_or_samples value.
+    fitter_or_samples : JAXSEDFit or mapping
+        Fitter with NUTS state, fitter with flattened samples, or a raw sample
+        mapping.
     """
     if not isinstance(fitter_or_samples, Mapping):
         nuts_result = getattr(fitter_or_samples, "nuts_result", None)
@@ -65,10 +66,11 @@ def _finite_scalar_sample_array(value: Any, *, grouped: bool) -> np.ndarray | No
 
     Parameters
     ----------
-    value : object
-        value value.
-    grouped : object
-        grouped value.
+    value : array-like
+        Candidate posterior sample array.
+    grouped : bool
+        If True, require ``(chain, draw)`` shape; otherwise require flattened
+        one-dimensional draws.
     """
     arr = np.asarray(value, dtype=float)
     if grouped:
@@ -86,10 +88,10 @@ def _has_dynamic_range(value: Any, *, grouped: bool) -> bool:
 
     Parameters
     ----------
-    value : object
-        value value.
-    grouped : object
-        grouped value.
+    value : array-like
+        Candidate posterior sample array.
+    grouped : bool
+        Whether ``value`` is expected to include an explicit chain axis.
     """
     arr = _finite_scalar_sample_array(value, grouped=grouped)
     if arr is None:
@@ -109,14 +111,15 @@ def _select_scalar_params(
 
     Parameters
     ----------
-    samples : object
-        samples value.
-    params : object
-        params value.
-    max_params : object
-        max_params value.
-    grouped : object
-        grouped value.
+    samples : mapping
+        Posterior samples keyed by sample-site name.
+    params : sequence of str or None
+        Explicit sample names to select. If omitted, finite scalar sites are
+        selected automatically.
+    max_params : int or None
+        Maximum number of automatically selected parameters.
+    grouped : bool
+        Whether samples include an explicit chain axis.
     """
     if params is not None:
         selected = [str(param) for param in params]
@@ -150,14 +153,15 @@ def _select_corner_params(
 
     Parameters
     ----------
-    samples : object
-        samples value.
-    params : object
-        params value.
-    max_params : object
-        max_params value.
-    grouped : object
-        grouped value.
+    samples : mapping
+        Posterior samples keyed by sample-site name.
+    params : sequence of str or None
+        Explicit sample names to select. If omitted, finite scalar sites with
+        nonzero dynamic range are selected automatically.
+    max_params : int or None
+        Maximum number of automatically selected parameters.
+    grouped : bool
+        Whether samples include an explicit chain axis.
     """
     if params is not None:
         selected = [str(param) for param in params]
@@ -187,10 +191,11 @@ def _labels_for_params(params: list[str], labels: Mapping[str, str] | list[str] 
 
     Parameters
     ----------
-    params : object
-        params value.
-    labels : object
-        labels value.
+    params : list of str
+        Selected posterior sample names.
+    labels : mapping, sequence, or None
+        Optional display labels keyed by parameter name, or labels in the same
+        order as ``params``.
     """
     if labels is None:
         return params
@@ -207,10 +212,11 @@ def _truths_for_params(params: list[str], truths: Mapping[str, float | None] | l
 
     Parameters
     ----------
-    params : object
-        params value.
-    truths : object
-        truths value.
+    params : list of str
+        Selected posterior sample names.
+    truths : mapping, sequence, or None
+        Optional truth/reference values keyed by parameter name, or values in
+        the same order as ``params``.
     """
     if truths is None:
         return None
@@ -227,12 +233,12 @@ def _sample_matrix(samples: Mapping[str, Any], params: list[str], *, grouped: bo
 
     Parameters
     ----------
-    samples : object
-        samples value.
-    params : object
-        params value.
-    grouped : object
-        grouped value.
+    samples : mapping
+        Posterior samples keyed by sample-site name.
+    params : list of str
+        Scalar posterior sample names to stack as matrix columns.
+    grouped : bool
+        Whether samples include an explicit chain axis.
     """
     columns = []
     draw_count = None
@@ -263,22 +269,24 @@ def plot_corner(
 
     Parameters
     ----------
-    fitter_or_samples : object
-        fitter_or_samples value.
-    output_path : object
-        output_path value.
-    params : object
-        params value.
-    max_params : object
-        max_params value.
-    labels : object
-        labels value.
-    truths : object
-        truths value.
-    show : object
-        show value.
+    fitter_or_samples : JAXSEDFit or mapping
+        Fitted object or raw posterior sample mapping to visualize.
+    output_path : str or pathlib.Path, optional
+        File path for saving the figure.
+    params : sequence of str, optional
+        Posterior sample names to include. If omitted, scalar sample sites with
+        dynamic range are selected automatically.
+    max_params : int, optional
+        Maximum number of automatically selected parameters to plot.
+    labels : mapping or sequence, optional
+        Axis labels keyed by parameter name, or labels in the same order as
+        ``params``.
+    truths : mapping or sequence, optional
+        Reference values to mark on the plot.
+    show : bool, optional
+        If True, display the figure interactively.
     **corner_kwargs : dict
-        Additional keyword arguments.
+        Additional keyword arguments forwarded to ``corner.corner``.
     """
     try:
         import corner as corner_lib
@@ -325,16 +333,17 @@ def plot_trace(
 
     Parameters
     ----------
-    fitter_or_samples : object
-        fitter_or_samples value.
-    output_path : object
-        output_path value.
-    params : object
-        params value.
-    max_params : object
-        max_params value.
-    show : object
-        show value.
+    fitter_or_samples : JAXSEDFit or mapping
+        Fitted object or raw posterior sample mapping to visualize.
+    output_path : str or pathlib.Path, optional
+        File path for saving the figure.
+    params : sequence of str, optional
+        Posterior sample names to include. If omitted, finite scalar sample
+        sites are selected automatically.
+    max_params : int, optional
+        Maximum number of automatically selected parameters to plot.
+    show : bool, optional
+        If True, display the figure interactively.
     """
     samples, grouped = _grouped_trace_samples(fitter_or_samples)
     selected = _select_scalar_params(samples, params, max_params=max_params, grouped=grouped)
@@ -381,10 +390,10 @@ def _median_site(pred: dict[str, Any], key: str) -> np.ndarray:
 
     Parameters
     ----------
-    pred : object
-        pred value.
-    key : object
-        key value.
+    pred : mapping
+        Predictive arrays keyed by deterministic site name.
+    key : str
+        Predictive site to reduce.
     """
     arr = np.asarray(pred[key], dtype=float)
     return np.median(arr, axis=0) if arr.ndim > 1 else arr
@@ -395,12 +404,12 @@ def _percentile_site(pred: dict[str, Any], key: str, q: float) -> np.ndarray:
 
     Parameters
     ----------
-    pred : object
-        pred value.
-    key : object
-        key value.
-    q : object
-        q value.
+    pred : mapping
+        Predictive arrays keyed by deterministic site name.
+    key : str
+        Predictive site to reduce.
+    q : float
+        Percentile between 0 and 100.
     """
     arr = np.asarray(pred[key], dtype=float)
     return np.percentile(arr, q, axis=0) if arr.ndim > 1 else arr
@@ -411,10 +420,10 @@ def _site_sum(pred: dict[str, Any], keys: tuple[str, ...]) -> np.ndarray:
 
     Parameters
     ----------
-    pred : object
-        pred value.
-    keys : object
-        keys value.
+    pred : mapping
+        Predictive arrays keyed by deterministic site name.
+    keys : tuple of str
+        Predictive sites to add when present.
     """
     arrays = [np.asarray(pred[key], dtype=float) for key in keys if key in pred]
     if not arrays:
@@ -427,10 +436,10 @@ def _median_site_sum(pred: dict[str, Any], keys: tuple[str, ...]) -> np.ndarray:
 
     Parameters
     ----------
-    pred : object
-        pred value.
-    keys : object
-        keys value.
+    pred : mapping
+        Predictive arrays keyed by deterministic site name.
+    keys : tuple of str
+        Predictive sites to add before taking the median.
     """
     arr = _site_sum(pred, keys)
     return np.median(arr, axis=0) if arr.ndim > 1 else arr
@@ -441,12 +450,12 @@ def _percentile_site_sum(pred: dict[str, Any], keys: tuple[str, ...], q: float) 
 
     Parameters
     ----------
-    pred : object
-        pred value.
-    keys : object
-        keys value.
-    q : object
-        q value.
+    pred : mapping
+        Predictive arrays keyed by deterministic site name.
+    keys : tuple of str
+        Predictive sites to add before taking the percentile.
+    q : float
+        Percentile between 0 and 100.
     """
     arr = _site_sum(pred, keys)
     return np.percentile(arr, q, axis=0) if arr.ndim > 1 else arr
@@ -457,10 +466,10 @@ def _to_display_flux_density(obs_wave: np.ndarray, sed: np.ndarray) -> np.ndarra
 
     Parameters
     ----------
-    obs_wave : object
-        obs_wave value.
-    sed : object
-        sed value.
+    obs_wave : array-like
+        Observed-frame wavelengths in Angstrom.
+    sed : array-like
+        Internal model spectral-density array on ``obs_wave``.
     """
     obs_wave = np.asarray(obs_wave, dtype=float)
     sed = np.asarray(sed, dtype=float)
@@ -472,10 +481,10 @@ def _median_effective_variance(fitter, pred: dict[str, Any]) -> np.ndarray:
 
     Parameters
     ----------
-    fitter : object
-        fitter value.
-    pred : object
-        pred value.
+    fitter : JAXSEDFit
+        Fitted object containing configuration and photometry context.
+    pred : mapping
+        Predictive arrays returned by :meth:`jaxsedfit.JAXSEDFit.predict`.
     """
     pred_fluxes = np.asarray(_median_site(pred, "pred_fluxes"), dtype=float)
     agn_fluxes = np.asarray(_median_site(pred, "agn_fluxes"), dtype=float) if "agn_fluxes" in pred else np.zeros_like(pred_fluxes)
@@ -531,16 +540,16 @@ def plot_fit_sed(
 
     Parameters
     ----------
-    fitter : object
-        fitter value.
-    output_path : object
-        output_path value.
-    posterior : object
-        posterior value.
-    show : object
-        show value.
-    annotate_band_names : object
-        annotate_band_names value.
+    fitter : JAXSEDFit
+        Fitted object with posterior samples and model context.
+    output_path : str or pathlib.Path, optional
+        File path for saving the figure.
+    posterior : {"latest"}, optional
+        Posterior selection passed to :meth:`jaxsedfit.JAXSEDFit.predict`.
+    show : bool, optional
+        If True, display the figure interactively.
+    annotate_band_names : bool, optional
+        If True, label observed photometric points by filter name.
     """
     pred = fitter.predict(posterior=posterior)
     obs_wave = _median_site(pred, "obs_wave")

--- a/src/jaxsedfit/results.py
+++ b/src/jaxsedfit/results.py
@@ -12,8 +12,9 @@ def median_mapping(values: Mapping[str, Any] | None) -> dict[str, Any]:
 
     Parameters
     ----------
-    values : object
-        values value.
+    values : mapping or None
+        Posterior sample mapping keyed by sample-site name. Each value is
+        reduced over its leading sample axis when possible.
     """
     out: dict[str, Any] = {}
     for key, value in (values or {}).items():
@@ -64,8 +65,8 @@ class PredictionResult:
 
         Parameters
         ----------
-        key : object
-            key value.
+        key : str
+            Predictive site name to retrieve.
         """
         return self.data[key]
 
@@ -80,10 +81,10 @@ class PredictionResult:
 
         Parameters
         ----------
-        key : object
-            key value.
-        default : object
-            default value.
+        key : str
+            Predictive site name to retrieve.
+        default : object, optional
+            Value returned when ``key`` is absent.
         """
         return self.data.get(key, default)
 
@@ -107,7 +108,8 @@ class FitResult:
         Parameters
         ----------
         **kwargs : dict
-            Additional keyword arguments.
+            Keyword arguments forwarded to :meth:`jaxsedfit.JAXSEDFit.predict`,
+            such as ``kind`` or ``max_draws``.
         """
         if self._state is not None:
             kwargs.setdefault("_state", self._state)
@@ -118,10 +120,11 @@ class FitResult:
 
         Parameters
         ----------
-        path : object
-            path value.
+        path : str or pathlib.Path, optional
+            Output directory or explicit HDF5 file path.
         **kwargs : dict
-            Additional keyword arguments.
+            Additional keyword arguments forwarded to
+            :meth:`jaxsedfit.JAXSEDFit.save`.
         """
         output_path = Path("." if path is None else path)
         if self._state is not None:
@@ -137,7 +140,8 @@ class FitResult:
         Parameters
         ----------
         **kwargs : dict
-            Additional keyword arguments.
+            Keyword arguments forwarded to
+            :meth:`jaxsedfit.JAXSEDFit.plot_corner`.
         """
         return self.fitter.plot_corner(**kwargs)
 
@@ -147,6 +151,7 @@ class FitResult:
         Parameters
         ----------
         **kwargs : dict
-            Additional keyword arguments.
+            Keyword arguments forwarded to
+            :meth:`jaxsedfit.JAXSEDFit.plot_trace`.
         """
         return self.fitter.plot_trace(**kwargs)


### PR DESCRIPTION
## Summary
- Replace placeholder public API parameter docs for FitConfig and PriorConfig.
- Add meaningful parameter docs for JAXSEDFit fit, predict, save, and plotting methods.
- Clean up result-wrapper and plotting helper docstrings so user-facing docs no longer say placeholder text like 'value value'.

## Checks
- conda run -n jaxcpu python -m py_compile src/jaxsedfit/config.py src/jaxsedfit/core.py src/jaxsedfit/results.py src/jaxsedfit/plotting.py
- git diff --check -- src/jaxsedfit/config.py src/jaxsedfit/core.py src/jaxsedfit/results.py src/jaxsedfit/plotting.py