### PR TITLE
Fix SED units and add physical invariant tests

### DIFF
--- a/src/jaxsedfit/benchmark.py
+++ b/src/jaxsedfit/benchmark.py
@@ -186,6 +186,7 @@ def _load_bruhweiler_feii_template() -> FeIITemplate:
         name="BruhweilerVerner08",
         wave=wave_rest.tolist(),
         lumin=(llam / norm).tolist(),
+        wavelength_unit="angstrom",
     )
     _BENCHMARK_RESOURCE_CACHE[cache_key] = tmpl
     return tmpl
@@ -214,6 +215,7 @@ def _load_mor_netzer_emission_lines() -> EmissionLineTemplate:
         lumin_blagn=np.asarray(data["broad"], dtype=float).tolist(),
         lumin_sy2=np.asarray(data["S2"], dtype=float).tolist(),
         lumin_liner=np.asarray(data["LINER"], dtype=float).tolist(),
+        wavelength_unit="angstrom",
     )
     _BENCHMARK_RESOURCE_CACHE[cache_key] = tmpl
     return tmpl

--- a/src/jaxsedfit/config.py
+++ b/src/jaxsedfit/config.py
@@ -28,6 +28,10 @@ class Observation:
         mode = str(self.redshift_mode).lower()
         if mode not in {"fixed", "fit"}:
             raise ValueError("observation.redshift_mode must be either 'fixed' or 'fit'.")
+        if not np.isfinite(float(self.redshift)) or float(self.redshift) < 0.0:
+            raise ValueError("observation.redshift must be finite and non-negative.")
+        if not np.isfinite(float(self.redshift_err)) or float(self.redshift_err) < 0.0:
+            raise ValueError("observation.redshift_err must be finite and non-negative.")
         self.redshift_mode = mode
 
 
@@ -129,19 +133,25 @@ class FilterSet:
 
 @dataclass
 class FeIITemplate:
-    """Fe II template configuration or inline template data."""
+    """Fe II template configuration or inline template data.
+
+    ``wavelength_unit`` is required for inline ``wave`` values. Supported
+    values are ``angstrom``, ``nm``, and ``micron`` (plus common aliases).
+    """
     name: str = "BruhweilerVerner08"
     wave: Sequence[float] | None = None
     lumin: Sequence[float] | None = None
+    wavelength_unit: str | None = None
 
 
 @dataclass
 class EmissionLineTemplate:
-    """Emission-line template tables for BLAGN, Sy2, and LINER branches."""
+    """Emission-line template tables with explicit inline wavelength units."""
     wave: Sequence[float] | None = None
     lumin_blagn: Sequence[float] | None = None
     lumin_sy2: Sequence[float] | None = None
     lumin_liner: Sequence[float] | None = None
+    wavelength_unit: str | None = None
 
 
 @dataclass
@@ -168,6 +178,19 @@ class GalaxyConfig:
     # empirical AGN component, not by adding AGN-absorbed luminosity here.
     use_energy_balance: bool = True
     dust_alpha: float = 2.0
+
+    def validate(self) -> None:
+        """Validate the internal Angstrom wavelength grid and SFH grid."""
+        if not np.isfinite(float(self.rest_wave_min)) or float(self.rest_wave_min) <= 0.0:
+            raise ValueError("galaxy.rest_wave_min must be positive and finite (Angstrom).")
+        if not np.isfinite(float(self.rest_wave_max)) or float(self.rest_wave_max) <= float(self.rest_wave_min):
+            raise ValueError("galaxy.rest_wave_max must be finite and greater than rest_wave_min (Angstrom).")
+        if int(self.n_wave) < 2:
+            raise ValueError("galaxy.n_wave must be at least 2.")
+        if int(self.sfh_n_steps) < 2:
+            raise ValueError("galaxy.sfh_n_steps must be at least 2.")
+        if not np.isfinite(float(self.sfh_t_min_gyr)) or float(self.sfh_t_min_gyr) <= 0.0:
+            raise ValueError("galaxy.sfh_t_min_gyr must be positive and finite.")
 
 
 @dataclass
@@ -218,6 +241,30 @@ class AGNConfig:
         """Normalize nested template sections."""
         self.feii_template = _coerce_dataclass(FeIITemplate, self.feii_template)
         self.emission_line_template = _coerce_dataclass(EmissionLineTemplate, self.emission_line_template)
+
+    def validate(self) -> None:
+        """Validate inline template units and array shapes."""
+        allowed_units = {"angstrom", "angstroms", "aa", "a", "nm", "nanometer", "nanometers", "um", "micron", "microns"}
+        for label, template in (("feii_template", self.feii_template), ("emission_line_template", self.emission_line_template)):
+            unit = None if template.wavelength_unit is None else str(template.wavelength_unit).strip().lower()
+            if template.wave is not None and unit is None:
+                raise ValueError(f"agn.{label}.wavelength_unit is required when inline wave values are provided.")
+            if unit is not None and unit not in allowed_units:
+                allowed = "angstrom, nm, micron"
+                raise ValueError(f"agn.{label}.wavelength_unit must be one of: {allowed}.")
+            if template.wave is not None:
+                wave = np.asarray(template.wave, dtype=float)
+                min_size = 2 if label == "feii_template" else 1
+                if wave.ndim != 1 or wave.size < min_size or not np.all(np.isfinite(wave)) or np.any(wave <= 0.0):
+                    raise ValueError(f"agn.{label}.wave must contain at least {min_size} positive finite wavelength value(s).")
+            if label == "feii_template" and template.wave is not None:
+                if template.lumin is None or len(template.lumin) != len(template.wave):
+                    raise ValueError("agn.feii_template.lumin must match feii_template.wave.")
+            if label == "emission_line_template" and template.wave is not None:
+                for field_name in ("lumin_blagn", "lumin_sy2", "lumin_liner"):
+                    values = getattr(template, field_name)
+                    if values is None or len(values) != len(template.wave):
+                        raise ValueError(f"agn.emission_line_template.{field_name} must match emission_line_template.wave.")
 
 
 @dataclass
