### PR TITLE
Use injected AGN luminosity in Chimera benchmark

### DIFF
--- a/notebooks/03_chimera_benchmarks.ipynb
+++ b/notebooks/03_chimera_benchmarks.ipynb
@@ -131,15 +131,20 @@
     "chimera_truth_lookup = load_chimera_truth_lookup(project_root)\n",
     "for row in subset:\n",
     "    row.update(chimera_truth_lookup.get(row[\"id\"], {}))\n",
+    "    row[\"log_lbol_chimera_truth\"] = (\n",
+    "        row.get(\"log_lbol_qso_truth\", np.nan) + np.log10(float(row[\"chimera_QSO_weight\"]))\n",
+    "    )\n",
     "\n",
     "qso_weights = np.array([row[\"chimera_QSO_weight\"] for row in subset], dtype=float)\n",
     "redshifts = np.array([row[\"redshift\"] for row in subset], dtype=float)\n",
     "log_lbol_qso = np.array([row.get(\"log_lbol_qso_truth\", np.nan) for row in subset], dtype=float)\n",
+    "log_lbol_chimera = np.array([row.get(\"log_lbol_chimera_truth\", np.nan) for row in subset], dtype=float)\n",
     "\n",
     "print(\"Deterministic subset size:\", len(subset))\n",
     "print(\"QSO-weight percentiles:\", np.percentile(qso_weights, [0, 25, 50, 75, 90, 95, 100]))\n",
     "print(\"Redshift percentiles:\", np.percentile(redshifts, [0, 25, 50, 75, 90, 95, 100]))\n",
-    "print(\"Truth log Lbol,QSO percentiles:\", np.nanpercentile(log_lbol_qso, [0, 25, 50, 75, 90, 95, 100]))\n"
+    "print(\"Truth log Lbol,QSO percentiles:\", np.nanpercentile(log_lbol_qso, [0, 25, 50, 75, 90, 95, 100]))\n",
+    "print(\"Truth injected log Lbol,Chimera percentiles:\", np.nanpercentile(log_lbol_chimera, [0, 25, 50, 75, 90, 95, 100]))\n"
    ]
   },
   {
@@ -161,13 +166,11 @@
     }
    ],
    "source": [
-    "finite_lbol_qso = log_lbol_qso[np.isfinite(log_lbol_qso)]\n",
-    "lbol_quartiles = np.quantile(finite_lbol_qso, [0.25, 0.50, 0.75])\n",
-    "LUMINOSITY_BIN_EDGES = np.concatenate(([-np.inf], lbol_quartiles, [np.inf]))\n",
+    "LUMINOSITY_BIN_EDGES = np.array([-np.inf, 42.0, 43.0, 44.0, 45.0])\n",
     "\n",
     "print(\"Luminosity bin edges:\", LUMINOSITY_BIN_EDGES)\n",
     "for low, high in zip(LUMINOSITY_BIN_EDGES[:-1], LUMINOSITY_BIN_EDGES[1:]):\n",
-    "    count = np.count_nonzero(np.isfinite(log_lbol_qso) & (log_lbol_qso >= low) & (log_lbol_qso < high))\n",
+    "    count = np.count_nonzero(np.isfinite(log_lbol_chimera) & (log_lbol_chimera >= low) & (log_lbol_chimera < high))\n",
     "    print(f\"  [{low:.3f}, {high:.3f}): {count} available objects\")\n"
    ]
   },
