### PR TITLE
Add GRAHSP-style AGN error model

### DIFF
--- a/src/jaxsedfit/benchmark.py
+++ b/src/jaxsedfit/benchmark.py
@@ -532,6 +532,7 @@ def _reduced_chi2_for_fit(fitter: Any) -> float:
             """Minimal likelihood configuration used when old fitter objects lack one."""
 
             systematics_width = 0.0
+            agn_systematics_width = 0.0
             variability_uncertainty = False
             attenuation_model_uncertainty = False
             lyman_break_uncertainty = False
@@ -543,7 +544,12 @@ def _reduced_chi2_for_fit(fitter: Any) -> float:
         if "systematics_width" in pred
         else float(cfg.systematics_width)
     )
-    sys_variance = (systematics_width * pred_fluxes) ** 2
+    agn_systematics_width = (
+        float(np.median(np.asarray(pred["agn_systematics_width"], dtype=float)))
+        if "agn_systematics_width" in pred
+        else float(getattr(cfg, "agn_systematics_width", 0.0))
+    )
+    sys_variance = (systematics_width * obs_fluxes) ** 2 + (agn_systematics_width * agn_fluxes) ** 2
     var_variance = np.where(bool(cfg.variability_uncertainty), agn_variability_nev * agn_fluxes**2, 0.0)
     if cfg.attenuation_model_uncertainty:
         tf = np.clip(transmitted_fraction, 1e-4, 1.0)

--- a/src/jaxsedfit/config.py
+++ b/src/jaxsedfit/config.py
@@ -289,6 +289,9 @@ class LikelihoodConfig:
     systematics_width: float = 0.10
     fit_systematics_width: bool = True
     systematics_width_prior_scale: float = 0.10
+    agn_systematics_width: float = 0.0
+    fit_agn_systematics_width: bool = True
+    agn_systematics_width_prior_scale: float = 0.20
     likelihood_family: str = "gaussian"
     student_t_df: float = 5.0
     variability_uncertainty: bool = True
@@ -747,6 +750,8 @@ class LikelihoodPriorConfig:
     """Likelihood and calibration prior options."""
     systematics_width: Any | None = None
     log_systematics_width: Any | None = None
+    agn_systematics_width: Any | None = None
+    log_agn_systematics_width: Any | None = None
     host_capture_scale_arcsec: Any | None = None
     log_host_capture_scale_arcsec: Any | None = None
     host_capture_slope: Any | None = None