@@ -844,7 +891,9 @@ class FitConfig:
         """Validate nested config components that require runtime checks."""
         self.observation.validate()
         self.photometry.validate()
+        self.galaxy.validate()
         self.nebular.validate()
+        self.agn.validate()
         for spectrum in self.spectroscopy_list:
             spectrum.validate()
         if not self.galaxy.fit_host and not self.agn.fit_agn:

--- a/src/jaxsedfit/model.py
+++ b/src/jaxsedfit/model.py
@@ -987,6 +987,14 @@ def _attenuation_transmitted_fraction(direct_attenuated, direct_intrinsic):
     )
 
 
+def _band_transmitted_fraction(direct_attenuated_flux, direct_intrinsic_flux):
+    """Return a dimensionless bandwise attenuated-to-intrinsic flux ratio."""
+    attenuated = jnp.asarray(direct_attenuated_flux, dtype=jnp.float64)
+    intrinsic = jnp.asarray(direct_intrinsic_flux, dtype=jnp.float64)
+    ratio = attenuated / jnp.maximum(intrinsic, 1.0e-30)
+    return jnp.where(intrinsic > 0.0, jnp.clip(ratio, 1.0e-4, 1.0), 1.0)
+
+
 def _apply_extended_capture(total_flux, extended_flux, capture_fraction):
     """Return total flux after aperture capture of extended components only.
 
@@ -3037,10 +3045,8 @@ def evaluate_photometric_state(
     )
     agn_rest = agn_attenuated_rest + torus_att_rest
     total_rest = gal_att_rest + dust_rest + agn_rest
-    transmitted_fraction = _attenuation_transmitted_fraction(
-        gal_att_rest + agn_attenuated_rest,
-        host_with_nebular_rest + agn_attenuated_input_rest,
-    )
+    direct_intrinsic_rest = host_with_nebular_rest + agn_attenuated_input_rest
+    direct_attenuated_rest = gal_att_rest + agn_attenuated_rest
     fast_projection_enabled = _can_use_fixed_filter_projection(context, cfg)
     redshift_projection_enabled = (
         _can_use_redshift_filter_projection(context, cfg)
@@ -3541,7 +3547,6 @@ def evaluate_photometric_state(
         line_nl_obs = _redshift_to_obs(rest_wave, line_nl_att_rest * igm, obs_wave, redshift, luminosity_distance_m)
         line_liner_obs = _redshift_to_obs(rest_wave, line_liner_att_rest * igm, obs_wave, redshift, luminosity_distance_m)
         balmer_obs = _redshift_to_obs(rest_wave, balmer_att_rest * igm, obs_wave, redshift, luminosity_distance_m)
-        transmitted_fraction_obs = _redshift_scalar_to_obs(rest_wave, transmitted_fraction, obs_wave, redshift)
         if fast_projection_enabled:
             agn_fluxes = _project_rest_luminosity_filters(context, agn_rest)
             dust_fluxes = _project_rest_luminosity_filters(context, dust_rest)
@@ -3556,7 +3561,8 @@ def evaluate_photometric_state(
             line_nl_fluxes = _project_rest_luminosity_filters(context, line_nl_att_rest)
             line_liner_fluxes = _project_rest_luminosity_filters(context, line_liner_att_rest)
             balmer_fluxes = _project_rest_luminosity_filters(context, balmer_att_rest)
-            trans_fluxes = _project_rest_scalar_filters(context, transmitted_fraction)
+            direct_attenuated_fluxes = _project_rest_luminosity_filters(context, direct_attenuated_rest)
+            direct_intrinsic_fluxes = _project_rest_luminosity_filters(context, direct_intrinsic_rest)
         else:
             agn_fluxes = _project_filters(agn_obs, context.packed_filters_jax)
             dust_fluxes = _project_filters(dust_obs, context.packed_filters_jax)
@@ -3571,7 +3577,15 @@ def evaluate_photometric_state(
             line_nl_fluxes = _project_filters(line_nl_obs, context.packed_filters_jax)
             line_liner_fluxes = _project_filters(line_liner_obs, context.packed_filters_jax)
             balmer_fluxes = _project_filters(balmer_obs, context.packed_filters_jax)
-            trans_fluxes = _project_filters(transmitted_fraction_obs, context.packed_filters_jax)
+            direct_attenuated_obs = _redshift_to_obs(
+                rest_wave, direct_attenuated_rest * igm, obs_wave, redshift, luminosity_distance_m
+            )
+            direct_intrinsic_obs = _redshift_to_obs(
+                rest_wave, direct_intrinsic_rest * igm, obs_wave, redshift, luminosity_distance_m
+            )
+            direct_attenuated_fluxes = _project_filters(direct_attenuated_obs, context.packed_filters_jax)
+            direct_intrinsic_fluxes = _project_filters(direct_intrinsic_obs, context.packed_filters_jax)
+        trans_fluxes = _band_transmitted_fraction(direct_attenuated_fluxes, direct_intrinsic_fluxes)
         if correct_nebular_line_photometry:
             nebular_lines_fluxes = local_nebular_line_fluxes
             nebular_fluxes = nebular_continuum_fluxes + local_nebular_line_fluxes
@@ -3608,12 +3622,21 @@ def evaluate_photometric_state(
             agn_fluxes = _apply_extended_capture(agn_fluxes, agn_narrow_line_fluxes_total, host_capture_fraction)
         if need_trans_fluxes:
             if fast_projection_enabled:
-                trans_fluxes = _project_rest_scalar_filters(context, transmitted_fraction)
+                direct_attenuated_fluxes = _project_rest_luminosity_filters(context, direct_attenuated_rest)
+                direct_intrinsic_fluxes = _project_rest_luminosity_filters(context, direct_intrinsic_rest)
             elif redshift_projection_enabled:
-                trans_fluxes = _project_redshift_scalar_filters(context, transmitted_fraction, redshift)
+                direct_attenuated_fluxes = _project_redshift_luminosity_filters(context, direct_attenuated_rest, redshift)
+                direct_intrinsic_fluxes = _project_redshift_luminosity_filters(context, direct_intrinsic_rest, redshift)
             else:
-                transmitted_fraction_obs = _redshift_scalar_to_obs(rest_wave, transmitted_fraction, obs_wave, redshift)
-                trans_fluxes = _project_filters(transmitted_fraction_obs, context.packed_filters_jax)
+                direct_attenuated_obs = _redshift_to_obs(
+                    rest_wave, direct_attenuated_rest * igm, obs_wave, redshift, luminosity_distance_m
+                )
+                direct_intrinsic_obs = _redshift_to_obs(
+                    rest_wave, direct_intrinsic_rest * igm, obs_wave, redshift, luminosity_distance_m
+                )
+                direct_attenuated_fluxes = _project_filters(direct_attenuated_obs, context.packed_filters_jax)
+                direct_intrinsic_fluxes = _project_filters(direct_intrinsic_obs, context.packed_filters_jax)
+            trans_fluxes = _band_transmitted_fraction(direct_attenuated_fluxes, direct_intrinsic_fluxes)
         else:
             trans_fluxes = jnp.ones_like(pred_fluxes)
 

--- a/src/jaxsedfit/preload.py
+++ b/src/jaxsedfit/preload.py
@@ -361,6 +361,28 @@ def _scalar_angstrom_value(value) -> float:
     return float(value)
 
 
+def _inline_wavelengths_to_angstrom(values, wavelength_unit: str | None, label: str) -> np.ndarray:
+    """Convert explicitly unit-tagged inline template wavelengths to Angstrom."""
+    aliases = {
+        "angstrom": u.AA,
+        "angstroms": u.AA,
+        "aa": u.AA,
+        "a": u.AA,
+        "nm": u.nm,
+        "nanometer": u.nm,
+        "nanometers": u.nm,
+        "um": u.um,
+        "micron": u.um,
+        "microns": u.um,
+    }
+    unit_key = str(wavelength_unit).strip().lower()
+    try:
+        unit = aliases[unit_key]
+    except KeyError as exc:
+        raise ValueError(f"{label}.wavelength_unit must be one of: angstrom, nm, micron.") from exc
+    return np.asarray((np.asarray(values, dtype=float) * unit).to_value(u.AA), dtype=float)
+
+
 def _mw_band_attenuation_factor(wave_obs, filt_trans, ebv, r_v=3.1):
     """Compute the Milky Way attenuation factor integrated through one bandpass.
 
