### PR TITLE
Use SSP-bin SFH integration

### DIFF
--- a/src/jaxsedfit/model.py
+++ b/src/jaxsedfit/model.py
@@ -27,6 +27,7 @@ from diffmah.diffmah_kernels import DEFAULT_MAH_PARAMS
 from diffstar import DEFAULT_DIFFSTAR_U_PARAMS, DiffstarUParams, calc_sfh_singlegal, get_bounded_diffstar_params
 from diffstar.defaults import FB as DIFFSTAR_FB
 from diffstar.defaults import LGT0 as DIFFSTAR_LGT0
+from dsps.sed.metallicity_weights import calc_lgmet_weights_from_lognormal_mdf
 from dsps.sed.ssp_weights import calc_ssp_weights_sfh_table_lognormal_mdf
 import numpyro
 import numpyro.distributions as dist
@@ -694,6 +695,53 @@ def _cigale_delayed_sfh_shape(elapsed_gyr, tau_gyr, age_gyr):
     age_gyr = jnp.asarray(age_gyr, dtype=jnp.float64)
     shape = elapsed_gyr * jnp.exp(-elapsed_gyr / tau_gyr) / (tau_gyr * tau_gyr)
     return jnp.where((elapsed_gyr > 0.0) & (elapsed_gyr <= age_gyr), shape, 0.0)