@@ -761,6 +766,8 @@ class LikelihoodPriorConfig:
             {
                 "systematics_width": "systematics_width",
                 "log_systematics_width": "log_systematics_width",
+                "agn_systematics_width": "agn_systematics_width",
+                "log_agn_systematics_width": "log_agn_systematics_width",
                 "host_capture_scale_arcsec": "host_capture_scale_arcsec",
                 "log_host_capture_scale_arcsec": "log_host_capture_scale_arcsec",
                 "host_capture_slope": "host_capture_slope",

--- a/src/jaxsedfit/core.py
+++ b/src/jaxsedfit/core.py
@@ -335,6 +335,7 @@ class JAXSEDFit:
             "log_agn_bol_luminosity_fit",
             "log_disk_luminosity_fit",
             "agn_variability_nev",
+            "agn_systematics_width",
             "host_total_fluxes",
             "host_capture_source_fluxes",
             "agn_narrow_line_fluxes_total",

--- a/src/jaxsedfit/model.py
+++ b/src/jaxsedfit/model.py
@@ -2290,6 +2290,7 @@ def photometric_loglike(
     redshift,
     nebular_line_component=None,
     local_nebular_line_uncertainty_dex=0.0,
+    agn_systematics_width=0.0,
 ):
     """Evaluate the broadband photometric log-likelihood for one model state.
 
@@ -2333,6 +2334,9 @@ def photometric_loglike(
         nebular_line_component value.
     local_nebular_line_uncertainty_dex : object
         local_nebular_line_uncertainty_dex value.
+    agn_systematics_width : object
+        Fractional AGN model-mismatch coefficient in the GRAHSP systematic
+        error term.
     """
     pred_fluxes = jnp.asarray(pred_fluxes, dtype=jnp.float64)
     obs_fluxes = jnp.asarray(obs_fluxes, dtype=jnp.float64)
@@ -2362,7 +2366,9 @@ def photometric_loglike(
     obs_variance = obs_errors**2
     variability_nev = _agn_variability_nev(agn_bol_lum_w, agn_nev)
     var_variance = jnp.where(variability_uncertainty, variability_nev * agn_component**2, 0.0)
-    sys_variance = (systematics_width * pred_fluxes) ** 2
+    # Keep the catalogue-wide systematic and AGN-template mismatch as
+    # independent contributions, as implemented by GRAHSP.
+    sys_variance = (systematics_width * obs_fluxes) ** 2 + (agn_systematics_width * agn_component) ** 2
     if nebular_line_component is not None:
         nebular_line_component = jnp.nan_to_num(nebular_line_component, nan=0.0, posinf=1.0e30, neginf=-1.0e30)
         nebular_line_sigma = jnp.expm1(
@@ -3140,6 +3146,17 @@ def evaluate_photometric_state(
             )
     else:
         systematics_width = jnp.asarray(float(cfg.likelihood.systematics_width), dtype=jnp.float64)
+    if cfg.likelihood.fit_agn_systematics_width and fit_agn:
+        agn_systematics_width = _sample_positive(
+            prior_config,
+            value_key="agn_systematics_width",
+            log_key="log_agn_systematics_width",
+            default_value=float(cfg.likelihood.agn_systematics_width_prior_scale),
+            default_log_scale=1.0,
+            default_family="exponential",
+        )
+    else:
+        agn_systematics_width = jnp.asarray(float(cfg.likelihood.agn_systematics_width), dtype=jnp.float64)
     if cfg.observation.fits_redshift:
         redshift = _sample_redshift(context, prior_config, cfg)
         luminosity_distance_m = _luminosity_distance_m_jax(
@@ -3810,6 +3827,7 @@ def evaluate_photometric_state(
         upper_limits=upper_limits,
         data_mask=data_mask,
         systematics_width=systematics_width,
+        agn_systematics_width=agn_systematics_width,
         likelihood_family=cfg.likelihood.likelihood_family,
         student_t_df=cfg.likelihood.student_t_df,
         agn_component=agn_fluxes,

--- a/src/jaxsedfit/model.py
+++ b/src/jaxsedfit/model.py
@@ -3695,7 +3695,13 @@ def evaluate_photometric_state(
     else:
         log_spectrum_scale = jnp.asarray(0.0, dtype=jnp.float64)
         spec_logl = jnp.asarray(0.0, dtype=jnp.float64)
-    need_agn_fluxes = fit_agn and (include_components or force_component_fluxes or cfg.likelihood.variability_uncertainty)
+    need_agn_fluxes = fit_agn and (
+        include_components
+        or force_component_fluxes
+        or cfg.likelihood.variability_uncertainty
+        or cfg.likelihood.fit_agn_systematics_width
+        or cfg.likelihood.agn_systematics_width > 0.0
+    )
     need_trans_fluxes = include_components or cfg.likelihood.attenuation_model_uncertainty
     if include_components:
         agn_obs = _redshift_to_obs(rest_wave, agn_rest * igm, obs_wave, redshift, luminosity_distance_m)

--- a/src/jaxsedfit/plotting.py
+++ b/src/jaxsedfit/plotting.py
@@ -502,6 +502,7 @@ def _median_effective_variance(fitter, pred: dict[str, Any]) -> np.ndarray:
             """Minimal likelihood configuration used when old fitter objects lack one."""
 
             systematics_width = 0.0
+            agn_systematics_width = 0.0
             variability_uncertainty = False
             attenuation_model_uncertainty = False
             lyman_break_uncertainty = False
@@ -509,12 +510,18 @@ def _median_effective_variance(fitter, pred: dict[str, Any]) -> np.ndarray:
         cfg = _FallbackLikelihood()
 
     obs_variance = obs_errors**2
+    obs_fluxes = np.asarray(getattr(fitter.context, "fluxes", fitter.config.photometry.fluxes), dtype=float)
     systematics_width = (
         float(np.median(np.asarray(pred["systematics_width"], dtype=float)))
         if "systematics_width" in pred
         else float(cfg.systematics_width)
     )
-    sys_variance = (systematics_width * pred_fluxes) ** 2
+    agn_systematics_width = (
+        float(np.median(np.asarray(pred["agn_systematics_width"], dtype=float)))
+        if "agn_systematics_width" in pred
+        else float(getattr(cfg, "agn_systematics_width", 0.0))
+    )
+    sys_variance = (systematics_width * obs_fluxes) ** 2 + (agn_systematics_width * agn_fluxes) ** 2
     var_variance = np.where(bool(cfg.variability_uncertainty), agn_variability_nev * agn_fluxes**2, 0.0)
     if cfg.attenuation_model_uncertainty:
         tf = np.clip(transmitted_fraction, 1e-4, 1.0)

--- a/tests/test_model_assembly.py
+++ b/tests/test_model_assembly.py
@@ -291,6 +291,26 @@ def test_systematics_width_can_use_physical_lognormal_prior(monkeypatch):
     assert np.isclose(_site(tr, "systematics_width"), 0.02)
 
 
+def test_agn_systematics_width_defaults_to_grahsp_exponential_prior(monkeypatch):
+    _patch_ssp(monkeypatch)
+    cfg = _cfg()
+    context = build_model_context(cfg)
+
+    tr = _deterministic_likelihood_trace(
+        context,
+        {
+            **_fixed_component_data(),
+            "agn_systematics_width": np.array(0.1),
+        },
+    )
+
+    assert tr["agn_systematics_width"]["type"] == "sample"
+    fn = tr["agn_systematics_width"]["fn"]
+    assert fn.__class__.__name__ == "Exponential"
+    assert np.isclose(np.asarray(fn.rate), 5.0)
+    assert np.isclose(_site(tr, "agn_systematics_width"), 0.1)
+
+
 def test_positive_geometry_parameters_are_sampled_in_log_space(monkeypatch):
     _patch_ssp(monkeypatch)
     context = build_model_context(_cfg())

--- a/tests/test_model_helpers.py
+++ b/tests/test_model_helpers.py
@@ -97,6 +97,8 @@ def test_likelihood_defaults_include_local_line_photometry():
     assert not hasattr(cfg, "absolute_flux_scale_prior_sigma_dex")
     assert cfg.use_local_line_photometry is True
     assert cfg.local_nebular_line_uncertainty_dex == pytest.approx(0.3)
+    assert cfg.fit_agn_systematics_width is True
+    assert cfg.agn_systematics_width_prior_scale == pytest.approx(0.20)
 
 
 @pytest.mark.parametrize("redshift", [-0.1, np.nan, np.inf])
@@ -946,6 +948,24 @@ def test_local_nebular_line_uncertainty_regularizes_only_line_component():
         )
     )
     assert no_line_component == pytest.approx(exact)
+
+
+def test_photometric_systematic_variance_matches_grahsp_error_model():
+    kwargs = _minimal_photometric_loglike_kwargs()
+    kwargs.update(
+        obs_fluxes=np.asarray([8.0]),
+        obs_errors=np.asarray([0.5]),
+        systematics_width=0.1,
+        agn_systematics_width=0.02,
+        agn_component=np.asarray([5.0]),
+    )
+    pred_fluxes = np.asarray([9.0])
+
+    actual = float(photometric_loglike(pred_fluxes=pred_fluxes, **kwargs))
+    sigma = np.sqrt(0.5**2 + (0.1 * 8.0) ** 2 + (0.02 * 5.0) ** 2)
+    expected = -0.5 * (((8.0 - 9.0) / sigma) ** 2 + np.log(2.0 * np.pi * sigma**2))
+
+    assert actual == pytest.approx(expected)
 
 
 def _minimal_photometric_loglike_kwargs():


### PR DESCRIPTION
## Summary

- separate the catalogue-wide systematic uncertainty from AGN-template mismatch in the photometric likelihood
- infer the fractional AGN systematic with a configurable exponential prior, using the GRAHSP scale of 0.2 by default
- retain the luminosity-dependent AGN variability variance as an independent contribution
- keep plotting and benchmark residual diagnostics consistent with the inference variance

## Motivation

The previous likelihood had only one global model-systematic term. This could understate host-galaxy uncertainty for AGN-dominated sources because uncertainty in the AGN component was not represented separately.

The updated variance is

```text
sigma_total^2 = sigma_obs^2
              + (f_overall * F_obs)^2
              + (f_sys * F_AGN)^2
              + NEV(L_bol) * F_AGN^2
              + optional component-specific terms
```

The independent quadrature terms follow the GRAHSP implementation and avoid introducing a cross-term between the catalogue and AGN systematics.

## Configuration

- `fit_agn_systematics_width = True`
- `agn_systematics_width_prior_scale = 0.20`
- `agn_systematics_width = 0.0` when fitting is disabled
- custom physical- or log-space priors remain available through `prior_config.likelihood`

## Validation

- `conda run -n jaxcpu python -m pytest -q tests/test_model_helpers.py tests/test_model_assembly.py tests/test_plotting.py tests/test_benchmark.py`
- 143 tests passed
- added an exact numerical likelihood test and a prior-parameterization test