@@ -565,6 +587,8 @@ def _load_templates(cfg: FitConfig) -> LoadedTemplates:
         need_agn_templates,
         need_dust_templates,
         feii.name,
+        feii.wavelength_unit,
+        em.wavelength_unit,
         id(feii.wave),
         id(feii.lumin),
         id(em.wave),
@@ -597,9 +621,9 @@ def _load_templates(cfg: FitConfig) -> LoadedTemplates:
         return loaded
     if feii.wave is not None and em.wave is not None:
         loaded = LoadedTemplates(
-            feii_wave=np.asarray(feii.wave, dtype=float),
+            feii_wave=_inline_wavelengths_to_angstrom(feii.wave, feii.wavelength_unit, "agn.feii_template"),
             feii_lumin=np.asarray(feii.lumin, dtype=float),
-            line_wave=np.asarray(em.wave, dtype=float),
+            line_wave=_inline_wavelengths_to_angstrom(em.wave, em.wavelength_unit, "agn.emission_line_template"),
             line_blagn=np.asarray(em.lumin_blagn, dtype=float),
             line_sy2=np.asarray(em.lumin_sy2, dtype=float),
             line_liner=np.asarray(em.lumin_liner, dtype=float),
@@ -985,7 +1009,7 @@ def _build_igm_cache_jax(rest_wave: np.ndarray) -> IGMCacheJax:
     wavelength = jnp.asarray(rest_wave, dtype=jnp.float64)
     n_transitions_low = 10
     n_transitions_max = 31
-    lambda_limit = 91.2
+    lambda_limit = 912.0
     n_arr = jnp.arange(n_transitions_max, dtype=jnp.float64)
     lambda_n = jnp.where(n_arr >= 2, lambda_limit / (1.0 - 1.0 / jnp.maximum(n_arr * n_arr, 1.0)), 1.0)
     z_n = wavelength[None, :] / lambda_n[:, None] - 1.0
@@ -1073,7 +1097,7 @@ def _build_fixed_igm_jax(igm_cache: IGMCacheJax, redshift: float) -> jnp.ndarray
     )
     term4 = jnp.sum(term4_terms, axis=0)
     tau_l_lls = jnp.where(w, n0 * ((term1 - term2) * term3 - term4), 0.0)
-    lambda_min_igm = (1.0 + z) * 70.0
+    lambda_min_igm = (1.0 + z) * 700.0
     weight = jnp.where(obs_wavelength < lambda_min_igm, (obs_wavelength / lambda_min_igm) ** 2, 1.0)
     return jnp.exp(-tau_taun - tau_l_igm - tau_l_lls) * weight
 

