### PR TITLE
Make SSP provenance explicit and harden likelihoods

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -348,7 +348,6 @@ templates justify:
    cfg.likelihood.likelihood_family = "gaussian"
    cfg.likelihood.systematics_width = 0.10
    cfg.likelihood.fit_systematics_width = True
-   cfg.likelihood.use_absolute_flux_scale_prior = True
 
 Useful options:
 
@@ -359,10 +358,6 @@ Useful options:
 ``systematics_width``
    Fractional model-error floor. Fix it for simpler geometry, or sample it
    with ``fit_systematics_width=True`` when the data warrant it.
-
-``use_absolute_flux_scale_prior``
-   Adds a broad prior on absolute scale so mass, AGN amplitude, and systematic
-   scatter do not drift into implausible combinations.
 
 ``variability_uncertainty``
    Adds an AGN variability term to photometric uncertainty when AGN emission is

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -223,10 +223,21 @@ low-dimensional and usually the most stable choice for broadband SED fitting.
        fit_host=True,
        host_sfh_model="delayed",
        dsps_ssp_fn="tempdata.h5",
+       ssp_imf="chabrier_2003",
+       ssp_metallicity_coordinate="absolute_log10_z",
+       ssp_solar_metallicity=0.019,
        rest_wave_min=100.0,
        rest_wave_max=3.0e6,
        n_wave=1024,
    )
+
+``ssp_imf`` and ``ssp_metallicity_coordinate`` declare the provenance of the
+loaded SSP library. They do not regenerate it. The IMF declaration also selects
+the matching DSPS surviving-mass calibration, so it must describe the SSP file
+accurately. Supported IMFs are ``chabrier_2003``, ``salpeter_1955``,
+``kroupa_2001``, and ``van_dokkum_2008``. Supported metallicity coordinates are
+``absolute_log10_z`` and ``log10_z_over_zsun``. Custom IMFs require an SSP format
+that supplies its own surviving-mass fractions and are not silently approximated.
 
 Use ``host_sfh_model="diffstar"`` when you want the Diffstar-based SFH
 parameterization:

--- a/src/jaxsedfit/config.py
+++ b/src/jaxsedfit/config.py
@@ -295,8 +295,6 @@ class LikelihoodConfig:
     agn_nev: float = 0.1
     attenuation_model_uncertainty: bool = False
     lyman_break_uncertainty: bool = False
-    use_absolute_flux_scale_prior: bool = True
-    absolute_flux_scale_prior_sigma_dex: float = 0.5
     use_host_capture_model: bool = False
     use_fast_photometry_projection: bool = True
     use_local_line_photometry: bool = True

--- a/src/jaxsedfit/config.py
+++ b/src/jaxsedfit/config.py
@@ -156,16 +156,20 @@ class EmissionLineTemplate:
 
 @dataclass
 class GalaxyConfig:
-    """Host-galaxy model, cosmology, and wavelength-grid settings."""
+    """Host-galaxy model, SSP provenance, cosmology, and wavelength-grid settings.
+
+    ``ssp_imf`` and ``ssp_metallicity_coordinate`` describe the already-built
+    library at ``dsps_ssp_fn``; they do not regenerate or transform that file.
+    The IMF declaration selects the matching stellar surviving-mass
+    calibration used to convert between formed and surviving mass.
+    """
     fit_host: bool = True
     fit_host_kinematics: bool = False
     host_sfh_model: str = "delayed"
     dsps_ssp_fn: str = "tempdata.h5"
-    age_grid_gyr: Sequence[float] = (0.1, 0.3, 1.0, 3.0, 10.0)
-    logzsol_grid: Sequence[float] = (-1.0, -0.5, 0.0, 0.2)
-    imf_type: int = 1
-    zcontinuous: int = 1
-    sfh: int = 0
+    ssp_imf: str = "chabrier_2003"
+    ssp_metallicity_coordinate: str = "absolute_log10_z"
+    ssp_solar_metallicity: float = 0.019
     rest_wave_min: float = 100.0
     rest_wave_max: float = 3.0e6
     n_wave: int = 1024
@@ -181,6 +185,18 @@ class GalaxyConfig:
 
     def validate(self) -> None:
         """Validate the internal Angstrom wavelength grid and SFH grid."""
+        supported_imfs = {"chabrier_2003", "salpeter_1955", "kroupa_2001", "van_dokkum_2008"}
+        self.ssp_imf = str(self.ssp_imf).strip().lower()
+        if self.ssp_imf not in supported_imfs:
+            supported = ", ".join(sorted(supported_imfs))
+            raise ValueError(f"galaxy.ssp_imf must be one of: {supported}.")
+        supported_coordinates = {"absolute_log10_z", "log10_z_over_zsun"}
+        self.ssp_metallicity_coordinate = str(self.ssp_metallicity_coordinate).strip().lower()
+        if self.ssp_metallicity_coordinate not in supported_coordinates:
+            supported = ", ".join(sorted(supported_coordinates))
+            raise ValueError(f"galaxy.ssp_metallicity_coordinate must be one of: {supported}.")
+        if not np.isfinite(float(self.ssp_solar_metallicity)) or float(self.ssp_solar_metallicity) <= 0.0:
+            raise ValueError("galaxy.ssp_solar_metallicity must be positive and finite.")
         if not np.isfinite(float(self.rest_wave_min)) or float(self.rest_wave_min) <= 0.0:
             raise ValueError("galaxy.rest_wave_min must be positive and finite (Angstrom).")
         if not np.isfinite(float(self.rest_wave_max)) or float(self.rest_wave_max) <= float(self.rest_wave_min):

--- a/src/jaxsedfit/core.py
+++ b/src/jaxsedfit/core.py
@@ -345,7 +345,6 @@ class JAXSEDFit:
             "log_host_capture_scale_arcsec_fit",
             "host_capture_slope_fit",
             "transmitted_fraction_fluxes",
-            "absolute_flux_scale_logprior",
         ]
         if kind == "photometry":
             return photometry_sites