+
+
+def _ssp_log_age_bin_edges(ssp_lg_age_gyr):
+    """Return logarithmic bin edges centered on the tabulated SSP ages."""
+    lg_age = jnp.asarray(ssp_lg_age_gyr, dtype=jnp.float64)
+    interior = 0.5 * (lg_age[:-1] + lg_age[1:])
+    first = lg_age[0] - 0.5 * (lg_age[1] - lg_age[0])
+    last = lg_age[-1] + 0.5 * (lg_age[-1] - lg_age[-2])
+    return jnp.concatenate((first[None], interior, last[None]))
+
+
+def _delayed_sfh_cumulative_mass(elapsed_gyr, tau_gyr):
+    """Integral from zero to ``elapsed_gyr`` of the delayed-tau SFH shape."""
+    elapsed_gyr = jnp.maximum(jnp.asarray(elapsed_gyr, dtype=jnp.float64), 0.0)
+    tau_gyr = jnp.maximum(jnp.asarray(tau_gyr, dtype=jnp.float64), 1.0e-12)
+    x = elapsed_gyr / tau_gyr
+    return -jnp.expm1(-x) - x * jnp.exp(-x)
+
+
+def _analytic_delayed_ssp_weights(
+    age_gyr,
+    tau_gyr,
+    gal_lgmet,
+    gal_lgmet_scatter,
+    ssp_lgmet,
+    ssp_lg_age_gyr,
+):
+    """Exact delayed-SFH mass weights in the native SSP stellar-age bins.
+
+    The delayed SFH has an analytic antiderivative, so its mass contribution
+    to each SSP age bin does not require an auxiliary cosmic-time grid.
+    """
+    age_gyr = jnp.maximum(jnp.asarray(age_gyr, dtype=jnp.float64), 0.0)
+    age_edges_gyr = 10.0 ** _ssp_log_age_bin_edges(ssp_lg_age_gyr)
+    # Stellar age increases in the opposite direction to formation time.
+    elapsed_lo = jnp.clip(age_gyr - age_edges_gyr[1:], 0.0, age_gyr)
+    elapsed_hi = jnp.clip(age_gyr - age_edges_gyr[:-1], 0.0, age_gyr)
+    bin_mass = _delayed_sfh_cumulative_mass(elapsed_hi, tau_gyr) - _delayed_sfh_cumulative_mass(
+        elapsed_lo, tau_gyr
+    )
+    age_weights = bin_mass / jnp.maximum(jnp.sum(bin_mass), 1.0e-30)
+    lgmet_weights = calc_lgmet_weights_from_lognormal_mdf(
+        gal_lgmet, gal_lgmet_scatter, ssp_lgmet
+    )
+    weights = lgmet_weights[:, None] * age_weights[None, :]
+    weights = weights / jnp.maximum(jnp.sum(weights), 1.0e-30)
+    return weights, lgmet_weights, age_weights
 
 
 def _cigale_delayed_burst_sfh_shape(
@@ -2090,6 +2138,12 @@ def _build_delayed_host(
         burst_tau_gyr = jnp.asarray(0.0, dtype=jnp.float64)
         base_sfh = _cigale_delayed_sfh_shape(sfh_age_gyr, tau_gyr, age_gyr)
     base_smh = _cumulative_trapezoid(base_sfh, gal_t_table) * 1.0e9
+    if not use_burst:
+        # Keep the reported cumulative mass history consistent with the exact
+        # integral used for the SSP weights and formed-mass normalization.
+        base_smh = _delayed_sfh_cumulative_mass(
+            jnp.clip(sfh_age_gyr, 0.0, age_gyr), tau_gyr
+        ) * 1.0e9
 
     gal_lgmet, gal_lgmet_scatter = _host_metallicity_parameters(
         context,
@@ -2106,20 +2160,35 @@ def _build_delayed_host(
         solar_metallicity=cfg.ssp_solar_metallicity,
     )
     numpyro.factor("mass_metallicity_relation_prior", mmr_logprior)
-    host_weights_info = calc_ssp_weights_sfh_table_lognormal_mdf(
-        gal_t_table,
-        base_sfh,
-        gal_lgmet,
-        gal_lgmet_scatter,
-        ssp_lgmet,
-        ssp_lg_age_gyr,
-        t_obs_gyr,
-    )
-    host_weights = host_weights_info.weights
-    surviving_mass_fraction = jnp.clip(jnp.sum(host_weights_info.age_weights * surviving_frac_by_age), 1e-12, 1.0)
+    if use_burst:
+        host_weights_info = calc_ssp_weights_sfh_table_lognormal_mdf(
+            gal_t_table,
+            base_sfh,
+            gal_lgmet,
+            gal_lgmet_scatter,
+            ssp_lgmet,
+            ssp_lg_age_gyr,
+            t_obs_gyr,
+        )
+        host_weights = host_weights_info.weights
+        lgmet_weights = host_weights_info.lgmet_weights
+        age_weights = host_weights_info.age_weights
+        base_formed_mass = jnp.clip(base_smh[-1], 1e-30, 1.0e40)
+    else:
+        host_weights, lgmet_weights, age_weights = _analytic_delayed_ssp_weights(
+            age_gyr,
+            tau_gyr,
+            gal_lgmet,
+            gal_lgmet_scatter,
+            ssp_lgmet,
+            ssp_lg_age_gyr,
+        )
+        base_formed_mass = jnp.maximum(
+            _delayed_sfh_cumulative_mass(age_gyr, tau_gyr) * 1.0e9, 1.0e-30
+        )
+    surviving_mass_fraction = jnp.clip(jnp.sum(age_weights * surviving_frac_by_age), 1e-12, 1.0)
     target_surviving_mass = 10.0**log_stellar_mass
     target_formed_mass = target_surviving_mass / surviving_mass_fraction
-    base_formed_mass = jnp.clip(base_smh[-1], 1e-30, 1.0e40)
     sfh_scale = target_formed_mass / base_formed_mass
     host_rest = target_formed_mass * jnp.tensordot(
         host_weights,
@@ -2135,8 +2204,8 @@ def _build_delayed_host(
         "gal_lgmet": gal_lgmet,
         "gal_lgmet_scatter": gal_lgmet_scatter,
         "mass_metallicity_relation_logprior": mmr_logprior,
-        "host_age_weights": host_weights_info.age_weights,
-        "host_lgmet_weights": host_weights_info.lgmet_weights,
+        "host_age_weights": age_weights,
+        "host_lgmet_weights": lgmet_weights,
         "host_ssp_weights": host_weights,
         "ssp_lg_age_gyr": ssp_lg_age_gyr,
         "ssp_lgmet": ssp_lgmet,
@@ -2150,8 +2219,8 @@ def _build_delayed_host(
         return state
     state.update(
         {
-            "host_age_weights": host_weights_info.age_weights,
-            "host_lgmet_weights": host_weights_info.lgmet_weights,
+            "host_age_weights": age_weights,
+            "host_lgmet_weights": lgmet_weights,
             "host_ssp_weights": host_weights,
             "gal_sfr_table": base_sfh * sfh_scale,
             "gal_smh_table": base_smh * sfh_scale,

--- a/src/jaxsedfit/model.py
+++ b/src/jaxsedfit/model.py
@@ -51,6 +51,7 @@ DEFAULT_BROAD_LINES_STRENGTH = 1.0
 DEFAULT_NARROW_LINES_STRENGTH = 1.0
 DEFAULT_FEII_STRENGTH = 5.0
 DEFAULT_BALMER_CONTINUUM_STRENGTH = 1.0e-3
+_SSP_BIN_QUAD_NODES, _SSP_BIN_QUAD_WEIGHTS = np.polynomial.legendre.leggauss(16)
 GRAHSP_BIATTENUATION_BREAK_A = 11000.0
 GRAHSP_EBV_MIN = 0.01
 GRAHSP_EBV_MAX = 10.0
@@ -727,6 +728,17 @@ def _analytic_delayed_ssp_weights(
     The delayed SFH has an analytic antiderivative, so its mass contribution
     to each SSP age bin does not require an auxiliary cosmic-time grid.
     """
+    age_weights = _analytic_delayed_age_weights(age_gyr, tau_gyr, ssp_lg_age_gyr)
+    lgmet_weights = calc_lgmet_weights_from_lognormal_mdf(
+        gal_lgmet, gal_lgmet_scatter, ssp_lgmet
+    )
+    weights = lgmet_weights[:, None] * age_weights[None, :]
+    weights = weights / jnp.maximum(jnp.sum(weights), 1.0e-30)
+    return weights, lgmet_weights, age_weights
+
+
+def _analytic_delayed_age_weights(age_gyr, tau_gyr, ssp_lg_age_gyr):
+    """Exact normalized delayed-SFH mass weights in SSP stellar-age bins."""
     age_gyr = jnp.maximum(jnp.asarray(age_gyr, dtype=jnp.float64), 0.0)
     age_edges_gyr = 10.0 ** _ssp_log_age_bin_edges(ssp_lg_age_gyr)
     # Stellar age increases in the opposite direction to formation time.
@@ -735,13 +747,93 @@ def _analytic_delayed_ssp_weights(
     bin_mass = _delayed_sfh_cumulative_mass(elapsed_hi, tau_gyr) - _delayed_sfh_cumulative_mass(
         elapsed_lo, tau_gyr
     )
-    age_weights = bin_mass / jnp.maximum(jnp.sum(bin_mass), 1.0e-30)
-    lgmet_weights = calc_lgmet_weights_from_lognormal_mdf(
-        gal_lgmet, gal_lgmet_scatter, ssp_lgmet
+    return bin_mass / jnp.maximum(jnp.sum(bin_mass), 1.0e-30)
+
+
+def _analytic_delayed_burst_age_weights(
+    age_gyr,
+    tau_gyr,
+    burst_fraction,
+    burst_age_gyr,
+    burst_tau_gyr,
+    ssp_lg_age_gyr,
+):
+    """Exact SSP age weights for CIGALE's delayed plus exponential burst SFH."""
+    age_gyr = jnp.maximum(jnp.asarray(age_gyr, dtype=jnp.float64), 0.0)
+    burst_fraction = jnp.clip(
+        jnp.asarray(burst_fraction, dtype=jnp.float64), 0.0, 1.0 - 1.0e-8
     )
-    weights = lgmet_weights[:, None] * age_weights[None, :]
-    weights = weights / jnp.maximum(jnp.sum(weights), 1.0e-30)
-    return weights, lgmet_weights, age_weights
+    burst_age_gyr = jnp.clip(
+        jnp.asarray(burst_age_gyr, dtype=jnp.float64), 1.0e-12, age_gyr
+    )
+    burst_tau_gyr = jnp.maximum(
+        jnp.asarray(burst_tau_gyr, dtype=jnp.float64), 1.0e-12
+    )
+    age_edges_gyr = 10.0 ** _ssp_log_age_bin_edges(ssp_lg_age_gyr)
+    elapsed_lo = jnp.clip(age_gyr - age_edges_gyr[1:], 0.0, age_gyr)
+    elapsed_hi = jnp.clip(age_gyr - age_edges_gyr[:-1], 0.0, age_gyr)
+
+    main_bin_mass = _delayed_sfh_cumulative_mass(
+        elapsed_hi, tau_gyr
+    ) - _delayed_sfh_cumulative_mass(elapsed_lo, tau_gyr)
+    burst_start = age_gyr - burst_age_gyr
+    burst_lo = jnp.clip(elapsed_lo, burst_start, age_gyr)
+    burst_hi = jnp.clip(elapsed_hi, burst_start, age_gyr)
+    burst_bin_mass = burst_tau_gyr * (
+        jnp.exp(-(burst_lo - burst_start) / burst_tau_gyr)
+        - jnp.exp(-(burst_hi - burst_start) / burst_tau_gyr)
+    )
+    main_total = _delayed_sfh_cumulative_mass(age_gyr, tau_gyr)
+    burst_total = burst_tau_gyr * (-jnp.expm1(-burst_age_gyr / burst_tau_gyr))
+    burst_scale = (
+        burst_fraction
+        / jnp.maximum(1.0 - burst_fraction, 1.0e-8)
+        * main_total
+        / jnp.maximum(burst_total, 1.0e-30)
+    )
+    age_weights = main_bin_mass + burst_scale * burst_bin_mass
+    return age_weights / jnp.maximum(jnp.sum(age_weights), 1.0e-30)
+
+
+def _exponential_burst_cumulative_mass(elapsed_gyr, age_gyr, burst_age_gyr, burst_tau_gyr):
+    """Integral of the unit-amplitude recent exponential burst from its onset."""
+    burst_start = age_gyr - burst_age_gyr
+    duration = jnp.clip(elapsed_gyr - burst_start, 0.0, burst_age_gyr)
+    return burst_tau_gyr * (-jnp.expm1(-duration / burst_tau_gyr))
+
+
+def _diffstar_ssp_age_weights(
+    bounded_diffstar_params,
+    ssp_lg_age_gyr,
+    t_obs_gyr,
+    t_birth_min_gyr=0.01,
+    quad_nodes=_SSP_BIN_QUAD_NODES,
+    quad_weights=_SSP_BIN_QUAD_WEIGHTS,
+):
+    """Integrate a Diffstar SFH directly inside every native SSP age bin."""
+    t_obs_gyr = jnp.asarray(t_obs_gyr, dtype=jnp.float64)
+    t_birth_min_gyr = jnp.asarray(t_birth_min_gyr, dtype=jnp.float64)
+    stellar_age_edges = 10.0 ** _ssp_log_age_bin_edges(ssp_lg_age_gyr)
+    birth_lo = jnp.clip(t_obs_gyr - stellar_age_edges[1:], t_birth_min_gyr, t_obs_gyr)
+    birth_hi = jnp.clip(t_obs_gyr - stellar_age_edges[:-1], t_birth_min_gyr, t_obs_gyr)
+    half_width = 0.5 * jnp.maximum(birth_hi - birth_lo, 0.0)
+    midpoint = 0.5 * (birth_hi + birth_lo)
+    nodes = midpoint[:, None] + half_width[:, None] * jnp.asarray(
+        quad_nodes, dtype=jnp.float64
+    )[None, :]
+    sfr = calc_sfh_singlegal(
+        bounded_diffstar_params,
+        DEFAULT_MAH_PARAMS,
+        nodes.reshape((-1,)),
+        lgt0=DIFFSTAR_LGT0,
+        fb=DIFFSTAR_FB,
+        return_smh=False,
+    ).reshape(nodes.shape)
+    bin_mass = half_width * jnp.sum(
+        sfr * jnp.asarray(quad_weights, dtype=jnp.float64)[None, :], axis=1
+    )
+    age_weights = bin_mass / jnp.maximum(jnp.sum(bin_mass), 1.0e-30)
+    return age_weights, bin_mass
 
 
 def _cigale_delayed_burst_sfh_shape(
@@ -1962,19 +2054,22 @@ def _build_diffstar_host(
         solar_metallicity=galaxy_cfg.ssp_solar_metallicity,
     )
     numpyro.factor("mass_metallicity_relation_prior", mmr_logprior)
-    host_weights_info = calc_ssp_weights_sfh_table_lognormal_mdf(
-        gal_t_table,
-        base_history.sfh,
-        gal_lgmet,
-        gal_lgmet_scatter,
-        ssp_lgmet,
+    age_weights, _ = _diffstar_ssp_age_weights(
+        bounded,
         ssp_lg_age_gyr,
         t_obs_gyr,
+        t_birth_min_gyr=gal_t_table[0],
     )
-    host_weights = host_weights_info.weights
-    surviving_mass_fraction = jnp.clip(jnp.sum(host_weights_info.age_weights * surviving_frac_by_age), 1e-12, 1.0)
+    lgmet_weights = calc_lgmet_weights_from_lognormal_mdf(
+        gal_lgmet, gal_lgmet_scatter, ssp_lgmet
+    )
+    host_weights = lgmet_weights[:, None] * age_weights[None, :]
+    host_weights = host_weights / jnp.maximum(jnp.sum(host_weights), 1.0e-30)
+    surviving_mass_fraction = jnp.clip(jnp.sum(age_weights * surviving_frac_by_age), 1e-12, 1.0)
     target_surviving_mass = 10.0**log_stellar_mass
     target_formed_mass = target_surviving_mass / surviving_mass_fraction
+    # The original history remains the reported/scaled SFH diagnostic; only
+    # its projection into SSP age bins uses the higher-accuracy quadrature.
     base_formed_mass = jnp.clip(base_history.smh[-1], 1e-30, 1.0e40)
     sfh_scale = target_formed_mass / base_formed_mass
     host_rest = target_formed_mass * jnp.tensordot(
@@ -1991,8 +2086,8 @@ def _build_diffstar_host(
         "gal_lgmet": gal_lgmet,
         "gal_lgmet_scatter": gal_lgmet_scatter,
         "mass_metallicity_relation_logprior": mmr_logprior,
-        "host_age_weights": host_weights_info.age_weights,
-        "host_lgmet_weights": host_weights_info.lgmet_weights,
+        "host_age_weights": age_weights,
+        "host_lgmet_weights": lgmet_weights,
         "host_ssp_weights": host_weights,
         "ssp_lg_age_gyr": ssp_lg_age_gyr,
         "ssp_lgmet": ssp_lgmet,
@@ -2005,8 +2100,8 @@ def _build_diffstar_host(
     scaled_smh = base_history.smh * sfh_scale
     state.update(
         {
-            "host_age_weights": host_weights_info.age_weights,
-            "host_lgmet_weights": host_weights_info.lgmet_weights,
+            "host_age_weights": age_weights,
+            "host_lgmet_weights": lgmet_weights,
             "host_ssp_weights": host_weights,
             "gal_sfr_table": scaled_sfh,
             "gal_smh_table": scaled_smh,
@@ -2137,13 +2232,30 @@ def _build_delayed_host(
         burst_age_gyr = jnp.asarray(0.0, dtype=jnp.float64)
         burst_tau_gyr = jnp.asarray(0.0, dtype=jnp.float64)
         base_sfh = _cigale_delayed_sfh_shape(sfh_age_gyr, tau_gyr, age_gyr)
-    base_smh = _cumulative_trapezoid(base_sfh, gal_t_table) * 1.0e9
-    if not use_burst:
-        # Keep the reported cumulative mass history consistent with the exact
-        # integral used for the SSP weights and formed-mass normalization.
-        base_smh = _delayed_sfh_cumulative_mass(
-            jnp.clip(sfh_age_gyr, 0.0, age_gyr), tau_gyr
-        ) * 1.0e9
+    elapsed_history = jnp.clip(sfh_age_gyr, 0.0, age_gyr)
+    main_cumulative = _delayed_sfh_cumulative_mass(elapsed_history, tau_gyr)
+    main_total = _delayed_sfh_cumulative_mass(age_gyr, tau_gyr)
+    if use_burst:
+        burst_cumulative = _exponential_burst_cumulative_mass(
+            elapsed_history, age_gyr, burst_age_gyr, burst_tau_gyr
+        )
+        burst_total = _exponential_burst_cumulative_mass(
+            age_gyr, age_gyr, burst_age_gyr, burst_tau_gyr
+        )
+        burst_scale = (
+            burst_fraction
+            / jnp.maximum(1.0 - burst_fraction, 1.0e-8)
+            * main_total
+            / jnp.maximum(burst_total, 1.0e-30)
+        )
+        base_smh = (main_cumulative + burst_scale * burst_cumulative) * 1.0e9
+        base_formed_mass = jnp.maximum(
+            main_total / jnp.maximum(1.0 - burst_fraction, 1.0e-8) * 1.0e9,
+            1.0e-30,
+        )
+    else:
+        base_smh = main_cumulative * 1.0e9
+        base_formed_mass = jnp.maximum(main_total * 1.0e9, 1.0e-30)
 
     gal_lgmet, gal_lgmet_scatter = _host_metallicity_parameters(
         context,
@@ -2161,31 +2273,21 @@ def _build_delayed_host(
     )
     numpyro.factor("mass_metallicity_relation_prior", mmr_logprior)
     if use_burst:
-        host_weights_info = calc_ssp_weights_sfh_table_lognormal_mdf(
-            gal_t_table,
-            base_sfh,
-            gal_lgmet,
-            gal_lgmet_scatter,
-            ssp_lgmet,
-            ssp_lg_age_gyr,
-            t_obs_gyr,
-        )
-        host_weights = host_weights_info.weights
-        lgmet_weights = host_weights_info.lgmet_weights
-        age_weights = host_weights_info.age_weights
-        base_formed_mass = jnp.clip(base_smh[-1], 1e-30, 1.0e40)
-    else:
-        host_weights, lgmet_weights, age_weights = _analytic_delayed_ssp_weights(
+        age_weights = _analytic_delayed_burst_age_weights(
             age_gyr,
             tau_gyr,
-            gal_lgmet,
-            gal_lgmet_scatter,
-            ssp_lgmet,
+            burst_fraction,
+            burst_age_gyr,
+            burst_tau_gyr,
             ssp_lg_age_gyr,
         )
-        base_formed_mass = jnp.maximum(
-            _delayed_sfh_cumulative_mass(age_gyr, tau_gyr) * 1.0e9, 1.0e-30
-        )
+    else:
+        age_weights = _analytic_delayed_age_weights(age_gyr, tau_gyr, ssp_lg_age_gyr)
+    lgmet_weights = calc_lgmet_weights_from_lognormal_mdf(
+        gal_lgmet, gal_lgmet_scatter, ssp_lgmet
+    )
+    host_weights = lgmet_weights[:, None] * age_weights[None, :]
+    host_weights = host_weights / jnp.maximum(jnp.sum(host_weights), 1.0e-30)
     surviving_mass_fraction = jnp.clip(jnp.sum(age_weights * surviving_frac_by_age), 1e-12, 1.0)
     target_surviving_mass = 10.0**log_stellar_mass
     target_formed_mass = target_surviving_mass / surviving_mass_fraction

--- a/tests/test_diffstar_host.py
+++ b/tests/test_diffstar_host.py
@@ -3,6 +3,7 @@ import jax.numpy as jnp
 import numpy as np
 import numpyro.distributions as dist
 import pytest
+from diffstar import DEFAULT_DIFFSTAR_U_PARAMS, get_bounded_diffstar_params
 from numpyro.handlers import seed, trace
 
 from jaxsedfit.config import (
@@ -23,11 +24,13 @@ from jaxsedfit.config import (
 )
 from jaxsedfit.core import JAXSEDFit
 from jaxsedfit.model import (
+    _analytic_delayed_burst_age_weights,
     _analytic_delayed_ssp_weights,
     _cigale_delayed_burst_sfh_shape,
     _cigale_delayed_sfh_shape,
     _delayed_sfh_cumulative_mass,
     _default_gal_lgmet_loc,
+    _diffstar_ssp_age_weights,
     _mass_metallicity_relation_logprior,
     _luminosity_distance_m_jax,
     grahsp_photometric_model,
@@ -210,6 +213,85 @@ def test_delayed_burst_sfh_matches_cigale_formed_mass_fraction():
 
     assert recovered_fraction == pytest.approx(f_burst, rel=2.0e-12)
     assert np.allclose(burst[elapsed_gyr < 4.8], 0.0)
+
+
+def test_analytic_delayed_burst_weights_match_dense_bin_integrals():
+    lg_age = jnp.linspace(-3.0, jnp.log10(5.5), 80)
+    age, tau = 5.0, 2.0
+    burst_fraction, burst_age, burst_tau = 0.08, 0.2, 0.05
+    analytic = np.asarray(
+        _analytic_delayed_burst_age_weights(
+            age, tau, burst_fraction, burst_age, burst_tau, lg_age
+        )
+    )
+
+    lg_age_np = np.asarray(lg_age)
+    edges = np.concatenate(
+        (
+            [lg_age_np[0] - 0.5 * (lg_age_np[1] - lg_age_np[0])],
+            0.5 * (lg_age_np[:-1] + lg_age_np[1:]),
+            [lg_age_np[-1] + 0.5 * (lg_age_np[-1] - lg_age_np[-2])],
+        )
+    )
+    elapsed = np.linspace(0.0, age, 500_001)
+    sfh_elapsed = np.asarray(
+        _cigale_delayed_burst_sfh_shape(
+            elapsed, tau, age, burst_fraction, burst_age, burst_tau
+        )
+    )
+    stellar_age = age - elapsed[::-1]
+    sfh = sfh_elapsed[::-1]
+    cumulative = np.concatenate(
+        ([0.0], np.cumsum(0.5 * (sfh[1:] + sfh[:-1]) * np.diff(stellar_age)))
+    )
+    mass_at_edges = np.interp(np.clip(10.0**edges, 0.0, age), stellar_age, cumulative)
+    numerical = np.diff(mass_at_edges)
+    numerical /= numerical.sum()
+    np.testing.assert_allclose(analytic, numerical, rtol=2e-3, atol=3e-7)
+
+    gradient = jax.grad(
+        lambda fraction: jnp.sum(
+            _analytic_delayed_burst_age_weights(
+                age, tau, fraction, burst_age, burst_tau, lg_age
+            )
+            * 10.0**lg_age
+        )
+    )(burst_fraction)
+    assert np.isfinite(float(gradient))
+
+
+@pytest.mark.parametrize(
+    "updates",
+    [
+        {},
+        {"u_lg_qt": -2.0, "u_qlglgdt": -2.0},
+        {"u_lg_qt": 2.0, "u_qlglgdt": 2.0, "u_lg_drop": 2.0},
+        {"u_lgmcrit": -2.0, "u_lgy_at_mcrit": 2.0},
+    ],
+)
+def test_diffstar_ssp_bin_quadrature_matches_64_node_reference(updates):
+    u_params = DEFAULT_DIFFSTAR_U_PARAMS._replace(**updates)
+    bounded = get_bounded_diffstar_params(u_params)
+    lg_age = jnp.linspace(-3.5, jnp.log10(13.5), 107)
+    weights16, _ = _diffstar_ssp_age_weights(bounded, lg_age, 13.7)
+    nodes64, quad64 = np.polynomial.legendre.leggauss(64)
+    weights64, _ = _diffstar_ssp_age_weights(
+        bounded, lg_age, 13.7, quad_nodes=nodes64, quad_weights=quad64
+    )
+    np.testing.assert_allclose(np.asarray(weights16).sum(), 1.0, rtol=1e-12)
+    assert float(jnp.sum(jnp.abs(weights16 - weights64))) < 2.0e-4
+
+    gradient = jax.grad(
+        lambda lgmcrit: jnp.sum(
+            _diffstar_ssp_age_weights(
+                get_bounded_diffstar_params(u_params._replace(u_lgmcrit=lgmcrit)),
+                lg_age,
+                13.7,
+            )[0]
+            * 10.0**lg_age
+        )
+    )(u_params.u_lgmcrit)
+    assert np.isfinite(float(gradient))
 
 
 def test_delayed_burst_host_exposes_burst_parameters(monkeypatch):

--- a/tests/test_diffstar_host.py
+++ b/tests/test_diffstar_host.py
@@ -1,3 +1,5 @@
+import jax
+import jax.numpy as jnp
 import numpy as np
 import numpyro.distributions as dist
 import pytest
@@ -21,8 +23,10 @@ from jaxsedfit.config import (
 )
 from jaxsedfit.core import JAXSEDFit
 from jaxsedfit.model import (
+    _analytic_delayed_ssp_weights,
     _cigale_delayed_burst_sfh_shape,
     _cigale_delayed_sfh_shape,
+    _delayed_sfh_cumulative_mass,
     _default_gal_lgmet_loc,
     _mass_metallicity_relation_logprior,
     _luminosity_distance_m_jax,
@@ -155,6 +159,35 @@ def test_delayed_sfh_matches_cigale_v2025_1_static_reference():
     np.testing.assert_allclose(normalized_sfr[sample_indices], expected, rtol=2.0e-12, atol=0.0)
     assert np.sum(normalized_sfr) * 1.0e6 == pytest.approx(1.0, rel=2.0e-12)
     assert float(_cigale_delayed_sfh_shape(5.001, 2.0, 5.0)) == 0.0
+
+
+def test_delayed_sfh_analytic_integral_matches_dense_quadrature():
+    elapsed = jnp.linspace(0.0, 3.7, 200_001)
+    numerical = jnp.trapezoid(_cigale_delayed_sfh_shape(elapsed, 0.8, 3.7), elapsed)
+    analytic = _delayed_sfh_cumulative_mass(3.7, 0.8)
+    np.testing.assert_allclose(analytic, numerical, rtol=1e-9, atol=1e-11)
+
+
+def test_analytic_delayed_ssp_weights_are_normalized_and_differentiable():
+    lg_age = jnp.linspace(-4.0, 1.1, 107)
+    lgmet = jnp.linspace(-2.0, -1.0, 12)
+
+    def mean_stellar_age(age, tau):
+        weights, met_weights, age_weights = _analytic_delayed_ssp_weights(
+            age, tau, -1.7, 0.1, lgmet, lg_age
+        )
+        assert weights.shape == (12, 107)
+        return (
+            jnp.sum(age_weights * 10.0**lg_age),
+            (jnp.sum(weights), jnp.sum(met_weights), jnp.sum(age_weights)),
+        )
+
+    (value, sums), gradients = jax.value_and_grad(mean_stellar_age, argnums=(0, 1), has_aux=True)(
+        3.7, 0.8
+    )
+    np.testing.assert_allclose(np.asarray(sums), 1.0, rtol=1e-12)
+    assert np.isfinite(float(value))
+    assert np.all(np.isfinite(np.asarray(gradients)))
 
 
 def test_delayed_burst_sfh_matches_cigale_formed_mass_fraction():


### PR DESCRIPTION
## Summary

- integrate the standard delayed-tau SFH analytically over the native SSP stellar-age bins
- remove the 64-point cosmic-time quadrature from delayed-host SSP weights and formed-mass normalization
- integrate the exponential burst analytically over the same SSP age bins
- replace Diffstar's global 64-point grid with 16-node Gauss-Legendre quadrature inside each SSP age bin
- add normalization, dense-reference, gradient, and mass-accounting regression coverage

## Why

The geometric 64-point cosmic-time grid severely undersampled recent star formation. In fixed-parameter comparisons, its 95th-percentile spectral error reached 0.44 dex for a 158 Myr population and 0.90 dex for a 562 Myr population. This particularly affects young/UV stellar components and can make the likelihood irregular as the SFH onset crosses grid samples.

The delayed SFH has a closed-form antiderivative, so the formed mass assigned to each SSP age bin can be calculated exactly without a separate integration grid.

## Impact

The delayed and delayed+burst hosts now have grid-independent SSP weights, exact formed/surviving-mass closure, and finite gradients. Diffstar weights are integrated on the grid that the SSP projection actually consumes. The shared `jaxsedfit.host.build_host_state` API means physical host fits in jaxqsofit also receive the correction once they use this revision.

For four representative Diffstar histories, the legacy spectral errors were 0.0118--0.131 dex relative to a dense reference. SSP-bin quadrature reduced these errors below 4.6e-5 dex. Its isolated steady-state value+gradient cost was 1.26x the legacy weight calculation (104 versus 82 microseconds on CPU).

## Validation

- focused host, assembly, and nebular suites: 97 passed
- full suite: 279 passed
- fixed-parameter FSPS/CIGALE comparison rerun across five age/tau cases
- Diffstar comparison against 64-node-per-SSP-bin references across four representative histories