--- a/tests/test_diffstar_host.py
+++ b/tests/test_diffstar_host.py
@@ -31,12 +31,13 @@ def _mock_config():
         filters=FilterSet(curves=[FilterCurve(name="f1", wave=[1000.0, 2000.0, 3000.0], transmission=[0.0, 1.0, 0.0])]),
         galaxy=GalaxyConfig(dsps_ssp_fn="fake.h5", rest_wave_max=10000.0, n_wave=2048, sfh_n_steps=16),
         agn=AGNConfig(
-            feii_template=FeIITemplate(name="fe", wave=[1000.0, 2000.0], lumin=[1.0, 0.5]),
+            feii_template=FeIITemplate(name="fe", wave=[1000.0, 2000.0], lumin=[1.0, 0.5], wavelength_unit="angstrom"),
             emission_line_template=EmissionLineTemplate(
                 wave=[121.6, 486.1],
                 lumin_blagn=[1.0, 0.5],
                 lumin_sy2=[0.2, 0.1],
                 lumin_liner=[0.1, 0.05],
+                wavelength_unit="angstrom",
             ),
         ),
         likelihood=LikelihoodConfig(),

--- a/tests/test_host_api.py
+++ b/tests/test_host_api.py
@@ -1,7 +1,8 @@
 import numpy as np
 import jax.numpy as jnp
 import numpyro
-from numpyro.handlers import seed, trace
+import pytest
+from numpyro.handlers import seed, substitute, trace
 
 from jaxsedfit.host import HostBasisJax, build_host_state, host_rest_on_basis
 
@@ -93,3 +94,55 @@ def test_public_host_rest_on_basis_reuses_sampled_weights():
     assert host_rest.shape == (5,)
     assert np.isfinite(np.asarray(host_rest, dtype=float)).all()
     assert np.allclose(np.asarray(host_rest), 2.0 * np.asarray(tr["public_host_rest"]["value"]))
+
+
+def _fixed_mass_host_trace(log_stellar_mass):
+    basis = _toy_host_basis()
+
+    def model():
+        state = build_host_state(
+            basis,
+            {"mass_metallicity_relation": {"enabled": False}},
+            host_sfh_model="delayed",
+            t_obs_gyr=1.2,
+        )
+        for key in (
+            "host_rest",
+            "host_ssp_weights",
+            "formed_mass",
+            "surviving_mass_fraction",
+            "gal_sfr_table",
+            "gal_smh_table",
+            "log_stellar_mass",
+        ):
+            numpyro.deterministic(f"mass_test_{key}", state[key])
+
+    fixed = substitute(model, data={"log_stellar_mass": jnp.asarray(log_stellar_mass)})
+    return trace(seed(fixed, 27)).get_trace()
+
+
+def test_host_luminosity_and_histories_scale_linearly_with_stellar_mass():
+    low = _fixed_mass_host_trace(8.0)
+    high = _fixed_mass_host_trace(9.0)
+
+    for key in ("host_rest", "formed_mass", "gal_sfr_table", "gal_smh_table"):
+        low_value = np.asarray(low[f"mass_test_{key}"]["value"], dtype=float)
+        high_value = np.asarray(high[f"mass_test_{key}"]["value"], dtype=float)
+        np.testing.assert_allclose(high_value, 10.0 * low_value, rtol=2.0e-12, atol=1.0e-20)
+    np.testing.assert_allclose(
+        np.asarray(high["mass_test_host_ssp_weights"]["value"]),
+        np.asarray(low["mass_test_host_ssp_weights"]["value"]),
+        rtol=0.0,
+        atol=0.0,
+    )
+
+
+def test_host_surviving_and_formed_mass_accounting_is_closed():
+    tr = _fixed_mass_host_trace(9.25)
+    formed = float(np.asarray(tr["mass_test_formed_mass"]["value"]))
+    surviving_fraction = float(np.asarray(tr["mass_test_surviving_mass_fraction"]["value"]))
+    target_surviving = 10.0 ** float(np.asarray(tr["mass_test_log_stellar_mass"]["value"]))
+    final_history_mass = float(np.asarray(tr["mass_test_gal_smh_table"]["value"])[-1])
+
+    assert formed * surviving_fraction == pytest.approx(target_surviving, rel=2.0e-12)
+    assert final_history_mass == pytest.approx(formed, rel=2.0e-12)

--- a/tests/test_model_assembly.py
+++ b/tests/test_model_assembly.py
@@ -75,12 +75,13 @@ def _cfg(
             fit_agn=fit_agn,
             fit_feii_broadening=fit_feii_broadening,
             fit_balmer_continuum=fit_balmer_continuum,
-            feii_template=FeIITemplate(name="fe", wave=[1000.0, 2000.0, 3000.0], lumin=[0.0, 1.0, 0.0]),
+            feii_template=FeIITemplate(name="fe", wave=[1000.0, 2000.0, 3000.0], lumin=[0.0, 1.0, 0.0], wavelength_unit="angstrom"),
             emission_line_template=EmissionLineTemplate(
                 wave=[486.1, 656.3],
                 lumin_blagn=[1.0, 0.5],
                 lumin_sy2=[0.2, 0.1],
                 lumin_liner=[0.1, 0.05],
+                wavelength_unit="angstrom",
             ),
         ),
         likelihood=LikelihoodConfig(
@@ -160,6 +161,19 @@ def _fixed_component_data():
         "balmer_tau": np.array(1.0),
         "balmer_vel": np.array(3000.0),
     }
+
+
+def test_attenuation_uncertainty_uses_dimensionless_band_flux_ratio(monkeypatch):
+    _patch_ssp(monkeypatch)
+    cfg = _cfg()
+    cfg.likelihood.attenuation_model_uncertainty = True
+    context = build_model_context(cfg)
+    tr = _deterministic_trace(context, _fixed_component_data())
+
+    transmitted = _site(tr, "transmitted_fraction_fluxes")
+    assert np.all(np.isfinite(transmitted))
+    assert np.all((transmitted >= 1.0e-4) & (transmitted <= 1.0))
+    assert np.any(transmitted < 0.99)
 
 
 def test_native_agn_lines_use_distinct_broad_and_narrow_widths(monkeypatch):

