### PR TITLE
Improve nebular and prior accuracy

### DIFF
--- a/src/jaxsedfit/config.py
+++ b/src/jaxsedfit/config.py
@@ -300,9 +300,9 @@ class LikelihoodConfig:
     use_local_line_photometry: bool = True
     local_nebular_line_uncertainty_dex: float = 0.3
     use_fixed_local_line_cache: bool = True
-    fixed_local_line_cache_n_width: int = 128
-    fixed_local_line_cache_min_width_kms: float = 200.0
-    fixed_local_line_cache_max_width_kms: float = 30000.0
+    fixed_local_line_cache_n_width: int = 256
+    fixed_local_line_cache_min_width_kms: float = 1.0
+    fixed_local_line_cache_max_width_kms: float = 100000.0
     use_redshift_projection_cache: bool = True
     redshift_projection_n_grid: int = 128
     redshift_projection_sigma: float = 6.0
@@ -832,6 +832,8 @@ class PriorConfig:
     def validate(self) -> None:
         """Validate nested semantic prior objects."""
         self.redshift.validate()
+        if self.host.log_sfh_tau_gyr is not None and self.host.log_sfh_tau_over_age is not None:
+            raise ValueError("Configure only one of host.log_sfh_tau_gyr and host.log_sfh_tau_over_age.")
 
     def to_mapping(self) -> dict[str, Any]:
         """Return the flat prior mapping consumed by the NumPyro model."""