@@ -1081,8 +1080,6 @@ class JAXSEDFit:
                 out["log_agn_bol_luminosity_fit"] = float(np.median(np.asarray(state.predictive["log_agn_bol_luminosity_fit"], dtype=float)))
             if "log_disk_luminosity_fit" in state.predictive:
                 out["log_disk_luminosity_fit"] = float(np.median(np.asarray(state.predictive["log_disk_luminosity_fit"], dtype=float)))
-            if "absolute_flux_scale_logprior" in state.predictive:
-                out["absolute_flux_scale_logprior"] = float(np.median(np.asarray(state.predictive["absolute_flux_scale_logprior"], dtype=float)))
         state.summary = out
         return out
 

--- a/src/jaxsedfit/host.py
+++ b/src/jaxsedfit/host.py
@@ -18,6 +18,7 @@ def build_host_basis_jax(
     rest_wave: np.ndarray,
     *,
     dsps_ssp_fn: str = "tempdata.h5",
+    ssp_imf: str = "chabrier_2003",
     t_obs_gyr: float,
     sfh_n_steps: int = 64,
     sfh_t_min_gyr: float = 0.01,
@@ -34,6 +35,8 @@ def build_host_basis_jax(
         rest_wave value.
     dsps_ssp_fn : object
         dsps_ssp_fn value.
+    ssp_imf : str
+        IMF provenance of the SSP library and surviving-mass calibration.
     t_obs_gyr : object
         t_obs_gyr value.
     sfh_n_steps : object
@@ -50,7 +53,7 @@ def build_host_basis_jax(
         max(float(t_obs_gyr), float(sfh_t_min_gyr) * 1.01),
         int(sfh_n_steps),
     )
-    host_basis = _build_host_basis(rest_wave, ssp_data)
+    host_basis = _build_host_basis(rest_wave, ssp_data, ssp_imf)
     return _build_host_basis_jax(ssp_data, host_basis, gal_t_table)
 
 
@@ -63,6 +66,8 @@ def build_host_state(
     redshift: float = 0.0,
     sfh_t_min_gyr: float = 0.01,
     tau_host_prior_scale: float = 0.5,
+    ssp_metallicity_coordinate: str = "absolute_log10_z",
+    ssp_solar_metallicity: float = 0.019,
     full_output: bool = True,
 ) -> dict[str, Any]:
     """Sample/build the JAXSEDFit physical host state from a host basis.
@@ -89,6 +94,10 @@ def build_host_state(
         sfh_t_min_gyr value.
     tau_host_prior_scale : object
         tau_host_prior_scale value.
+    ssp_metallicity_coordinate : str
+        Coordinate used by ``host_basis_jax.ssp_lgmet``.
+    ssp_solar_metallicity : float
+        Absolute solar metallicity used for coordinate conversion.
     full_output : object
         full_output value.
     """
@@ -96,6 +105,8 @@ def build_host_state(
         host_sfh_model=str(host_sfh_model),
         sfh_t_min_gyr=float(sfh_t_min_gyr),
         tau_host_prior_scale=float(tau_host_prior_scale),
+        ssp_metallicity_coordinate=str(ssp_metallicity_coordinate),
+        ssp_solar_metallicity=float(ssp_solar_metallicity),
     )
     observation = SimpleNamespace(redshift=float(redshift))
     context = SimpleNamespace(

--- a/src/jaxsedfit/model.py
+++ b/src/jaxsedfit/model.py
@@ -425,21 +425,33 @@ def _sample_log_stellar_mass(prior_config: dict[str, Any]):
     return _sample_prior(prior_config, "log_stellar_mass", dist.StudentT(df=5.0, loc=10.0, scale=2.0))
 
 
-def _ssp_lgmet_solar_offset(ssp_lgmet):
-    """Return the solar-metallicity offset for the SSP metallicity convention.
+def _ssp_lgmet_solar_offset(
+    ssp_lgmet,
+    metallicity_coordinate: str = "absolute_log10_z",
+    solar_metallicity: float = DSPS_SOLAR_METALLICITY,
+):
+    """Return the declared solar-metallicity offset of an SSP grid.
 
     Parameters
     ----------
     ssp_lgmet : object
         ssp_lgmet value.
     """
-    ssp_lgmet = jnp.asarray(ssp_lgmet, dtype=jnp.float64)
-    # DSPS SSP grids use absolute log10(Z). Older/simple test grids may use
-    # log10(Z/Zsun). A max below -1 is a robust signature of absolute log10(Z).
-    return jnp.where(jnp.nanmax(ssp_lgmet) < -1.0, jnp.log10(DSPS_SOLAR_METALLICITY), 0.0)
+    del ssp_lgmet
+    coordinate = str(metallicity_coordinate).strip().lower()
+    if coordinate == "absolute_log10_z":
+        return jnp.log10(jnp.asarray(solar_metallicity, dtype=jnp.float64))
+    if coordinate == "log10_z_over_zsun":
+        return jnp.asarray(0.0, dtype=jnp.float64)
+    raise ValueError(f"Unsupported SSP metallicity coordinate: {metallicity_coordinate!r}.")
 
 
-def _gal_lgmet_to_absolute_z(gal_lgmet, ssp_lgmet):
+def _gal_lgmet_to_absolute_z(
+    gal_lgmet,
+    ssp_lgmet=None,
+    metallicity_coordinate: str = "absolute_log10_z",
+    solar_metallicity: float = DSPS_SOLAR_METALLICITY,
+):
     """Convert galaxy metallicity from the SSP-grid convention to absolute Z.
 
     Parameters
@@ -450,16 +462,22 @@ def _gal_lgmet_to_absolute_z(gal_lgmet, ssp_lgmet):
         ssp_lgmet value.
     """
     gal_lgmet = jnp.asarray(gal_lgmet, dtype=jnp.float64)
-    ssp_lgmet = jnp.asarray(ssp_lgmet, dtype=jnp.float64)
-    absolute_logz = jnp.where(
-        jnp.nanmax(ssp_lgmet) < -1.0,
-        gal_lgmet,
-        gal_lgmet + jnp.log10(DSPS_SOLAR_METALLICITY),
-    )
+    del ssp_lgmet
+    coordinate = str(metallicity_coordinate).strip().lower()
+    if coordinate == "absolute_log10_z":
+        absolute_logz = gal_lgmet
+    elif coordinate == "log10_z_over_zsun":
+        absolute_logz = gal_lgmet + jnp.log10(jnp.asarray(solar_metallicity, dtype=jnp.float64))
+    else:
+        raise ValueError(f"Unsupported SSP metallicity coordinate: {metallicity_coordinate!r}.")
     return jnp.power(10.0, absolute_logz)
 
 
-def _default_gal_lgmet_loc(ssp_lgmet):
+def _default_gal_lgmet_loc(
+    ssp_lgmet,
+    metallicity_coordinate: str = "absolute_log10_z",
+    solar_metallicity: float = DSPS_SOLAR_METALLICITY,
+):
     """Default galaxy metallicity center in the SSP grid's metallicity convention.
 
     Parameters
@@ -468,7 +486,7 @@ def _default_gal_lgmet_loc(ssp_lgmet):
         ssp_lgmet value.
     """
     ssp_lgmet = jnp.asarray(ssp_lgmet, dtype=jnp.float64)
-    loc = _ssp_lgmet_solar_offset(ssp_lgmet) - 0.3
+    loc = _ssp_lgmet_solar_offset(ssp_lgmet, metallicity_coordinate, solar_metallicity) - 0.3
     return jnp.clip(loc, jnp.nanmin(ssp_lgmet), jnp.nanmax(ssp_lgmet))
 
 
@@ -522,6 +540,8 @@ def _mass_metallicity_relation_logprior(
     *,
     ssp_lgmet=None,
     redshift: float = 0.0,
+    metallicity_coordinate: str = "absolute_log10_z",
+    solar_metallicity: float = DSPS_SOLAR_METALLICITY,
 ):
     """Return an optional soft stellar mass-metallicity log-prior.
 
@@ -567,7 +587,11 @@ def _mass_metallicity_relation_logprior(
     if not isinstance(cfg, dict) or cfg.get("enabled", True) is False:
         return jnp.asarray(0.0, dtype=jnp.float64)
 
-    solar_offset = _ssp_lgmet_solar_offset(ssp_lgmet) if ssp_lgmet is not None else jnp.asarray(0.0, dtype=jnp.float64)
+    solar_offset = (
+        _ssp_lgmet_solar_offset(ssp_lgmet, metallicity_coordinate, solar_metallicity)
+        if ssp_lgmet is not None
+        else jnp.asarray(0.0, dtype=jnp.float64)
+    )
     pivot_mass = jnp.asarray(cfg.get("pivot_mass", 10.0), dtype=jnp.float64)
     pivot_lgmet = _cfg_lgmet_value(cfg, "pivot_logzsol", -0.15, solar_offset, absolute_key="pivot_lgmet")
     slope = jnp.asarray(cfg.get("slope", 0.35), dtype=jnp.float64)
@@ -1577,6 +1601,7 @@ def _build_diffstar_host(context: ModelContext, prior_config: dict[str, Any], *,
     surviving_frac_by_age = context.host_basis_jax.surviving_frac_by_age
     gal_t_table = context.host_basis_jax.gal_t_table
     t_obs_gyr = jnp.asarray(context.t_obs_gyr, dtype=jnp.float64)
+    galaxy_cfg = context.fit_config.galaxy
 
     log_stellar_mass = _sample_log_stellar_mass(prior_config)
 
@@ -1594,7 +1619,18 @@ def _build_diffstar_host(context: ModelContext, prior_config: dict[str, Any], *,
         return_smh=True,
     )
 
-    gal_lgmet = _sample_prior(prior_config, "gal_lgmet", dist.Normal(_default_gal_lgmet_loc(ssp_lgmet), 0.5))
+    gal_lgmet = _sample_prior(
+        prior_config,
+        "gal_lgmet",
+        dist.Normal(
+            _default_gal_lgmet_loc(
+                ssp_lgmet,
+                galaxy_cfg.ssp_metallicity_coordinate,
+                galaxy_cfg.ssp_solar_metallicity,
+            ),
+            0.5,
+        ),
+    )
     gal_lgmet_scatter = _sample_positive_distribution(
         prior_config,
         value_key="gal_lgmet_scatter",
@@ -1609,6 +1645,8 @@ def _build_diffstar_host(context: ModelContext, prior_config: dict[str, Any], *,
         prior_config,
         ssp_lgmet=ssp_lgmet,
         redshift=float(context.fit_config.observation.redshift),
+        metallicity_coordinate=galaxy_cfg.ssp_metallicity_coordinate,
+        solar_metallicity=galaxy_cfg.ssp_solar_metallicity,
     )
     numpyro.factor("mass_metallicity_relation_prior", mmr_logprior)
     host_weights_info = calc_ssp_weights_sfh_table_lognormal_mdf(
@@ -1710,7 +1748,18 @@ def _build_delayed_host(context: ModelContext, prior_config: dict[str, Any], *, 
     base_sfh = jnp.where((sfh_age_gyr > 0.0) & (sfh_age_gyr <= age_gyr), sfh_age_gyr * jnp.exp(-sfh_age_gyr / tau_gyr), 0.0)
     base_smh = _cumulative_trapezoid(base_sfh, gal_t_table) * 1.0e9
 
-    gal_lgmet = _sample_prior(prior_config, "gal_lgmet", dist.Normal(_default_gal_lgmet_loc(ssp_lgmet), 0.5))
+    gal_lgmet = _sample_prior(
+        prior_config,
+        "gal_lgmet",
+        dist.Normal(
+            _default_gal_lgmet_loc(
+                ssp_lgmet,
+                cfg.ssp_metallicity_coordinate,
+                cfg.ssp_solar_metallicity,
+            ),
+            0.5,
+        ),
+    )
     gal_lgmet_scatter = _sample_positive_distribution(
         prior_config,
         value_key="gal_lgmet_scatter",
@@ -1725,6 +1774,8 @@ def _build_delayed_host(context: ModelContext, prior_config: dict[str, Any], *, 
         prior_config,
         ssp_lgmet=ssp_lgmet,
         redshift=float(context.fit_config.observation.redshift),
+        metallicity_coordinate=cfg.ssp_metallicity_coordinate,
+        solar_metallicity=cfg.ssp_solar_metallicity,
     )
     numpyro.factor("mass_metallicity_relation_prior", mmr_logprior)
     host_weights_info = calc_ssp_weights_sfh_table_lognormal_mdf(
@@ -1889,7 +1940,12 @@ def _build_nebular_components(context: ModelContext, host_state: dict[str, Any],
 
     logu = _sample_optional_normal(prior_config, "nebular_logU", float(cfg.logU), 0.3)
     default_zgas = float(cfg.zgas) if cfg.zgas is not None else None
-    host_zgas = _gal_lgmet_to_absolute_z(host_state["gal_lgmet"], host_state["ssp_lgmet"])
+    galaxy_cfg = context.fit_config.galaxy
+    host_zgas = _gal_lgmet_to_absolute_z(
+        host_state["gal_lgmet"],
+        metallicity_coordinate=galaxy_cfg.ssp_metallicity_coordinate,
+        solar_metallicity=galaxy_cfg.ssp_solar_metallicity,
+    )
     zgas_default = host_zgas if default_zgas is None else jnp.asarray(default_zgas, dtype=jnp.float64)
     zgas = _sample_optional_normal(prior_config, "nebular_zgas", float(default_zgas) if default_zgas is not None else 0.02, 0.01)
     zgas = jnp.where(default_zgas is None and "nebular_zgas" not in prior_config, zgas_default, jnp.clip(zgas, 1.0e-6, 1.0))
@@ -2236,7 +2292,29 @@ def photometric_loglike(
     local_nebular_line_uncertainty_dex : object
         local_nebular_line_uncertainty_dex value.
     """
+    pred_fluxes = jnp.asarray(pred_fluxes, dtype=jnp.float64)
+    obs_fluxes = jnp.asarray(obs_fluxes, dtype=jnp.float64)
+    obs_errors = jnp.asarray(obs_errors, dtype=jnp.float64)
+    agn_component = jnp.asarray(agn_component, dtype=jnp.float64)
+    transmitted_fraction = jnp.asarray(transmitted_fraction, dtype=jnp.float64)
+    active = jnp.asarray(data_mask, dtype=bool) | jnp.asarray(upper_limits, dtype=bool)
+    input_valid = (
+        jnp.isfinite(pred_fluxes)
+        & jnp.isfinite(obs_fluxes)
+        & jnp.isfinite(obs_errors)
+        & (obs_errors > 0.0)
+    )
+    auxiliary_valid = jnp.ones_like(input_valid)
+    if variability_uncertainty:
+        auxiliary_valid = auxiliary_valid & jnp.isfinite(agn_component)
+    if attenuation_model_uncertainty:
+        auxiliary_valid = auxiliary_valid & jnp.isfinite(transmitted_fraction)
+    if nebular_line_component is not None:
+        auxiliary_valid = auxiliary_valid & jnp.isfinite(jnp.asarray(nebular_line_component, dtype=jnp.float64))
+
     pred_fluxes = jnp.nan_to_num(pred_fluxes, nan=0.0, posinf=1.0e30, neginf=-1.0e30)
+    obs_fluxes = jnp.nan_to_num(obs_fluxes, nan=0.0, posinf=1.0e30, neginf=-1.0e30)
+    obs_errors = jnp.nan_to_num(obs_errors, nan=1.0e30, posinf=1.0e30, neginf=1.0e30)
     agn_component = jnp.nan_to_num(agn_component, nan=0.0, posinf=1.0e30, neginf=-1.0e30)
     transmitted_fraction = jnp.nan_to_num(transmitted_fraction, nan=1.0e-4, posinf=1.0, neginf=1.0e-4)
     obs_variance = obs_errors**2
@@ -2258,7 +2336,9 @@ def photometric_loglike(
     if lyman_break_uncertainty:
         ly_unc = jnp.where(filter_wavelength / (1.0 + redshift) < 1500.0, 1.0e8, 0.0)
         sys_variance = sys_variance + (ly_unc * pred_fluxes) ** 2
-    total_variance = jnp.nan_to_num(obs_variance + sys_variance + var_variance, nan=1.0e30, posinf=1.0e30, neginf=1.0e30)
+    raw_total_variance = obs_variance + sys_variance + var_variance
+    variance_valid = jnp.isfinite(raw_total_variance) & (raw_total_variance > 0.0)
+    total_variance = jnp.nan_to_num(raw_total_variance, nan=1.0e30, posinf=1.0e30, neginf=1.0e30)
     scale = jnp.sqrt(jnp.clip(total_variance, 1e-30, 1.0e60))
     family = str(likelihood_family).lower()
     if family in {"gaussian", "normal"}:
@@ -2269,7 +2349,7 @@ def photometric_loglike(
         raise ValueError("likelihood.likelihood_family must be one of: 'gaussian', 'student_t'.")
     logl_data = jnp.sum(jnp.where(data_mask, data_dist.log_prob(obs_fluxes), 0.0))
     logl_lim = jnp.sum(jnp.where(upper_limits, -0.5 * _chi2_upper_limit(obs_fluxes, pred_fluxes, total_variance), 0.0))
-    invalid = ~(jnp.isfinite(pred_fluxes) & jnp.isfinite(scale) & jnp.isfinite(obs_fluxes) & jnp.isfinite(obs_errors))
+    invalid = active & ~(input_valid & auxiliary_valid & variance_valid)
     penalty = -1.0e6 * jnp.sum(invalid.astype(jnp.float64))
     return logl_data + logl_lim + penalty
 
@@ -2292,13 +2372,24 @@ def spectroscopic_loglike(pred_fluxes, obs_fluxes, obs_errors, mask, systematics
     student_t_df : object
         student_t_df value.
     """
+    pred_fluxes = jnp.asarray(pred_fluxes, dtype=jnp.float64)
+    obs_fluxes = jnp.asarray(obs_fluxes, dtype=jnp.float64)
+    obs_errors = jnp.asarray(obs_errors, dtype=jnp.float64)
+    mask = jnp.asarray(mask, dtype=bool)
+    input_valid = (
+        jnp.isfinite(pred_fluxes)
+        & jnp.isfinite(obs_fluxes)
+        & jnp.isfinite(obs_errors)
+        & (obs_errors > 0.0)
+    )
     pred_fluxes = jnp.nan_to_num(pred_fluxes, nan=0.0, posinf=1.0e30, neginf=-1.0e30)
     obs_fluxes = jnp.nan_to_num(obs_fluxes, nan=0.0, posinf=1.0e30, neginf=-1.0e30)
     obs_errors = jnp.nan_to_num(obs_errors, nan=1.0e30, posinf=1.0e30, neginf=1.0e30)
     variance = obs_errors**2 + (jnp.maximum(systematics_width, 0.0) * pred_fluxes) ** 2
+    variance_valid = jnp.isfinite(variance) & (variance > 0.0)
     scale = jnp.sqrt(jnp.clip(variance, 1e-30, 1.0e60))
     student = dist.StudentT(df=student_t_df, loc=pred_fluxes, scale=scale)
-    valid = mask & jnp.isfinite(pred_fluxes) & jnp.isfinite(obs_fluxes) & jnp.isfinite(scale)
+    valid = mask & input_valid & variance_valid & jnp.isfinite(scale)
     penalty = -1.0e6 * jnp.sum((mask & ~valid).astype(jnp.float64))
     return jnp.sum(jnp.where(valid, student.log_prob(obs_fluxes), 0.0)) + penalty
 

--- a/src/jaxsedfit/model.py
+++ b/src/jaxsedfit/model.py
@@ -2144,51 +2144,6 @@ def _chi2_upper_limit(obs_fluxes, model_fluxes, total_variance):
     return -2.0 * jnp.log(0.5 * (1.0 + jax.scipy.special.erf(z)) + 1e-300)
 
 
-def _robust_flux_scale(fluxes, valid_mask):
-    """Estimate a robust characteristic flux scale from valid photometric points.
-
-    Parameters
-    ----------
-    fluxes : object
-        fluxes value.
-    valid_mask : object
-        valid_mask value.
-    """
-    fluxes = jnp.asarray(fluxes, dtype=jnp.float64)
-    valid_mask = jnp.asarray(valid_mask, dtype=bool)
-    safe_flux = jnp.where(valid_mask, jnp.abs(fluxes), jnp.nan)
-    scale = jnp.nanmedian(safe_flux)
-    fallback = jnp.nanmax(safe_flux)
-    scale = jnp.where(jnp.isfinite(scale) & (scale > 0.0), scale, fallback)
-    return jnp.where(jnp.isfinite(scale) & (scale > 0.0), scale, 1.0e-6)
-
-
-def _absolute_flux_scale_logprior(pred_fluxes, obs_fluxes, valid_mask, sigma_dex):
-    """Penalize solutions whose overall flux scale is far from the data.
-
-    Parameters
-    ----------
-    pred_fluxes : object
-        pred_fluxes value.
-    obs_fluxes : object
-        obs_fluxes value.
-    valid_mask : object
-        valid_mask value.
-    sigma_dex : object
-        sigma_dex value.
-    """
-    n_valid = jnp.sum(valid_mask.astype(jnp.int32))
-
-    def _compute():
-        """Evaluate the Gaussian prior on log10 model/data flux scale."""
-        obs_scale = _robust_flux_scale(obs_fluxes, valid_mask)
-        pred_scale = _robust_flux_scale(pred_fluxes, valid_mask)
-        log_ratio = jnp.log10(jnp.maximum(pred_scale, 1.0e-30) / jnp.maximum(obs_scale, 1.0e-30))
-        return dist.Normal(0.0, jnp.maximum(jnp.asarray(sigma_dex, dtype=jnp.float64), 1.0e-6)).log_prob(log_ratio)
-
-    return jax.lax.cond(n_valid > 0, _compute, lambda: jnp.asarray(0.0, dtype=jnp.float64))
-
-
 def _agn_variability_nev(agn_bol_lum_w, max_nev):
     """Return the Simm+2016-inspired fractional variability variance cap.
 
@@ -2670,7 +2625,6 @@ def evaluate_photometric_state(
     obs_errors = _np_to_jnp(context.errors)
     upper_limits = _bool_to_jnp(context.upper_limits)
     data_mask = _bool_to_jnp(context.data_mask)
-    positive_detected_mask = _bool_to_jnp(context.positive_detected_mask)
     spec_wave_obs = _np_to_jnp(context.spec_wave_obs)
     spec_fluxes = _np_to_jnp(context.spec_fluxes)
     spec_errors = _np_to_jnp(context.spec_errors)
@@ -3754,17 +3708,6 @@ def evaluate_photometric_state(
     )
     if add_likelihood:
         numpyro.factor("photometry_loglike", logl)
-    abs_flux_scale_logprior = jnp.asarray(0.0, dtype=jnp.float64)
-    if cfg.likelihood.use_absolute_flux_scale_prior:
-        abs_flux_scale_logprior = _absolute_flux_scale_logprior(
-            pred_fluxes=pred_fluxes,
-            obs_fluxes=obs_fluxes,
-            valid_mask=positive_detected_mask,
-            sigma_dex=cfg.likelihood.absolute_flux_scale_prior_sigma_dex,
-        )
-        if add_likelihood:
-            numpyro.factor("absolute_flux_scale_prior", abs_flux_scale_logprior)
-
     numpyro.deterministic("pred_fluxes", pred_fluxes)
     numpyro.deterministic("pred_spectrum_fluxes", spec_model_fluxes)
     numpyro.deterministic("spec_continuum_model_fluxes", spec_continuum_model_fluxes)
@@ -3812,7 +3755,6 @@ def evaluate_photometric_state(
     numpyro.deterministic("nebular_corr_fit", nebular["corr"])
     numpyro.deterministic("nebular_n_ly_young_fit", nebular["n_ly_young"])
     numpyro.deterministic("nebular_n_ly_old_fit", nebular["n_ly_old"])
-    numpyro.deterministic("absolute_flux_scale_logprior", abs_flux_scale_logprior)
     numpyro.deterministic("rest_wave", rest_wave)
     numpyro.deterministic("obs_wave", obs_wave)
     numpyro.deterministic("spec_wave_obs", spec_wave_obs)

--- a/src/jaxsedfit/preload.py
+++ b/src/jaxsedfit/preload.py
@@ -435,34 +435,6 @@ def _mw_pixel_attenuation_factor(wave_obs, ebv, r_v=3.1):
     return factors
 
 
-def _map_logzsol_to_dsps_lgmet(logzsol_grid: Sequence[float], ssp_lgmet: np.ndarray) -> np.ndarray:
-    """Map log(Z/Zsun) fitting values onto the DSPS metallicity convention.
-
-    Parameters
-    ----------
-    logzsol_grid : object
-        logzsol_grid value.
-    ssp_lgmet : object
-        ssp_lgmet value.
-    """
-    logzsol_grid = np.asarray(logzsol_grid, dtype=float)
-    ssp_lgmet = np.asarray(ssp_lgmet, dtype=float)
-    cand_direct = logzsol_grid
-    cand_shifted = logzsol_grid + np.log10(0.019)
-
-    def mismatch(cand):
-        """Return the mean nearest-grid mismatch for one metallicity convention.
-
-        Parameters
-        ----------
-        cand : object
-            cand value.
-        """
-        return np.mean([np.min(np.abs(ssp_lgmet - val)) for val in cand])
-
-    return cand_direct if mismatch(cand_direct) <= mismatch(cand_shifted) else cand_shifted
-
-
 def load_cached_ssp_data(dsps_ssp_fn: str) -> SSPData:
     """Load DSPS SSP data once and cache it by input file path.
 
@@ -1101,7 +1073,30 @@ def _build_fixed_igm_jax(igm_cache: IGMCacheJax, redshift: float) -> jnp.ndarray
     weight = jnp.where(obs_wavelength < lambda_min_igm, (obs_wavelength / lambda_min_igm) ** 2, 1.0)
     return jnp.exp(-tau_taun - tau_l_igm - tau_l_lls) * weight
 
-def _build_host_basis(rest_wave: np.ndarray, ssp_data: SSPData) -> HostBasis:
+def _surviving_fraction_for_imf(lg_age_gyr: np.ndarray, ssp_imf: str) -> np.ndarray:
+    """Return an IMF-consistent surviving stellar-mass fraction."""
+    from dsps.imf.surviving_mstar import (
+        CHABRIER_PARAMS,
+        KROUPA_PARAMS,
+        SALPETER_PARAMS,
+        VAN_DOKKUM_PARAMS,
+        surviving_mstar,
+    )
+
+    params_by_imf = {
+        "chabrier_2003": CHABRIER_PARAMS,
+        "salpeter_1955": SALPETER_PARAMS,
+        "kroupa_2001": KROUPA_PARAMS,
+        "van_dokkum_2008": VAN_DOKKUM_PARAMS,
+    }
+    try:
+        params = params_by_imf[str(ssp_imf)]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported SSP IMF for surviving-mass calculation: {ssp_imf!r}.") from exc
+    return np.asarray(surviving_mstar(np.asarray(lg_age_gyr, dtype=float) + 9.0, **params), dtype=float)
+
+
+def _build_host_basis(rest_wave: np.ndarray, ssp_data: SSPData, ssp_imf: str = "chabrier_2003") -> HostBasis:
     """Precompute the SSP basis on the model rest-wave grid.
 
     Parameters
@@ -1116,6 +1111,7 @@ def _build_host_basis(rest_wave: np.ndarray, ssp_data: SSPData) -> HostBasis:
         float(rest_wave[0]),
         float(rest_wave[-1]),
         int(rest_wave.size),
+        str(ssp_imf),
     )
     cached = _HOST_BASIS_CACHE.get(cache_key)
     if cached is not None:
@@ -1138,9 +1134,7 @@ def _build_host_basis(rest_wave: np.ndarray, ssp_data: SSPData) -> HostBasis:
                 left=0.0,
                 right=0.0,
             )
-    from dsps.imf.surviving_mstar import surviving_mstar
-
-    surviving_frac_by_age = np.asarray(surviving_mstar(ssp_data.ssp_lg_age_gyr + 9.0), dtype=float)
+    surviving_frac_by_age = _surviving_fraction_for_imf(ssp_data.ssp_lg_age_gyr, ssp_imf)
     loaded = HostBasis(
         rest_llambda=rest_llambda,
         surviving_frac_by_age=surviving_frac_by_age,
@@ -1920,7 +1914,7 @@ def build_model_context(cfg: FitConfig) -> ModelContext:
     ).astype(float)
     if cfg.galaxy.fit_host:
         ssp_data = load_cached_ssp_data(cfg.galaxy.dsps_ssp_fn)
-        host_basis = _build_host_basis(rest_wave, ssp_data)
+        host_basis = _build_host_basis(rest_wave, ssp_data, cfg.galaxy.ssp_imf)
         host_basis_jax = _build_host_basis_jax(ssp_data, host_basis, gal_t_table)
     else:
         ssp_data = _empty_ssp_data()
@@ -1938,7 +1932,7 @@ def build_model_context(cfg: FitConfig) -> ModelContext:
     )
     if needs_spec_host_basis:
         spec_rest_wave = (spec_wave_obs / (1.0 + max(cfg.observation.redshift, 0.0))).astype(float)
-        spec_host_basis = _build_host_basis(spec_rest_wave, ssp_data)
+        spec_host_basis = _build_host_basis(spec_rest_wave, ssp_data, cfg.galaxy.ssp_imf)
         spec_host_basis_jax = _build_host_basis_jax(ssp_data, spec_host_basis, gal_t_table)
 
     filter_responses = _load_filter_responses(cfg)

--- a/tests/test_diffstar_host.py
+++ b/tests/test_diffstar_host.py
@@ -69,7 +69,6 @@ def test_diffstar_host_model_exposes_log_stellar_mass(monkeypatch):
     assert np.all(np.isfinite(np.asarray(tr["host_absorbed_rest_sed"]["value"])))
     assert np.all(np.isfinite(np.asarray(tr["dust_rest_sed"]["value"])))
     assert np.all(np.asarray(tr["dust_rest_sed"]["value"]) >= 0.0)
-    assert np.isfinite(float(np.asarray(tr["absolute_flux_scale_logprior"]["value"])))
     assert np.any(np.asarray(tr["line_bl_rest_sed"]["value"]) > 0.0)
     assert np.any(np.asarray(tr["line_nl_rest_sed"]["value"]) > 0.0)
     assert np.allclose(np.asarray(tr["line_liner_rest_sed"]["value"]), 0.0)

--- a/tests/test_model_assembly.py
+++ b/tests/test_model_assembly.py
@@ -86,7 +86,6 @@ def _cfg(
         ),
         likelihood=LikelihoodConfig(
             variability_uncertainty=False,
-            use_absolute_flux_scale_prior=False,
             use_host_capture_model=False,
         ),
         spectroscopy=(

--- a/tests/test_model_helpers.py
+++ b/tests/test_model_helpers.py
@@ -88,10 +88,10 @@ from jaxsedfit.preload import (
 )
 
 
-def test_likelihood_defaults_include_absolute_flux_scale_prior():
+def test_likelihood_defaults_include_local_line_photometry():
     cfg = LikelihoodConfig()
-    assert cfg.use_absolute_flux_scale_prior is True
-    assert cfg.absolute_flux_scale_prior_sigma_dex > 0.0
+    assert not hasattr(cfg, "use_absolute_flux_scale_prior")
+    assert not hasattr(cfg, "absolute_flux_scale_prior_sigma_dex")
     assert cfg.use_local_line_photometry is True
     assert cfg.local_nebular_line_uncertainty_dex == pytest.approx(0.3)
 
@@ -1497,7 +1497,6 @@ def test_jaxqsofit_spectrum_resolution_host_basis_uses_host_kinematics(monkeypat
         nebular=NebularConfig(enabled=False),
         likelihood=LikelihoodConfig(
             variability_uncertainty=False,
-            use_absolute_flux_scale_prior=False,
         ),
         spectroscopy=SpectroscopyData(
             wave_obs=[5000.0, 5100.0, 5200.0],
@@ -1564,7 +1563,6 @@ def test_jaxqsofit_backend_keeps_nebular_width_fixed_without_nebular_prior(monke
         nebular=NebularConfig(enabled=True, zgas=0.02),
         likelihood=LikelihoodConfig(
             variability_uncertainty=False,
-            use_absolute_flux_scale_prior=False,
         ),
         spectroscopy=SpectroscopyData(
             wave_obs=[4995.0, 5000.0, 5005.0],
@@ -1625,7 +1623,6 @@ def test_jaxsedfit_model_can_call_jaxqsofit_backend(monkeypatch):
         likelihood=LikelihoodConfig(
             use_host_capture_model=True,
             variability_uncertainty=False,
-            use_absolute_flux_scale_prior=False,
         ),
         spectroscopy=SpectroscopyData(
             wave_obs=[5200.0, 5400.0, 5600.0],
@@ -1704,7 +1701,6 @@ def test_jaxsedfit_jaxqsofit_backend_uses_nested_tied_line_config(monkeypatch):
         agn=AGNConfig(),
         likelihood=LikelihoodConfig(
             variability_uncertainty=False,
-            use_absolute_flux_scale_prior=False,
         ),
         spectroscopy=SpectroscopyData(
             wave_obs=[4800.0, 4900.0, 5000.0],
@@ -1807,7 +1803,6 @@ def test_jaxsedfit_jaxqsofit_tied_line_backend_runs_svi_jit(monkeypatch):
         agn=AGNConfig(),
         likelihood=LikelihoodConfig(
             variability_uncertainty=False,
-            use_absolute_flux_scale_prior=False,
         ),
         spectroscopy=SpectroscopyData(
             wave_obs=[4900.0, 5000.0, 5100.0],

--- a/tests/test_model_helpers.py
+++ b/tests/test_model_helpers.py
@@ -66,7 +66,7 @@ from jaxsedfit.model import (
     spectroscopic_likelihood_weight,
     spectroscopic_log_likelihood,
 )
-from jaxsedfit.preload import _build_fixed_igm_jax, _build_igm_cache_jax, build_model_context
+from jaxsedfit.preload import _build_fixed_igm_jax, _build_igm_cache_jax, _surviving_fraction_for_imf, build_model_context
 from jaxsedfit.filters import load_filter_curve
 from jaxsedfit.preload import (
     ModelContext,
@@ -489,12 +489,37 @@ def test_biattenuation_routes_host_and_agn_extinction_and_dust_budget():
 
 
 def test_gal_lgmet_to_absolute_z_respects_ssp_metallicity_convention():
-    absolute_grid = np.asarray([-4.34771165, -3.34771165, -2.34771165, -1.34771165])
-    relative_grid = np.asarray([-2.0, -1.0, -0.3, 0.0])
+    assert float(_gal_lgmet_to_absolute_z(np.log10(0.019), metallicity_coordinate="absolute_log10_z")) == pytest.approx(0.019)
+    assert float(_gal_lgmet_to_absolute_z(0.0, metallicity_coordinate="log10_z_over_zsun")) == pytest.approx(0.019)
+    assert float(_gal_lgmet_to_absolute_z(-0.3, metallicity_coordinate="log10_z_over_zsun")) == pytest.approx(0.019 * 10.0**-0.3)
 
-    assert float(_gal_lgmet_to_absolute_z(np.log10(0.019), absolute_grid)) == pytest.approx(0.019)
-    assert float(_gal_lgmet_to_absolute_z(0.0, relative_grid)) == pytest.approx(0.019)
-    assert float(_gal_lgmet_to_absolute_z(-0.3, relative_grid)) == pytest.approx(0.019 * 10.0**-0.3)
+
+@pytest.mark.parametrize("field", ["age_grid_gyr", "logzsol_grid", "imf_type", "zcontinuous", "sfh"])
+def test_removed_fsps_generation_fields_are_not_galaxy_runtime_options(field):
+    with pytest.raises(TypeError):
+        GalaxyConfig(**{field: 1})
+
+
+@pytest.mark.parametrize("ssp_imf", ["chabrier_2003", "salpeter_1955", "kroupa_2001", "van_dokkum_2008"])
+def test_galaxy_accepts_supported_ssp_imf_provenance(ssp_imf):
+    GalaxyConfig(ssp_imf=ssp_imf).validate()
+
+
+def test_galaxy_rejects_ambiguous_ssp_provenance():
+    with pytest.raises(ValueError, match="ssp_imf"):
+        GalaxyConfig(ssp_imf="unknown").validate()
+    with pytest.raises(ValueError, match="ssp_metallicity_coordinate"):
+        GalaxyConfig(ssp_metallicity_coordinate="guess").validate()
+
+
+def test_surviving_mass_fraction_uses_declared_ssp_imf():
+    ages = np.asarray([-1.0, 0.0, 1.0])
+    chabrier = _surviving_fraction_for_imf(ages, "chabrier_2003")
+    salpeter = _surviving_fraction_for_imf(ages, "salpeter_1955")
+
+    assert np.all(np.isfinite(chabrier))
+    assert np.all(np.isfinite(salpeter))
+    assert not np.allclose(chabrier, salpeter)
 
 
 def test_attenuation_transmitted_fraction_uses_only_direct_light():
@@ -827,6 +852,80 @@ def test_local_nebular_line_uncertainty_regularizes_only_line_component():
         )
     )
     assert no_line_component == pytest.approx(exact)
+
+
+def _minimal_photometric_loglike_kwargs():
+    return dict(
+        obs_fluxes=np.asarray([1.0]),
+        obs_errors=np.asarray([0.1]),
+        upper_limits=np.asarray([False]),
+        data_mask=np.asarray([True]),
+        systematics_width=0.0,
+        likelihood_family="gaussian",
+        student_t_df=5.0,
+        agn_component=np.asarray([0.0]),
+        agn_bol_lum_w=1.0e38,
+        agn_nev=0.1,
+        variability_uncertainty=False,
+        attenuation_model_uncertainty=False,
+        transmitted_fraction=np.asarray([1.0]),
+        lyman_break_uncertainty=False,
+        filter_wavelength=np.asarray([5000.0]),
+        redshift=0.0,
+    )
+
+
+@pytest.mark.parametrize("invalid_prediction", [np.nan, np.inf, -np.inf])
+def test_photometric_likelihood_penalizes_nonfinite_active_predictions(invalid_prediction):
+    logl = float(
+        photometric_loglike(
+            pred_fluxes=np.asarray([invalid_prediction]),
+            **_minimal_photometric_loglike_kwargs(),
+        )
+    )
+
+    assert np.isfinite(logl)
+    assert logl < -9.0e5
+
+
+def test_photometric_likelihood_ignores_nonfinite_masked_predictions():
+    kwargs = _minimal_photometric_loglike_kwargs()
+    kwargs["data_mask"] = np.asarray([False])
+    logl = float(photometric_loglike(pred_fluxes=np.asarray([np.nan]), **kwargs))
+
+    assert logl == pytest.approx(0.0)
+
+
+@pytest.mark.parametrize("invalid_prediction", [np.nan, np.inf, -np.inf])
+def test_spectroscopic_likelihood_penalizes_nonfinite_active_predictions(invalid_prediction):
+    logl = float(
+        spectroscopic_log_likelihood(
+            np.asarray([invalid_prediction]),
+            np.asarray([1.0]),
+            np.asarray([0.1]),
+            np.asarray([True]),
+            0.0,
+            5.0,
+        )
+    )
+
+    assert np.isfinite(logl)
+    assert logl < -9.0e5
+
+
+def test_spectroscopic_likelihood_ignores_nonfinite_masked_predictions():
+    logl = float(
+        spectroscopic_log_likelihood(
+            np.asarray([np.nan]),
+            np.asarray([1.0]),
+            np.asarray([0.1]),
+            np.asarray([False]),
+            0.0,
+            5.0,
+        )
+    )
+
+    assert logl == pytest.approx(0.0)
 
 
 def test_spectroscopic_likelihood_weight_uses_resolution_elements():


### PR DESCRIPTION
## Summary

- remove inert FSPS-generation options from runtime galaxy configuration
- declare SSP IMF and metallicity coordinates explicitly
- use IMF-matched DSPS surviving-mass calibrations
- replace metallicity-grid guessing with explicit coordinate conversion
- penalize non-finite active photometric and spectroscopic predictions before sanitization

## Why

The removed fields appeared to change the IMF, metallicity grid, or SFH construction but did not affect the loaded SSP library. More importantly, surviving stellar mass always used a Chabrier calibration even when a different IMF was implied, and metallicity conventions were inferred from grid values. The likelihood also sanitized non-finite predictions before checking validity, allowing invalid model states to retain finite posterior density.

## Impact

This is an intentional breaking configuration cleanup. SSP provenance is now expressed with `ssp_imf`, `ssp_metallicity_coordinate`, and `ssp_solar_metallicity`. Supported IMF declarations select matching return-fraction calibrations, ambiguous values fail early, and the removed FSPS-style options are rejected. Active NaN or infinite predictions now receive the hard invalid-state penalty, while deliberately masked points remain ignored.

## Validation

- `MPLCONFIGDIR=/tmp/matplotlib conda run -n jaxcpu pytest -q`
- 231 passed
- `git diff --check`