--- a/tests/test_model_helpers.py
+++ b/tests/test_model_helpers.py
@@ -38,6 +38,7 @@ from jaxsedfit.model import (
     GRAHSP_SI_EM_WIDTH_A,
     GRAHSP_TORUS_NORM_A,
     C_MS,
+    _band_transmitted_fraction,
     _attenuation_transmitted_fraction,
     _attenuation_curve,
     _apply_biattenuation,
@@ -80,6 +81,7 @@ from jaxsedfit.preload import (
     _build_host_basis,
     _lnu_lsun_per_hz_to_llambda_w_per_a_np,
     _load_filter_responses,
+    _load_templates,
     _mw_band_attenuation_factor,
     _mw_pixel_attenuation_factor,
     _load_vendored_dale2014_templates,
@@ -92,6 +94,37 @@ def test_likelihood_defaults_include_absolute_flux_scale_prior():
     assert cfg.absolute_flux_scale_prior_sigma_dex > 0.0
     assert cfg.use_local_line_photometry is True
     assert cfg.local_nebular_line_uncertainty_dex == pytest.approx(0.3)
+
+
+@pytest.mark.parametrize("redshift", [-0.1, np.nan, np.inf])
+def test_observation_rejects_invalid_redshift(redshift):
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        Observation(redshift=redshift).validate()
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"rest_wave_min": 0.0},
+        {"rest_wave_min": 1000.0, "rest_wave_max": 1000.0},
+        {"n_wave": 1},
+        {"sfh_n_steps": 1},
+    ],
+)
+def test_galaxy_rejects_invalid_internal_grids(kwargs):
+    with pytest.raises(ValueError):
+        GalaxyConfig(**kwargs).validate()
+
+
+def test_inline_templates_require_explicit_wavelength_units():
+    cfg = AGNConfig(
+        feii_template=FeIITemplate(wave=[1000.0, 2000.0], lumin=[1.0, 1.0]),
+        emission_line_template=EmissionLineTemplate(
+            wave=[5000.0], lumin_blagn=[1.0], lumin_sy2=[1.0], lumin_liner=[1.0]
+        ),
+    )
+    with pytest.raises(ValueError, match="wavelength_unit is required"):
+        cfg.validate()
 
 
 def test_photometry_method_is_normalized_metadata_only():
@@ -480,6 +513,11 @@ def test_attenuation_transmitted_fraction_uses_only_direct_light():
     np.testing.assert_allclose(frac[:2], [0.2, 0.8])
     assert frac[2] == pytest.approx(1.0e-4)
     assert np.all(total_emergent_fraction[:2] > frac[:2])
+
+
+def test_band_transmitted_fraction_is_dimensionless_ratio():
+    fraction = np.asarray(_band_transmitted_fraction([2.0, 8.0, 0.0], [10.0, 10.0, 0.0]))
+    np.testing.assert_allclose(fraction, [0.2, 0.8, 1.0])
 
 
 def test_extended_capture_leaves_compact_flux_unchanged_and_scales_extended_flux():
@@ -936,12 +974,13 @@ def test_build_context_with_inline_templates(monkeypatch):
         filters=FilterSet(curves=[FilterCurve(name="f1", wave=[1000.0, 2000.0, 3000.0], transmission=[0.0, 1.0, 0.0])]),
         galaxy=GalaxyConfig(dsps_ssp_fn="fake.h5", n_wave=64),
         agn=AGNConfig(
-            feii_template=FeIITemplate(name="fe", wave=[1000.0, 2000.0], lumin=[1.0, 0.5]),
+            feii_template=FeIITemplate(name="fe", wave=[1000.0, 2000.0], lumin=[1.0, 0.5], wavelength_unit="angstrom"),
             emission_line_template=EmissionLineTemplate(
                 wave=[121.6, 486.1],
                 lumin_blagn=[1.0, 0.5],
                 lumin_sy2=[0.2, 0.1],
                 lumin_liner=[0.1, 0.05],
+                wavelength_unit="nm",
             ),
         ),
         likelihood=LikelihoodConfig(),
@@ -962,6 +1001,7 @@ def test_build_context_with_inline_templates(monkeypatch):
     assert len(context.filters) == 1
     assert context.filters[0].name == "f1"
     assert context.templates.feii_wave.shape[0] == 2
+    np.testing.assert_allclose(context.templates.line_wave, [1216.0, 4861.0])
     assert context.templates.dust_alpha_grid.size > 0
     assert context.templates.dust_wave.size > 0
     assert context.templates.dust_lumin.ndim == 2