--- a/src/jaxsedfit/model.py
+++ b/src/jaxsedfit/model.py
@@ -376,8 +376,8 @@ def _sample_optional_normal(prior_config: dict[str, Any], key: str, default: flo
     return _sample_prior(prior_config, key, dist.Normal(default, scale))
 
 
-def _sample_optional_truncnorm(prior_config: dict[str, Any], key: str, default: float, scale: float, low: float, high: float):
-    """Return a fixed default unless a truncated Normal-like prior is explicitly configured.
+def _sample_bounded_normal(prior_config: dict[str, Any], key: str, default: float, scale: float, low, high):
+    """Sample a Normal-like prior truncated to model support.
 
     Parameters
     ----------
@@ -394,9 +394,40 @@ def _sample_optional_truncnorm(prior_config: dict[str, Any], key: str, default: 
     high : object
         high value.
     """
+    cfg = prior_config.get(key, None)
+    loc = default
+    prior_scale = scale
+    prior_low = low
+    prior_high = high
+    if isinstance(cfg, (tuple, list)) and len(cfg) >= 2:
+        loc, prior_scale = cfg[:2]
+    elif isinstance(cfg, dict):
+        family = str(cfg.get("dist", cfg.get("family", "normal"))).lower()
+        if family not in {"normal", "gaussian", "truncatednormal", "truncated_normal", "truncnormal", "truncnorm"}:
+            raise ValueError(f"prior_config[{key!r}] must be Normal-like to enforce bounded model support.")
+        loc = cfg.get("loc", default)
+        prior_scale = cfg.get("scale", scale)
+        if family not in {"normal", "gaussian"}:
+            prior_low = jnp.maximum(jnp.asarray(low, dtype=jnp.float64), jnp.asarray(cfg.get("low", low), dtype=jnp.float64))
+            prior_high = jnp.minimum(jnp.asarray(high, dtype=jnp.float64), jnp.asarray(cfg.get("high", high), dtype=jnp.float64))
+    prior_low = jnp.asarray(prior_low, dtype=jnp.float64)
+    prior_high = jnp.asarray(prior_high, dtype=jnp.float64)
+    return numpyro.sample(
+        key,
+        dist.TruncatedNormal(
+            jnp.asarray(loc, dtype=jnp.float64),
+            jnp.maximum(jnp.asarray(prior_scale, dtype=jnp.float64), 1.0e-6),
+            low=prior_low,
+            high=prior_high,
+        ),
+    )
+
+
+def _sample_optional_truncnorm(prior_config: dict[str, Any], key: str, default: float, scale: float, low, high):
+    """Return a fixed default unless a bounded Normal-like prior is configured."""
     if key not in prior_config:
         return jnp.asarray(default, dtype=jnp.float64)
-    return _sample_prior(prior_config, key, dist.TruncatedNormal(default, scale, low=low, high=high))
+    return _sample_bounded_normal(prior_config, key, default, scale, low, high)
 
 
 def _safe_log10(x):
@@ -952,6 +983,13 @@ def _attenuation_curve(wave_rest, opt_index, nir_index, norm, lam_break):
         lam_break value.
     """
     return norm * (wave_rest / lam_break) ** jnp.where(wave_rest < lam_break, opt_index, nir_index)
+
+
+def _absorbed_line_luminosity(line_wave, line_lumin, ebv, opt_index, nir_index, norm, lam_break):
+    """Return attenuation-absorbed energy from integrated narrow-line luminosities."""
+    curve = _attenuation_curve(line_wave, opt_index, nir_index, norm, lam_break)
+    transmitted = 10 ** (jnp.asarray(ebv, dtype=jnp.float64) * curve / -2.5)
+    return jnp.sum(jnp.asarray(line_lumin, dtype=jnp.float64) * (1.0 - transmitted))
 
 
 def _apply_biattenuation(wave_rest, gal_spec, agn_spec, ebv_gal, ebv_agn, opt_index, nir_index, norm, lam_break):
@@ -1619,17 +1657,17 @@ def _build_diffstar_host(context: ModelContext, prior_config: dict[str, Any], *,
         return_smh=True,
     )
 
-    gal_lgmet = _sample_prior(
+    gal_lgmet = _sample_bounded_normal(
         prior_config,
         "gal_lgmet",
-        dist.Normal(
-            _default_gal_lgmet_loc(
-                ssp_lgmet,
-                galaxy_cfg.ssp_metallicity_coordinate,
-                galaxy_cfg.ssp_solar_metallicity,
-            ),
-            0.5,
+        _default_gal_lgmet_loc(
+            ssp_lgmet,
+            galaxy_cfg.ssp_metallicity_coordinate,
+            galaxy_cfg.ssp_solar_metallicity,
         ),
+        0.5,
+        jnp.min(ssp_lgmet),
+        jnp.max(ssp_lgmet),
     )
     gal_lgmet_scatter = _sample_positive_distribution(
         prior_config,
@@ -1725,40 +1763,52 @@ def _build_delayed_host(context: ModelContext, prior_config: dict[str, Any], *, 
     log_stellar_mass = _sample_log_stellar_mass(prior_config)
     min_age = jnp.asarray(max(float(cfg.sfh_t_min_gyr), 1.0e-3), dtype=jnp.float64)
     max_age = jnp.maximum(t_obs_gyr, min_age * 1.01)
-    log_age_gyr = _sample_prior(
+    log_age_gyr = _sample_bounded_normal(
         prior_config,
         "log_sfh_age_gyr",
-        dist.TruncatedNormal(
-            np.log(min(3.0, max(float(context.t_obs_gyr), 1.0e-3))),
-            1.0,
-            low=jnp.log(min_age),
-            high=jnp.log(max_age),
-        ),
-    )
-    log_tau_over_age = _sample_prior(
-        prior_config,
-        "log_sfh_tau_over_age",
-        dist.Normal(0.0, float(cfg.tau_host_prior_scale)),
+        np.log(min(3.0, max(float(context.t_obs_gyr), 1.0e-3))),
+        1.0,
+        jnp.log(min_age),
+        jnp.log(max_age),
     )
     age_gyr = jnp.exp(log_age_gyr)
-    tau_gyr = jnp.clip(age_gyr * jnp.exp(log_tau_over_age), 0.03, 30.0)
-    log_tau_gyr = numpyro.deterministic("log_sfh_tau_gyr", jnp.log(tau_gyr))
+    if "log_sfh_tau_gyr" in prior_config:
+        log_tau_gyr = _sample_bounded_normal(
+            prior_config,
+            "log_sfh_tau_gyr",
+            np.log(1.0),
+            float(cfg.tau_host_prior_scale),
+            np.log(0.03),
+            np.log(30.0),
+        )
+        log_tau_over_age = numpyro.deterministic("log_sfh_tau_over_age", log_tau_gyr - log_age_gyr)
+    else:
+        log_tau_over_age = _sample_bounded_normal(
+            prior_config,
+            "log_sfh_tau_over_age",
+            0.0,
+            float(cfg.tau_host_prior_scale),
+            jnp.log(0.03 / age_gyr),
+            jnp.log(30.0 / age_gyr),
+        )
+        log_tau_gyr = numpyro.deterministic("log_sfh_tau_gyr", log_age_gyr + log_tau_over_age)
+    tau_gyr = jnp.exp(log_tau_gyr)
     stellar_age_gyr = jnp.maximum(t_obs_gyr - gal_t_table, 0.0)
     sfh_age_gyr = age_gyr - stellar_age_gyr
     base_sfh = jnp.where((sfh_age_gyr > 0.0) & (sfh_age_gyr <= age_gyr), sfh_age_gyr * jnp.exp(-sfh_age_gyr / tau_gyr), 0.0)
     base_smh = _cumulative_trapezoid(base_sfh, gal_t_table) * 1.0e9
 
-    gal_lgmet = _sample_prior(
+    gal_lgmet = _sample_bounded_normal(
         prior_config,
         "gal_lgmet",
-        dist.Normal(
-            _default_gal_lgmet_loc(
-                ssp_lgmet,
-                cfg.ssp_metallicity_coordinate,
-                cfg.ssp_solar_metallicity,
-            ),
-            0.5,
+        _default_gal_lgmet_loc(
+            ssp_lgmet,
+            cfg.ssp_metallicity_coordinate,
+            cfg.ssp_solar_metallicity,
         ),
+        0.5,
+        jnp.min(ssp_lgmet),
+        jnp.max(ssp_lgmet),
     )
     gal_lgmet_scatter = _sample_positive_distribution(
         prior_config,
@@ -1899,7 +1949,14 @@ def _empty_host_state(context: ModelContext):
     }
 
 
-def _build_nebular_components(context: ModelContext, host_state: dict[str, Any], host_rest, prior_config: dict[str, Any]):
+def _build_nebular_components(
+    context: ModelContext,
+    host_state: dict[str, Any],
+    host_rest,
+    prior_config: dict[str, Any],
+    *,
+    build_line_sed: bool = True,
+):
     """Build CIGALE/GRAHSP-style host nebular absorption, lines, and continuum.
 
     Parameters
@@ -1938,7 +1995,15 @@ def _build_nebular_components(context: ModelContext, host_state: dict[str, Any],
             "line_lumin": jnp.zeros((1,), dtype=jnp.float64),
         }
 
-    logu = _sample_optional_normal(prior_config, "nebular_logU", float(cfg.logU), 0.3)
+    templates = context.nebular_templates_jax
+    logu = _sample_optional_truncnorm(
+        prior_config,
+        "nebular_logU",
+        float(cfg.logU),
+        0.3,
+        templates.logu_grid[0],
+        templates.logu_grid[-1],
+    )
     default_zgas = float(cfg.zgas) if cfg.zgas is not None else None
     galaxy_cfg = context.fit_config.galaxy
     host_zgas = _gal_lgmet_to_absolute_z(
@@ -1947,9 +2012,23 @@ def _build_nebular_components(context: ModelContext, host_state: dict[str, Any],
         solar_metallicity=galaxy_cfg.ssp_solar_metallicity,
     )
     zgas_default = host_zgas if default_zgas is None else jnp.asarray(default_zgas, dtype=jnp.float64)
-    zgas = _sample_optional_normal(prior_config, "nebular_zgas", float(default_zgas) if default_zgas is not None else 0.02, 0.01)
-    zgas = jnp.where(default_zgas is None and "nebular_zgas" not in prior_config, zgas_default, jnp.clip(zgas, 1.0e-6, 1.0))
-    ne = jnp.clip(_sample_optional_normal(prior_config, "nebular_ne", float(cfg.ne), 100.0), 1.0e-6, 1.0e8)
+    zgas = _sample_optional_truncnorm(
+        prior_config,
+        "nebular_zgas",
+        float(default_zgas) if default_zgas is not None else 0.02,
+        0.01,
+        templates.z_grid[0],
+        templates.z_grid[-1],
+    )
+    zgas = jnp.where(default_zgas is None and "nebular_zgas" not in prior_config, zgas_default, zgas)
+    ne = _sample_optional_truncnorm(
+        prior_config,
+        "nebular_ne",
+        float(cfg.ne),
+        100.0,
+        templates.ne_grid[0],
+        templates.ne_grid[-1],
+    )
     f_esc = _sample_optional_truncnorm(prior_config, "nebular_f_esc", float(cfg.f_esc), 0.1, 0.0, 1.0)
     default_remaining = max(1.0 - float(cfg.f_esc), 1.0e-12)
     default_f_dust_fraction = float(np.clip(float(cfg.f_dust) / default_remaining, 0.0, 1.0))
@@ -1962,7 +2041,14 @@ def _build_nebular_components(context: ModelContext, host_state: dict[str, Any],
         1.0,
     )
     f_dust = jnp.maximum(1.0 - f_esc, 0.0) * f_dust_fraction
-    lines_width = jnp.clip(_sample_optional_normal(prior_config, "nebular_lines_width", float(cfg.lines_width), 100.0), 0.0, 1.0e5)
+    lines_width = _sample_optional_truncnorm(
+        prior_config,
+        "nebular_lines_width",
+        float(cfg.lines_width),
+        100.0,
+        1.0,
+        1.0e5,
+    )
     if "log_nebular_line_scale" in prior_config:
         line_scale = _sample_log_positive_from_distribution(
             prior_config,
@@ -1987,7 +2073,6 @@ def _build_nebular_components(context: ModelContext, host_state: dict[str, Any],
     ly_lum_total = jnp.clip(ly_lum_young + ly_lum_old, 0.0, 1.0e300)
 
     corr = _cigale_nebular_correction(f_esc, f_dust)
-    templates = context.nebular_templates_jax
     rest_templates = context.nebular_rest_templates_jax
     continuum_per_photon = _trilinear_nebular_grid(
         rest_templates.continuum_lumin_per_a_per_photon,
@@ -2009,7 +2094,9 @@ def _build_nebular_components(context: ModelContext, host_state: dict[str, Any],
     )
     continuum_rest = continuum_per_photon * n_ly_total * corr
     line_lumin = line_lumin_per_photon * n_ly_total * corr
-    if context.fixed_nebular_line_profile_jax is not None:
+    if not build_line_sed:
+        lines_rest = zeros
+    elif context.fixed_nebular_line_profile_jax is not None:
         lines_rest = context.fixed_nebular_line_profile_jax * n_ly_total * corr
     elif rest_templates.line_profile_per_photon is not None:
         line_profile_per_photon = _trilinear_nebular_grid(
@@ -2675,6 +2762,15 @@ def evaluate_photometric_state(
         and not spectroscopy_enabled
         and not cfg.likelihood.attenuation_model_uncertainty
     )
+    skip_coarse_nebular_line_grid = bool(
+        fit_host
+        and cfg.nebular.enabled
+        and cfg.nebular.emission
+        and cfg.likelihood.use_local_line_photometry
+        and not include_components
+        and not spectroscopy_enabled
+        and not cfg.likelihood.attenuation_model_uncertainty
+    )
     needs_spec_host_basis = bool(
         spectroscopy_enabled
         and str(cfg.spectroscopy_config.backend).lower() == "jaxqsofit"
@@ -3010,10 +3106,13 @@ def evaluate_photometric_state(
         else jnp.asarray(0.0, dtype=jnp.float64)
     )
     if cfg.galaxy.use_energy_balance and fit_host:
-        dust_alpha = _sample_prior(
+        dust_alpha = _sample_bounded_normal(
             prior_config,
             "dust_alpha",
-            dist.TruncatedNormal(cfg.galaxy.dust_alpha, 0.4, low=float(np.min(dust_alpha_grid)), high=float(np.max(dust_alpha_grid))),
+            cfg.galaxy.dust_alpha,
+            0.4,
+            float(np.min(dust_alpha_grid)),
+            float(np.max(dust_alpha_grid)),
         )
     else:
         dust_alpha = jnp.asarray(float(cfg.galaxy.dust_alpha), dtype=jnp.float64)
@@ -3053,7 +3152,13 @@ def evaluate_photometric_state(
         redshift = context.fixed_redshift_jax
         luminosity_distance_m = context.fixed_luminosity_distance_m_jax
         igm = context.fixed_igm_jax
-    nebular = _build_nebular_components(context, host_state, host_rest, prior_config)
+    nebular = _build_nebular_components(
+        context,
+        host_state,
+        host_rest,
+        prior_config,
+        build_line_sed=not skip_coarse_nebular_line_grid,
+    )
     host_with_nebular_rest = host_rest + nebular["absorption_rest"] + nebular["emission_rest"]
     agn_attenuated_input_rest = disk_rest + feii_rest + line_rest + balmer_rest
     gal_att_rest, agn_attenuated_rest, host_absorbed_rest, dust_luminosity = _apply_biattenuation(
@@ -3067,6 +3172,19 @@ def evaluate_photometric_state(
         1.2,
         GRAHSP_BIATTENUATION_BREAK_A,
     )
+    if skip_coarse_nebular_line_grid:
+        # Narrow lines are generally unresolved by the broadband rest-wave
+        # grid.  Use their conserved integrated luminosities for energy
+        # balance instead of integrating undersampled Gaussian profiles.
+        dust_luminosity = dust_luminosity + _absorbed_line_luminosity(
+            context.nebular_templates_jax.line_wave_a,
+            nebular["line_lumin"],
+            ebv_gal,
+            -1.2,
+            -3.0,
+            1.2,
+            GRAHSP_BIATTENUATION_BREAK_A,
+        )
     dust_luminosity = dust_luminosity + nebular["dust_luminosity"]
     attenuation_curve = _attenuation_curve(rest_wave, -1.2, -3.0, 1.2, GRAHSP_BIATTENUATION_BREAK_A)
     gal_att_factor = 10 ** (ebv_gal * attenuation_curve / -2.5)

--- a/tests/test_diffstar_host.py
+++ b/tests/test_diffstar_host.py
@@ -1,5 +1,6 @@
 import numpy as np
 import numpyro.distributions as dist
+import pytest
 from numpyro.handlers import seed, trace
 
 from jaxsedfit.config import (
@@ -99,6 +100,47 @@ def test_delayed_host_model_is_default(monkeypatch):
     assert np.isfinite(float(np.asarray(tr["sfh_tau_gyr_fit"]["value"])))
     assert np.all(np.isfinite(np.asarray(tr["gal_sfr_table"]["value"], dtype=float)))
     assert np.all(np.isfinite(np.asarray(tr["gal_smh_table"]["value"], dtype=float)))
+
+
+def test_delayed_host_priors_respect_physical_and_template_support(monkeypatch):
+    class _SSPData:
+        ssp_lgmet = np.array([-2.0, -1.5, -1.0, -0.5])
+        ssp_lg_age_gyr = np.array([-1.0, -0.5, 0.0, 0.5])
+        ssp_wave = np.array([900.0, 2000.0, 5000.0, 10000.0])
+        ssp_flux = np.ones((4, 4, 4))
+
+    monkeypatch.setattr("jaxsedfit.preload._load_ssp_templates", lambda fn: _SSPData())
+    monkeypatch.setattr("jaxsedfit.preload._SSP_DATA_CACHE", {})
+    cfg = _mock_config()
+    cfg.galaxy.dsps_ssp_fn = "fake-bounded-delayed.h5"
+    cfg.prior_config.host.log_sfh_age_gyr = dist.Normal(0.0, 10.0)
+    cfg.prior_config.host.log_sfh_tau_gyr = dist.Normal(0.0, 10.0)
+    cfg.prior_config.host.gal_lgmet = dist.Normal(-1.0, 10.0)
+    cfg.prior_config.host.dust_alpha = dist.Normal(2.0, 10.0)
+    context = build_model_context(cfg)
+    tr = trace(seed(lambda: grahsp_photometric_model(context, include_components=False), 11)).get_trace()
+
+    assert tr["log_sfh_tau_gyr"]["type"] == "sample"
+    assert tr["log_sfh_tau_over_age"]["type"] == "deterministic"
+    bounds = {
+        "log_sfh_age_gyr": (np.log(cfg.galaxy.sfh_t_min_gyr), np.log(context.t_obs_gyr)),
+        "log_sfh_tau_gyr": (np.log(0.03), np.log(30.0)),
+        "gal_lgmet": (-2.0, -0.5),
+        "dust_alpha": (float(np.min(context.templates.dust_alpha_grid)), float(np.max(context.templates.dust_alpha_grid))),
+    }
+    for name, (low, high) in bounds.items():
+        support = tr[name]["fn"].support
+        assert float(np.asarray(support.lower_bound)) == pytest.approx(low)
+        assert float(np.asarray(support.upper_bound)) == pytest.approx(high)
+
+
+def test_delayed_host_rejects_both_tau_prior_parameterizations():
+    cfg = _mock_config()
+    cfg.prior_config.host.log_sfh_tau_gyr = dist.Normal(0.0, 1.0)
+    cfg.prior_config.host.log_sfh_tau_over_age = dist.Normal(0.0, 1.0)
+
+    with pytest.raises(ValueError, match="Configure only one"):
+        cfg.validate()
 
 
 def test_agn_type_2_uses_sy2_narrow_lines_only(monkeypatch):

--- a/tests/test_model_assembly.py
+++ b/tests/test_model_assembly.py
@@ -1,4 +1,6 @@
 import numpy as np
+import jax
+import jax.numpy as jnp
 import numpyro.distributions as dist
 from numpyro.handlers import seed, substitute, trace
 
@@ -21,7 +23,7 @@ from jaxsedfit.config import (
     SpectroscopyData,
 )
 from jaxsedfit.core import JAXSEDFit
-from jaxsedfit.model import GRAHSP_PL_BEND_LOC_A, GRAHSP_PL_BEND_WIDTH, GRAHSP_PL_CUTOFF_A, _project_filters, _redshift_to_obs, evaluate_photometric_state, grahsp_photometric_model
+from jaxsedfit.model import GRAHSP_PL_BEND_LOC_A, GRAHSP_PL_BEND_WIDTH, GRAHSP_PL_CUTOFF_A, _project_filters, _project_fixed_cached_local_line_filters, _project_fixed_cached_local_nebular_line_filters, _project_local_line_filters, _project_local_nebular_line_filters, _redshift_to_obs, evaluate_photometric_state, grahsp_photometric_model
 from jaxsedfit.preload import build_model_context
 
 
@@ -796,6 +798,33 @@ def test_fixed_local_nebular_line_cache_matches_exact_projection(monkeypatch):
 
     np.testing.assert_allclose(cached, exact, rtol=5.0e-4, atol=1.0e-30)
 
+    line_lumin = jnp.ones(cached_context.nebular_templates_jax.line_wave_a.shape)
+
+    def cached_projection(width_kms):
+        return jnp.sum(_project_fixed_cached_local_nebular_line_filters(cached_context, line_lumin, width_kms, 0.2))
+
+    def exact_projection(width_kms):
+        return jnp.sum(_project_local_nebular_line_filters(
+            exact_context,
+            exact_context.nebular_templates_jax.line_wave_a,
+            line_lumin,
+            width_kms,
+            0.2,
+            exact_context.fixed_redshift_jax,
+            exact_context.fixed_luminosity_distance_m_jax,
+            exact_context.fixed_igm_jax,
+        ))
+
+    widths = jnp.geomspace(1.05, 9.5e4, 21)
+    cached_fluxes = jax.vmap(cached_projection)(widths)
+    exact_fluxes = jax.vmap(exact_projection)(widths)
+    np.testing.assert_allclose(cached_fluxes, exact_fluxes, rtol=5.0e-4, atol=1.0e-30)
+
+    cached_gradients = jax.vmap(jax.grad(cached_projection))(widths)
+    exact_gradients = jax.vmap(jax.grad(exact_projection))(widths)
+    gradient_scale = jnp.maximum(jnp.max(jnp.abs(exact_gradients)), 1.0e-30)
+    assert float(jnp.max(jnp.abs(cached_gradients - exact_gradients)) / gradient_scale) < 0.05
+
 
 def test_predict_supports_lightweight_and_median_modes(monkeypatch):
     _patch_ssp(monkeypatch)
@@ -929,16 +958,41 @@ def test_fixed_local_line_cache_matches_exact_local_line_projection(monkeypatch)
     data["log_narrow_line_width_kms"] = np.array(np.log(1200.0))
     data["feii_norm"] = np.array(0.0)
 
-    cached = _site(
-        _deterministic_likelihood_trace(build_model_context(_line_cfg(use_cache=True)), data),
-        "pred_fluxes",
-    )
-    exact = _site(
-        _deterministic_likelihood_trace(build_model_context(_line_cfg(use_cache=False)), data),
-        "pred_fluxes",
-    )
+    cached_context = build_model_context(_line_cfg(use_cache=True))
+    exact_context = build_model_context(_line_cfg(use_cache=False))
+    cached = _site(_deterministic_likelihood_trace(cached_context, data), "pred_fluxes")
+    exact = _site(_deterministic_likelihood_trace(exact_context, data), "pred_fluxes")
 
     np.testing.assert_allclose(cached, exact, rtol=5.0e-4, atol=1.0e-30)
+
+    line_lumin = jnp.ones(cached_context.templates.line_wave.shape)
+
+    def cached_projection(width_kms):
+        return jnp.sum(_project_fixed_cached_local_line_filters(cached_context, line_lumin, width_kms, 0.3))
+
+    def exact_projection(width_kms):
+        return jnp.sum(_project_local_line_filters(
+            exact_context,
+            exact_context.templates.line_wave,
+            line_lumin,
+            width_kms,
+            0.3,
+            exact_context.fixed_redshift_jax,
+            exact_context.fixed_luminosity_distance_m_jax,
+            exact_context.fixed_igm_jax,
+        ))
+
+    widths = jnp.geomspace(1.05, 9.5e4, 21)
+    np.testing.assert_allclose(
+        jax.vmap(cached_projection)(widths),
+        jax.vmap(exact_projection)(widths),
+        rtol=5.0e-4,
+        atol=1.0e-30,
+    )
+    cached_gradients = jax.vmap(jax.grad(cached_projection))(widths)
+    exact_gradients = jax.vmap(jax.grad(exact_projection))(widths)
+    gradient_scale = jnp.maximum(jnp.max(jnp.abs(exact_gradients)), 1.0e-30)
+    assert float(jnp.max(jnp.abs(cached_gradients - exact_gradients)) / gradient_scale) < 0.05
 
 
 def test_local_line_photometry_improves_redshift_fit_line_projection(monkeypatch):

--- a/tests/test_model_helpers.py
+++ b/tests/test_model_helpers.py
@@ -39,6 +39,7 @@ from jaxsedfit.model import (
     GRAHSP_TORUS_NORM_A,
     C_MS,
     _band_transmitted_fraction,
+    _absorbed_line_luminosity,
     _attenuation_transmitted_fraction,
     _attenuation_curve,
     _apply_biattenuation,
@@ -52,11 +53,13 @@ from jaxsedfit.model import (
     _host_dust_emission,
     _igm_transmission,
     _line_gaussians,
+    _local_flux_conserving_line_grid,
     _evaluate_jaxqsofit_backend,
     _powerlaw_jax,
     _project_local_nebular_line_filters,
     _project_filters,
     _redshift_to_obs,
+    _sample_bounded_normal,
     _torus_component,
     evaluate_sed_model,
     grahsp_photometric_model,
@@ -440,6 +443,97 @@ def test_flux_conserving_lines_preserve_integrated_luminosity():
     line = np.asarray(_flux_conserving_line_gaussians(wave, np.asarray([5000.0]), np.asarray([3.0]), 300.0))
 
     assert np.trapezoid(line, x=wave) == pytest.approx(3.0, rel=2.0e-4)
+
+
+def test_absorbed_line_luminosity_uses_conserved_integrated_energy():
+    line_wave = np.asarray([1000.0, 5000.0])
+    line_lumin = np.asarray([2.0, 3.0])
+    ebv = 0.2
+    curve = np.asarray(_attenuation_curve(line_wave, -1.2, -3.0, 1.2, GRAHSP_BIATTENUATION_BREAK_A))
+    expected = np.sum(line_lumin * (1.0 - 10 ** (ebv * curve / -2.5)))
+
+    absorbed = _absorbed_line_luminosity(
+        line_wave,
+        line_lumin,
+        ebv,
+        -1.2,
+        -3.0,
+        1.2,
+        GRAHSP_BIATTENUATION_BREAK_A,
+    )
+
+    assert float(absorbed) == pytest.approx(expected, rel=1.0e-12)
+
+
+def test_bounded_physical_priors_have_supported_nonzero_edge_gradients():
+    specs = {
+        "sfh_age": (0.0, 1.0, -4.0, 2.0),
+        "sfh_tau": (0.0, 1.0, np.log(0.03), np.log(30.0)),
+        "stellar_metallicity": (-1.0, 0.5, -2.0, -0.5),
+        "dust_alpha": (2.0, 0.4, 0.5, 4.0),
+        "nebular_logu": (-2.0, 0.3, -4.0, -1.0),
+        "nebular_z": (0.02, 0.01, 1.0e-4, 0.05),
+        "nebular_ne": (100.0, 100.0, 10.0, 1000.0),
+        "line_width": (300.0, 100.0, 1.0, 1.0e5),
+    }
+    prior_config = {
+        name: {
+            "dist": "TruncatedNormal",
+            "loc": loc,
+            "scale": scale,
+            "low": low - abs(high - low),
+            "high": high + abs(high - low),
+        }
+        for name, (loc, scale, low, high) in specs.items()
+    }
+
+    def model():
+        for name, (loc, scale, low, high) in specs.items():
+            _sample_bounded_normal(prior_config, name, loc, scale, low, high)
+
+    tr = trace(seed(model, 123)).get_trace()
+    for name, (_, _, low, high) in specs.items():
+        fn = tr[name]["fn"]
+        assert float(np.asarray(fn.support.lower_bound)) == pytest.approx(low)
+        assert float(np.asarray(fn.support.upper_bound)) == pytest.approx(high)
+        span = high - low
+        for value in (low + 0.01 * span, high - 0.01 * span):
+            gradient = jax.grad(lambda x: fn.log_prob(x))(value)
+            assert np.isfinite(float(gradient))
+            assert abs(float(gradient)) > 0.0
+
+
+def test_local_nebular_line_grid_converges_at_filter_edge():
+    """Bound sparse-quadrature error where a line crosses a sharp band edge."""
+    line_wave = 5000.0
+    line_lumin = np.asarray([1.0])
+    width_kms = 300.0
+    fwhm = line_wave * width_kms / 299792.458
+    edge_offsets = np.asarray([-1.0, -0.5, 0.0, 0.5, 1.0])
+
+    sparse_wave, sparse_lumin = _local_flux_conserving_line_grid(
+        np.asarray([line_wave]), line_lumin, width_kms
+    )
+    dense_wave, dense_lumin = _local_flux_conserving_line_grid(
+        np.asarray([line_wave]), line_lumin, width_kms, n_local=4097
+    )
+    sparse_wave = np.asarray(sparse_wave[0])
+    sparse_lumin = np.asarray(sparse_lumin[0])
+    dense_wave = np.asarray(dense_wave[0])
+    dense_lumin = np.asarray(dense_lumin[0])
+
+    sparse_flux = []
+    dense_flux = []
+    for offset in edge_offsets:
+        edge_center = line_wave + offset * fwhm
+        # A deliberately severe edge that ramps from zero to unity over two
+        # line FWHM; ordinary broadband edges are generally much smoother.
+        sparse_trans = np.clip((sparse_wave - edge_center) / (2.0 * fwhm) + 0.5, 0.0, 1.0)
+        dense_trans = np.clip((dense_wave - edge_center) / (2.0 * fwhm) + 0.5, 0.0, 1.0)
+        sparse_flux.append(np.trapezoid(sparse_lumin * sparse_trans, x=sparse_wave))
+        dense_flux.append(np.trapezoid(dense_lumin * dense_trans, x=dense_wave))
+
+    np.testing.assert_allclose(sparse_flux, dense_flux, rtol=0.0, atol=0.04)
 
 
 def test_native_agn_lines_use_5100_scaled_normalization():

--- a/tests/test_nebular.py
+++ b/tests/test_nebular.py
@@ -157,6 +157,30 @@ def test_nebular_trilinear_interpolation_has_parameter_gradients():
     assert all(abs(float(g)) > 0.0 for g in grads)
 
 
+def test_nebular_priors_are_truncated_to_template_and_cache_support(monkeypatch):
+    _patch_ssp(monkeypatch)
+    cfg = _mock_config()
+    cfg.prior_config.nebular.logU = dist.Normal(-2.0, 10.0)
+    cfg.prior_config.nebular.zgas = dist.Normal(0.02, 1.0)
+    cfg.prior_config.nebular.ne = dist.Normal(100.0, 1.0e5)
+    cfg.prior_config.nebular.lines_width = dist.Normal(300.0, 1.0e5)
+    context = build_model_context(cfg)
+
+    tr = trace(seed(lambda: grahsp_photometric_model(context, include_components=False), 7)).get_trace()
+    expected_bounds = {
+        "nebular_logU": (context.nebular_templates_jax.logu_grid[0], context.nebular_templates_jax.logu_grid[-1]),
+        "nebular_zgas": (context.nebular_templates_jax.z_grid[0], context.nebular_templates_jax.z_grid[-1]),
+        "nebular_ne": (context.nebular_templates_jax.ne_grid[0], context.nebular_templates_jax.ne_grid[-1]),
+        "nebular_lines_width": (1.0, 1.0e5),
+    }
+    for name, (low, high) in expected_bounds.items():
+        support = tr[name]["fn"].support
+        np.testing.assert_allclose(np.asarray(support.lower_bound), np.asarray(low), rtol=0.0, atol=0.0)
+        np.testing.assert_allclose(np.asarray(support.upper_bound), np.asarray(high), rtol=0.0, atol=0.0)
+        value = float(np.asarray(tr[name]["value"]))
+        assert float(low) <= value <= float(high)
+
+
 def test_host_basis_lyman_rates_are_finite(monkeypatch):
     _patch_ssp(monkeypatch)
     cfg = _mock_config()


### PR DESCRIPTION
## Summary

- skip redundant coarse nebular-line SED construction in photometry-only likelihood evaluations while conserving integrated attenuated line energy
- expand fixed local-line caches to 1--100,000 km/s with 256 width nodes
- truncate nebular, stellar metallicity, SFH age/timescale, and dust-template priors to their actual model support
- honor the public `log_sfh_tau_gyr` prior and reject simultaneous absolute-tau and tau/age parameterizations
- add filter-edge, cache flux/gradient convergence, energy-conservation, and prior-boundary regression tests

## Motivation

Narrow nebular lines were synthesized on the coarse broadband wavelength grid even though their photometry was subsequently replaced by local-grid projection. The coarse profiles also made the dust-energy budget resolution dependent. Separately, several custom Normal priors could override bounded defaults or be clipped after sampling, creating unsupported likelihood plateaus and zero-gradient regions.

## Validation

- 72 host, nebular, and model assembly tests passed
- dedicated prior-boundary and SFH parameterization tests passed
- AGN and nebular line caches agree with direct projection across 21 widths spanning 1.05--95,000 km/s to `rtol=5e-4`
- cached width gradients remain within 5% of the maximum direct-gradient scale
- filter-edge quadrature is checked against a 4097-point reference