@@ -190,7 +193,7 @@
    "source": [
     "## Luminosity-Stratified AGN Benchmark\n",
     "\n",
-    "The helper below runs the same MAP+NUTS fitting path row by row. It divides the deterministic Chimera subset at its bolometric-luminosity quartiles and selects the same number of objects from each bin. Selection does not use `chimera_QSO_weight`; the diagnostic plot instead shows that weight continuously by color.\n",
+    "The helper below runs the same MAP+NUTS fitting path row by row. It bins by the true injected Chimera AGN luminosity, `logLbol_QSO + log10(chimera_QSO_weight)`, and selects up to the same number of objects from each requested bin. QSO weight is not used as an additional selection cut; the diagnostic plot shows it continuously by color.\n",
     "\n",
     "Use `num_workers=1` while debugging a model configuration in Jupyter. Increase it once the setup is stable; each worker runs an independent object fit.\n",
     "\n",
@@ -213,6 +216,7 @@
     "        \"chimera_QSO_weight\": float(row[\"chimera_QSO_weight\"]),\n",
     "        \"log_lbol_qso_truth\": log_lbol_qso,\n",
     "        \"log_lbol_qso_truth_err\": log_lbol_qso_err,\n",
+    "        \"log_lbol_chimera_truth\": float(row.get(\"log_lbol_chimera_truth\", np.nan)),\n",
     "        \"resample_weight\": float(row[\"resample_weight\"]),\n",
     "        \"log_stellar_mass_truth\": logm_truth,\n",
     "        \"log_stellar_mass_fit\": np.nan,\n",
@@ -314,6 +318,7 @@
     "                    \"chimera_QSO_weight\": float(row[\"chimera_QSO_weight\"]),\n",
     "                    \"log_lbol_qso_truth\": log_lbol_qso,\n",
     "                    \"log_lbol_qso_truth_err\": log_lbol_qso_err,\n",
+    "                    \"log_lbol_chimera_truth\": float(row.get(\"log_lbol_chimera_truth\", np.nan)),\n",
     "                    \"resample_weight\": float(row[\"resample_weight\"]),\n",
     "                    \"log_stellar_mass_truth\": logm_truth,\n",
     "                    \"log_stellar_mass_fit\": np.nan,\n",
@@ -534,8 +539,8 @@
     "    for bin_index, (low, high) in enumerate(zip(luminosity_bin_edges[:-1], luminosity_bin_edges[1:])):\n",
     "        bin_rows = [\n",
     "            row for row in rows\n",
-    "            if np.isfinite(row.get(\"log_lbol_qso_truth\", np.nan))\n",
-    "            and low <= float(row[\"log_lbol_qso_truth\"]) < high\n",
+    "            if np.isfinite(row.get(\"log_lbol_chimera_truth\", np.nan))\n",
+    "            and low <= float(row[\"log_lbol_chimera_truth\"]) < high\n",
     "        ]\n",
     "        if limit_per_bin is not None and len(bin_rows) > limit_per_bin:\n",
     "            take = np.sort(rng.choice(len(bin_rows), size=int(limit_per_bin), replace=False))\n",
@@ -613,7 +618,7 @@
     "            f\"[{label}] {idx:03d}/{total} bin={row['luminosity_bin_index']} {row['id']} stellar mass: \"\n",
     "            f\"truth={row['log_stellar_mass_truth']:.3f}, recovered={row['log_stellar_mass_fit']:.3f} \"\n",
     "            f\"(-{row['log_stellar_mass_fit_err_lo']:.3f}/+{row['log_stellar_mass_fit_err_hi']:.3f}) dex, \"\n",
-    "            f\"log Lbol,QSO={row['log_lbol_qso_truth']:.3f}\"\n",
+    "            f\"log Lbol,Chimera={row['log_lbol_chimera_truth']:.3f}\"\n",
     "        )\n",
     "    else:\n",
     "        print(\n",
@@ -639,7 +644,7 @@
     "    fit = np.array([row[\"log_stellar_mass_fit\"] for row in rows], dtype=float)\n",
     "    fit_err_lo = np.array([row.get(\"log_stellar_mass_fit_err_lo\", np.nan) for row in rows], dtype=float)\n",
     "    fit_err_hi = np.array([row.get(\"log_stellar_mass_fit_err_hi\", np.nan) for row in rows], dtype=float)\n",
-    "    log_lbol = np.array([row.get(\"log_lbol_qso_truth\", np.nan) for row in rows], dtype=float)\n",
+    "    log_lbol = np.array([row.get(\"log_lbol_chimera_truth\", np.nan) for row in rows], dtype=float)\n",
     "    qso_weight = np.array([row.get(\"chimera_QSO_weight\", np.nan) for row in rows], dtype=float)\n",
     "    finite = np.isfinite(truth) & np.isfinite(fit)\n",
     "    finite_err = finite & np.isfinite(fit_err_lo) & np.isfinite(fit_err_hi)\n",
@@ -696,7 +701,7 @@
     "    axes[0].set_ylabel(\"Recovered log stellar mass\")\n",
     "    if scatter is not None:\n",
     "        fig.colorbar(scatter, ax=axes, label=\"Chimera QSO weight\", pad=0.01)\n",
-    "    fig.suptitle(r\"Truth log $L_{\\mathrm{bol,QSO}}$ [erg s$^{-1}$]\")\n",
+    "    fig.suptitle(r\"Truth injected log $L_{\\mathrm{bol,Chimera}}$ [erg s$^{-1}$]\")\n",
     "    return fig, axes\n",
     "\n"
    ]
@@ -1008,7 +1013,7 @@
     "\n",
     "- The official benchmark is the only built-in regression path in the package today.\n",
     "- The luminosity-stratified sample in this notebook is an analysis convenience, not a separate packaged dataset.\n",
-    "- The luminosity bins are quartiles of the full deterministic subset, and QSO weight is not used in selection.\n",
+    "- The luminosity bins use the true injected Chimera AGN luminosity and span `<42`, `42–43`, `43–44`, and `44–45`.\n",
     "- The AGN normalization is inferred directly from the photometry when AGN fitting is enabled.\n",
     "- Increase `limit`, `map_steps`, or switch to the CLI benchmark once you are satisfied the notebook path is behaving as expected.\n"
    ]


### PR DESCRIPTION
## Summary

- compute the true injected Chimera AGN luminosity as `logLbol_QSO + log10(chimera_QSO_weight)`
- sample reproducibly in the requested `<42`, `42–43`, `43–44`, and `44–45` luminosity bins
- select up to 20 objects per bin without an additional QSO-weight cut
- color stellar-mass recovery points by continuous Chimera QSO weight on a shared logarithmic scale
- report metrics separately for each luminosity bin

## Motivation

`logLbol_QSO` describes the unscaled donor QSO, not the AGN luminosity injected into a Chimera source. Binning on that column omitted the many low-luminosity AGN produced by the Chimera QSO scaling.

In the 270-object deterministic subset, the requested injected-luminosity bins contain 18, 49, 65, and 64 available objects. With the default cap of 20, the benchmark selects 18, 20, 20, and 20 objects. Sources at `log L >= 45` are intentionally outside these panels.

## Validation

- validated the notebook as JSON
- parsed every code cell with Python's `ast` module
- verified the source-pool counts are 18/49/65/64
- smoke-tested the plotting function with panel counts 18/20/20/20 and the logarithmic weight color scale