@@ -1413,12 +1453,13 @@ def test_jaxqsofit_backend_keeps_nebular_width_fixed_without_nebular_prior(monke
         filters=FilterSet(curves=[FilterCurve(name="f1", wave=[1000.0, 2000.0, 3000.0], transmission=[0.0, 1.0, 0.0])]),
         galaxy=GalaxyConfig(dsps_ssp_fn="fake.h5", n_wave=64, fit_host=True),
         agn=AGNConfig(
-            feii_template=FeIITemplate(name="fe", wave=[1000.0, 2000.0], lumin=[0.0, 0.0]),
+            feii_template=FeIITemplate(name="fe", wave=[1000.0, 2000.0], lumin=[0.0, 0.0], wavelength_unit="angstrom"),
             emission_line_template=EmissionLineTemplate(
                 wave=[5000.0],
                 lumin_blagn=[0.0],
                 lumin_sy2=[0.0],
                 lumin_liner=[0.0],
+                wavelength_unit="angstrom",
             ),
         ),
         nebular=NebularConfig(enabled=True, zgas=0.02),
@@ -1473,12 +1514,13 @@ def test_jaxsedfit_model_can_call_jaxqsofit_backend(monkeypatch):
         filters=FilterSet(curves=[FilterCurve(name="f1", wave=[1000.0, 2000.0, 3000.0], transmission=[0.0, 1.0, 0.0])]),
         galaxy=GalaxyConfig(dsps_ssp_fn="fake.h5", n_wave=64, fit_host=False),
         agn=AGNConfig(
-            feii_template=FeIITemplate(name="fe", wave=[1000.0, 2000.0], lumin=[0.0, 0.0]),
+            feii_template=FeIITemplate(name="fe", wave=[1000.0, 2000.0], lumin=[0.0, 0.0], wavelength_unit="angstrom"),
             emission_line_template=EmissionLineTemplate(
                 wave=[486.1],
                 lumin_blagn=[0.0],
                 lumin_sy2=[0.0],
                 lumin_liner=[0.0],
+                wavelength_unit="angstrom",
             ),
         ),
         likelihood=LikelihoodConfig(
@@ -1805,7 +1847,7 @@ def test_config_rejects_invalid_redshift_pdf():
 
 
 def test_igm_transmission_on_rest_grid_is_near_unity_redward_of_lyman_alpha():
-    rest_wave = np.array([150.0, 121.6, 100.0, 91.2, 80.0], dtype=float)
+    rest_wave = np.array([1500.0, 1216.0, 1000.0, 912.0, 800.0], dtype=float)
     cache = _build_igm_cache_jax(rest_wave)
     transmission = np.asarray(_build_fixed_igm_jax(cache, 1.0), dtype=float)
 
@@ -1817,7 +1859,7 @@ def test_igm_transmission_on_rest_grid_is_near_unity_redward_of_lyman_alpha():
 
 
 def test_dynamic_and_fixed_igm_evaluators_match():
-    rest_wave = np.array([150.0, 121.6, 100.0, 91.2, 80.0], dtype=float)
+    rest_wave = np.array([1500.0, 1216.0, 1000.0, 912.0, 800.0], dtype=float)
     cache = _build_igm_cache_jax(rest_wave)
 
     fixed = np.asarray(_build_fixed_igm_jax(cache, 2.0), dtype=float)

--- a/tests/test_nebular.py
+++ b/tests/test_nebular.py
@@ -33,12 +33,13 @@ def _mock_config():
         galaxy=GalaxyConfig(dsps_ssp_fn="fake.h5", rest_wave_min=100.0, rest_wave_max=10000.0, n_wave=96, sfh_n_steps=16),
         agn=AGNConfig(
             fit_agn=False,
-            feii_template=FeIITemplate(name="fe", wave=[1000.0, 2000.0], lumin=[1.0, 0.5]),
+            feii_template=FeIITemplate(name="fe", wave=[1000.0, 2000.0], lumin=[1.0, 0.5], wavelength_unit="angstrom"),
             emission_line_template=EmissionLineTemplate(
                 wave=[121.6, 486.1],
                 lumin_blagn=[1.0, 0.5],
                 lumin_sy2=[0.2, 0.1],
                 lumin_liner=[0.1, 0.05],
+                wavelength_unit="angstrom",
             ),
         ),
         inference=InferenceConfig(map_steps=2),

--- a/tests/test_physical_invariants.py
+++ b/tests/test_physical_invariants.py
@@ -1,0 +1,251 @@
+"""Physical and numerical invariants for the JAXSEDfit forward model."""
+
+from types import SimpleNamespace
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from jaxsedfit.config import FilterCurve
+from jaxsedfit.model import (
+    _apply_biattenuation,
+    _host_dust_emission,
+    _powerlaw_jax,
+    _project_filters,
+    _redshift_to_obs,
+    _torus_component,
+)
+from jaxsedfit.preload import (
+    _build_filter_projection_matrices_for_redshift,
+    _build_fixed_filter_projection_matrices,
+    _load_vendored_dale2014_templates,
+    _pack_loaded_filters,
+    _pack_loaded_filters_jax,
+    _prepare_loaded_filter,
+)
+
+
+def _smooth_filter(name: str, center: float, half_width: float, n: int = 257) -> FilterCurve:
+    wave = np.linspace(center - half_width, center + half_width, n)
+    transmission = np.maximum(1.0 - np.abs(wave - center) / half_width, 0.0)
+    return FilterCurve(name=name, wave=wave, transmission=transmission)
+
+
+@pytest.mark.parametrize("profile", ["top_hat", "triangle"])
+@pytest.mark.parametrize("power", [0, 1, 2])
+def test_synthetic_photometry_matches_analytic_polynomial_moments(profile, power):
+    """Filter integration and f_lambda-to-mJy conversion match analytic moments."""
+    center = 6000.0
+    half_width = 1000.0
+    obs_wave = np.linspace(3000.0, 9000.0, 12001)
+    if profile == "top_hat":
+        filter_wave = np.linspace(center - half_width, center + half_width, 1001)
+        transmission = np.ones_like(filter_wave)
+        second_moment = center**2 + half_width**2 / 3.0
+    else:
+        filter_wave = np.linspace(center - half_width, center + half_width, 1001)
+        transmission = np.maximum(1.0 - np.abs(filter_wave - center) / half_width, 0.0)
+        second_moment = center**2 + half_width**2 / 6.0
+    curve = FilterCurve(name=profile, wave=filter_wave, transmission=transmission)
+    packed = _pack_loaded_filters_jax(_pack_loaded_filters([_prepare_loaded_filter(obs_wave, curve)]))
+    amplitude = 2.5e-20
+    flux_lambda = amplitude * (obs_wave / center) ** power
+
+    projected = float(np.asarray(_project_filters(flux_lambda, packed))[0])
+    if power == 0:
+        mean_flux_lambda = amplitude
+    elif power == 1:
+        mean_flux_lambda = amplitude
+    else:
+        mean_flux_lambda = amplitude * second_moment / center**2
+    conversion = 1.0e-10 / 299792458.0 * 1.0e29 * center**2
+    assert projected == pytest.approx(conversion * mean_flux_lambda, rel=2.0e-7)
+
+
+def test_flat_fnu_matches_documented_effective_wavelength_convention():
+    """A flat f_nu spectrum follows the code's explicit effective-lambda convention."""
+    center = 7000.0
+    curve = _smooth_filter("broad", center, 2500.0, n=2001)
+    obs_wave = np.linspace(3000.0, 11000.0, 16001)
+    loaded = _prepare_loaded_filter(obs_wave, curve)
+    packed = _pack_loaded_filters_jax(_pack_loaded_filters([loaded]))
+    target_mjy = 3.2
+    conversion_at_wave = 1.0e-10 / 299792458.0 * 1.0e29 * obs_wave**2
+    flat_fnu_as_flambda = target_mjy / conversion_at_wave
+
+    projected = float(np.asarray(_project_filters(flat_fnu_as_flambda, packed))[0])
+    work = loaded.work_wave
+    trans = loaded.transmission
+    mean_inverse_square = np.trapezoid(trans / work**2, work) / np.trapezoid(trans, work)
+    expected = target_mjy * loaded.effective_wavelength**2 * mean_inverse_square
+    assert projected == pytest.approx(expected, rel=2.0e-7)
+
+
+def test_filter_curve_resampling_invariance():
+    """Equivalent samplings of a triangular bandpass produce stable photometry."""
+    obs_wave = np.linspace(3500.0, 8500.0, 20001)
+    flux_lambda = 1.7e-20 * (obs_wave / 6000.0) ** 1.3
+    results = []
+    for n_filter in (17, 65, 257, 1025):
+        curve = _smooth_filter("triangle", 6000.0, 1400.0, n=n_filter)
+        packed = _pack_loaded_filters_jax(_pack_loaded_filters([_prepare_loaded_filter(obs_wave, curve)]))
+        results.append(float(np.asarray(_project_filters(flux_lambda, packed))[0]))
+
+    np.testing.assert_allclose(results, results[-1], rtol=2.0e-5, atol=0.0)
+
+
+def test_narrow_feature_moves_continuously_across_filter_edge():
+    """A narrow feature entering a linear filter edge has monotonic throughput."""
+    obs_wave = np.linspace(4000.0, 8000.0, 40001)
+    curve = _smooth_filter("triangle", 6000.0, 1500.0, n=2001)
+    packed = _pack_loaded_filters_jax(_pack_loaded_filters([_prepare_loaded_filter(obs_wave, curve)]))
+    centers = np.asarray([4400.0, 4550.0, 4800.0, 5200.0, 5600.0])
+    projected = []
+    for feature_center in centers:
+        feature = np.exp(-0.5 * ((obs_wave - feature_center) / 8.0) ** 2)
+        projected.append(float(np.asarray(_project_filters(feature, packed))[0]))
+
+    assert projected[0] < projected[1] < projected[2] < projected[3] < projected[4]
+
+
+@pytest.mark.parametrize("redshift", [0.01, 0.3, 1.5, 4.0])
+@pytest.mark.parametrize("shape", ["flat", "powerlaw", "curved"])
+def test_fast_and_direct_filter_projection_parity(redshift, shape):
+    """Cached matrix projection must reproduce the direct observed-grid path."""
+    rest_wave = np.geomspace(500.0, 3.0e5, 4096)
+    obs_wave = rest_wave * (1.0 + redshift)
+    x = rest_wave / 5100.0
+    if shape == "flat":
+        rest_lum = np.full_like(rest_wave, 2.0e31)
+    elif shape == "powerlaw":
+        rest_lum = 2.0e31 * x**-1.3
+    else:
+        rest_lum = 2.0e31 * x**-0.7 * np.exp(-0.5 * (np.log10(rest_wave / 9000.0) / 0.35) ** 2)
+    igm = np.where(rest_wave < 1216.0, 0.63, 1.0)
+    distance_m = 2.4e25
+    curves = [
+        _smooth_filter("optical", 5500.0 * (1.0 + redshift), 1100.0),
+        _smooth_filter("nir", 18000.0 * (1.0 + redshift), 3500.0),
+    ]
+    loaded = [_prepare_loaded_filter(obs_wave, curve) for curve in curves]
+    packed_np = _pack_loaded_filters(loaded)
+    packed_jax = _pack_loaded_filters_jax(packed_np)
+
+    obs_flux = _redshift_to_obs(rest_wave, rest_lum * igm, obs_wave, redshift, distance_m)
+    direct = np.asarray(_project_filters(obs_flux, packed_jax))
+    fixed, _ = _build_fixed_filter_projection_matrices(
+        rest_wave, packed_np, igm, distance_m, redshift
+    )
+    arbitrary_z, _ = _build_filter_projection_matrices_for_redshift(
+        rest_wave, packed_np, igm, distance_m, redshift
+    )
+
+    np.testing.assert_allclose(fixed @ rest_lum, direct, rtol=2.0e-12, atol=0.0)
+    np.testing.assert_allclose(arbitrary_z @ rest_lum, direct, rtol=3.0e-4, atol=0.0)
+
+
+@pytest.mark.parametrize("redshift", [0.0, 0.1, 1.0, 3.0, 7.0])
+@pytest.mark.parametrize("shape", ["flat", "powerlaw", "gaussian"])
+def test_redshift_projection_conserves_bolometric_flux(redshift, shape):
+    """Integrating observed f_lambda must recover L/(4 pi D_L^2)."""
+    rest_wave = np.geomspace(700.0, 2.0e5, 32768)
+    if shape == "flat":
+        rest_lum = np.full_like(rest_wave, 3.0e28)
+    elif shape == "powerlaw":
+        rest_lum = 3.0e28 * (rest_wave / 5000.0) ** -1.4
+    else:
+        rest_lum = 3.0e28 * np.exp(-0.5 * ((rest_wave - 8000.0) / 1200.0) ** 2)
+    obs_wave = rest_wave * (1.0 + redshift)
+    distance_m = 1.0e24 if redshift == 0.0 else 3.0e25
+    obs_flux = np.asarray(_redshift_to_obs(rest_wave, rest_lum, obs_wave, redshift, distance_m))
+
+    observed_integral = np.trapezoid(obs_flux, obs_wave)
+    expected = np.trapezoid(rest_lum, rest_wave) / (4.0 * np.pi * distance_m**2)
+    assert observed_integral == pytest.approx(expected, rel=2.0e-12)
+    sample = rest_wave.size // 3
+    expected_density = rest_lum[sample] / (4.0 * np.pi * distance_m**2 * (1.0 + redshift))
+    assert obs_flux[sample] == pytest.approx(expected_density, rel=2.0e-12)
+
+
+@pytest.mark.parametrize("ebv", [0.0, 0.05, 0.3, 1.0])
+@pytest.mark.parametrize("dust_alpha", [1.0, 2.0, 3.0])
+def test_host_dust_energy_balance(ebv, dust_alpha):
+    """The normalized Dale template must reradiate absorbed host luminosity."""
+    alpha_grid, dust_wave, dust_grid = _load_vendored_dale2014_templates()
+    rest_wave = np.unique(np.concatenate([np.geomspace(100.0, 3.0e7, 32768), dust_wave]))
+    host = 4.0e28 * (rest_wave / 5500.0) ** -0.8 * np.exp(-rest_wave / 8.0e5)
+    zeros = np.zeros_like(host)
+    _, _, _, absorbed = _apply_biattenuation(
+        rest_wave, host, zeros, ebv, 0.0, -1.2, -3.0, 1.2, 11000.0
+    )
+    dust_on_rest = np.stack(
+        [np.interp(rest_wave, dust_wave, row, left=0.0, right=0.0) for row in dust_grid]
+    )
+    context = SimpleNamespace(
+        dust_alpha_grid_jax=jnp.asarray(alpha_grid),
+        dust_lumin_rest_jax=jnp.asarray(dust_on_rest),
+    )
+    emitted = np.asarray(_host_dust_emission(context, absorbed, dust_alpha))
+
+    emitted_integral = np.trapezoid(emitted, rest_wave)
+    assert emitted_integral == pytest.approx(float(absorbed), rel=2.0e-3, abs=1.0e-20)
+    assert np.all(emitted >= 0.0)
+
+
+def _smooth_component_photometry(n_wave: int) -> tuple[np.ndarray, float]:
+    rest_wave = np.geomspace(500.0, 3.0e6, n_wave)
+    redshift = 0.4
+    distance_m = 2.0e25
+    disk = np.asarray(
+        _powerlaw_jax(rest_wave, 1.0e34, 0.0, -1.8, 5100.0, 1000.0, 10.0, 100000.0)
+    )
+    torus = np.asarray(
+        _torus_component(
+            rest_wave,
+            0.2,
+            0.0,
+            17.0,
+            0.45,
+            2.0,
+            0.5,
+            0.1,
+            0.29,
+            98410.0,
+            142240.0,
+            10253.0,
+            11635.0,
+            5.1e37,
+        )
+    )
+    total = disk + torus
+    obs_wave = rest_wave * (1.0 + redshift)
+    filters = [
+        _smooth_filter("uv", 2500.0 * (1.0 + redshift), 500.0),
+        _smooth_filter("opt", 5100.0 * (1.0 + redshift), 1200.0),
+        _smooth_filter("nir", 20000.0 * (1.0 + redshift), 5000.0),
+        _smooth_filter("mir", 120000.0 * (1.0 + redshift), 30000.0),
+    ]
+    packed = _pack_loaded_filters_jax(
+        _pack_loaded_filters([_prepare_loaded_filter(obs_wave, curve) for curve in filters])
+    )
+    obs_flux = _redshift_to_obs(rest_wave, total, obs_wave, redshift, distance_m)
+    photometry = np.asarray(_project_filters(obs_flux, packed))
+    bolometric = float(np.trapezoid(total, rest_wave))
+    return photometry, bolometric
+
+
+def test_smooth_components_converge_with_wavelength_grid_resolution():
+    """Disk/torus photometry and luminosity should converge under grid refinement."""
+    reference_photometry, reference_bolometric = _smooth_component_photometry(32768)
+    errors = []
+    for n_wave in (256, 2048, 8192):
+        photometry, bolometric = _smooth_component_photometry(n_wave)
+        error = max(
+            float(np.max(np.abs(photometry / reference_photometry - 1.0))),
+            abs(bolometric / reference_bolometric - 1.0),
+        )
+        errors.append(error)
+
+    assert errors[1] < errors[0]
+    assert errors[2] < errors[1]
+    assert errors[-1] < 5.0e-4


### PR DESCRIPTION
## Summary

- correct IGM wavelength thresholds and make inline Fe II/emission-template wavelength units explicit
- validate redshift and wavelength-grid inputs and fix bandwise attenuation projection units
- add physical invariant coverage for projection parity, redshift flux conservation, dust energy balance, grid convergence, synthetic photometry, and host mass accounting

## Why

The model audit found wavelength-unit ambiguities, incorrect nanometer-to-angstrom constants in IGM attenuation, and a dimensionally inconsistent scalar attenuation projection. These could silently bias model photometry or allow invalid grids and redshifts into compiled calculations.

## Impact

Inline spectral templates now require an explicit wavelength unit, invalid model grids fail early, and attenuation is projected as a dimensionless band transmission. The new regression and invariant tests cover the corrected behavior without requiring GRAHSP.

## Validation

- `MPLCONFIGDIR=/tmp/matplotlib conda run -n jaxcpu pytest -q`
- 212 passed
- `git diff --check`
