### PR TITLE
Fix SSP IMF default and disable MZR prior

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -223,7 +223,7 @@ low-dimensional and usually the most stable choice for broadband SED fitting.
        fit_host=True,
        host_sfh_model="delayed",
        dsps_ssp_fn="tempdata.h5",
-       ssp_imf="chabrier_2003",
+       ssp_imf="kroupa_2001",
        ssp_metallicity_coordinate="absolute_log10_z",
        ssp_solar_metallicity=0.019,
        rest_wave_min=100.0,
@@ -234,7 +234,8 @@ low-dimensional and usually the most stable choice for broadband SED fitting.
 ``ssp_imf`` and ``ssp_metallicity_coordinate`` declare the provenance of the
 loaded SSP library. They do not regenerate it. The IMF declaration also selects
 the matching DSPS surviving-mass calibration, so it must describe the SSP file
-accurately. Supported IMFs are ``chabrier_2003``, ``salpeter_1955``,
+accurately. The public DSPS FSPS-v3.2 artifact used above was generated with the
+FSPS default Kroupa (2001) IMF. Supported IMFs are ``chabrier_2003``, ``salpeter_1955``,
 ``kroupa_2001``, and ``van_dokkum_2008``. Supported metallicity coordinates are
 ``absolute_log10_z`` and ``log10_z_over_zsun``. Custom IMFs require an SSP format
 that supplies its own surviving-mass fractions and are not silently approximated.

--- a/src/jaxsedfit/config.py
+++ b/src/jaxsedfit/config.py
@@ -168,7 +168,9 @@ class GalaxyConfig:
     fit_host_kinematics: bool = False
     host_sfh_model: str = "delayed"
     dsps_ssp_fn: str = "tempdata.h5"
-    ssp_imf: str = "chabrier_2003"
+    # The public DSPS FSPS-v3.2 SSP artifact recommended by jaxsedfit is
+    # generated with the FSPS default IMF (imf_type=2; Kroupa 2001).
+    ssp_imf: str = "kroupa_2001"
     ssp_metallicity_coordinate: str = "absolute_log10_z"
     ssp_solar_metallicity: float = 0.019
     # GRAHSP-like default: use one solar-metallicity SSP and the same
@@ -568,8 +570,7 @@ class RedshiftPriorConfig:
 @dataclass
 class MassMetallicityPriorConfig:
     """Soft stellar mass-metallicity prior for host metallicity."""
-    configured: bool = False
-    enabled: bool = True
+    enabled: bool = False
     pivot_mass: float = 10.0
     pivot_logzsol: float = -0.15
     pivot_lgmet: float | None = None
@@ -584,8 +585,6 @@ class MassMetallicityPriorConfig:
 
     def to_mapping(self) -> dict[str, Any]:
         """Convert the mass-metallicity relation prior into model settings."""
-        if not self.configured:
-            return {}
         out: dict[str, Any] = {
             "enabled": bool(self.enabled),
             "pivot_mass": float(self.pivot_mass),

--- a/src/jaxsedfit/host.py
+++ b/src/jaxsedfit/host.py
@@ -18,7 +18,7 @@ def build_host_basis_jax(
     rest_wave: np.ndarray,
     *,
     dsps_ssp_fn: str = "tempdata.h5",
-    ssp_imf: str = "chabrier_2003",
+    ssp_imf: str = "kroupa_2001",
     t_obs_gyr: float,
     sfh_n_steps: int = 64,
     sfh_t_min_gyr: float = 0.01,

--- a/src/jaxsedfit/model.py
+++ b/src/jaxsedfit/model.py
@@ -925,9 +925,7 @@ def _mass_metallicity_relation_logprior(
         redshift value.
     """
     cfg = prior_config.get("mass_metallicity_relation", None)
-    if cfg is None:
-        cfg = {}
-    if not isinstance(cfg, dict) or cfg.get("enabled", True) is False:
+    if not isinstance(cfg, dict) or cfg.get("enabled", False) is not True:
         return jnp.asarray(0.0, dtype=jnp.float64)
 
     solar_offset = (

--- a/src/jaxsedfit/preload.py
+++ b/src/jaxsedfit/preload.py
@@ -1122,7 +1122,7 @@ def _surviving_fraction_for_imf(lg_age_gyr: np.ndarray, ssp_imf: str) -> np.ndar
     return np.asarray(surviving_mstar(np.asarray(lg_age_gyr, dtype=float) + 9.0, **params), dtype=float)
 
 
-def _build_host_basis(rest_wave: np.ndarray, ssp_data: SSPData, ssp_imf: str = "chabrier_2003") -> HostBasis:
+def _build_host_basis(rest_wave: np.ndarray, ssp_data: SSPData, ssp_imf: str = "kroupa_2001") -> HostBasis:
     """Precompute the SSP basis on the model rest-wave grid.
 
     Parameters

--- a/tests/test_diffstar_host.py
+++ b/tests/test_diffstar_host.py
@@ -438,7 +438,6 @@ def test_optional_mass_metallicity_prior_is_exposed(monkeypatch):
     cfg = _mock_config()
     cfg.galaxy.dsps_ssp_fn = "fake-diffstar.h5"
     cfg.prior_config.mass_metallicity = MassMetallicityPriorConfig(
-        configured=True,
         enabled=True,
         pivot_mass=10.0,
         pivot_logzsol=-0.2,
@@ -453,7 +452,7 @@ def test_optional_mass_metallicity_prior_is_exposed(monkeypatch):
     assert np.all(np.isfinite(np.asarray(tr["mass_metallicity_relation_logprior"]["value"], dtype=float)))
 
 
-def test_mass_metallicity_prior_is_enabled_by_default(monkeypatch):
+def test_mass_metallicity_prior_is_disabled_by_default(monkeypatch):
     class _SSPData:
         ssp_lgmet = np.array([-2.0, -1.5, -1.0, -0.5])
         ssp_lg_age_gyr = np.array([-1.0, -0.5, 0.0, 0.5])
@@ -464,12 +463,22 @@ def test_mass_metallicity_prior_is_enabled_by_default(monkeypatch):
     monkeypatch.setattr("jaxsedfit.preload._SSP_DATA_CACHE", {})
     cfg = _mock_config()
     cfg.galaxy.dsps_ssp_fn = "fake-diffstar.h5"
+    assert cfg.prior_config.mass_metallicity.enabled is False
     context = build_model_context(cfg)
     tr = trace(seed(lambda: grahsp_photometric_model(context, include_components=True), 0)).get_trace()
 
     assert "mass_metallicity_relation_prior" in tr
-    assert np.all(np.isfinite(np.asarray(tr["mass_metallicity_relation_prior"]["value"], dtype=float)))
-    assert np.all(np.isfinite(np.asarray(tr["mass_metallicity_relation_logprior"]["value"], dtype=float)))
+    assert np.allclose(np.asarray(tr["mass_metallicity_relation_prior"]["value"], dtype=float), 0.0)
+    assert np.allclose(np.asarray(tr["mass_metallicity_relation_logprior"]["value"], dtype=float), 0.0)
+
+    missing_config_logprior = _mass_metallicity_relation_logprior(
+        7.0,
+        0.0,
+        {},
+        ssp_lgmet=_SSPData.ssp_lgmet,
+        redshift=0.5,
+    )
+    assert float(np.asarray(missing_config_logprior)) == 0.0
 
 
 def test_default_metallicity_prior_uses_dsps_absolute_lgmet_grid():
@@ -481,13 +490,13 @@ def test_default_metallicity_prior_uses_dsps_absolute_lgmet_grid():
     low_mass_prior = _mass_metallicity_relation_logprior(
         8.0,
         np.log10(0.019) - 0.85,
-        {},
+        {"mass_metallicity_relation": {"enabled": True}},
         ssp_lgmet=ssp_lgmet,
     )
     old_convention_prior = _mass_metallicity_relation_logprior(
         8.0,
         -0.85,
-        {},
+        {"mass_metallicity_relation": {"enabled": True}},
         ssp_lgmet=ssp_lgmet,
     )
 
@@ -506,7 +515,7 @@ def test_mass_metallicity_prior_can_be_disabled(monkeypatch):
     monkeypatch.setattr("jaxsedfit.preload._SSP_DATA_CACHE", {})
     cfg = _mock_config()
     cfg.galaxy.dsps_ssp_fn = "fake-diffstar.h5"
-    cfg.prior_config.mass_metallicity = MassMetallicityPriorConfig(configured=True, enabled=False)
+    cfg.prior_config.mass_metallicity = MassMetallicityPriorConfig(enabled=False)
     context = build_model_context(cfg)
     tr = trace(seed(lambda: grahsp_photometric_model(context, include_components=True), 0)).get_trace()
 

--- a/tests/test_model_helpers.py
+++ b/tests/test_model_helpers.py
@@ -336,7 +336,7 @@ def test_prior_config_object_exposes_flat_mapping():
     prior = PriorConfig(
         redshift=RedshiftPriorConfig(z_grid=[0.1, 0.2, 0.3], pdf=[0.2, 0.6, 0.2]),
         stellar_mass=dist.Uniform(8.0, 12.0),
-        mass_metallicity=MassMetallicityPriorConfig(configured=True, enabled=False),
+        mass_metallicity=MassMetallicityPriorConfig(enabled=False),
     )
     prior.agn.log_amp = dist.Normal(44.0, 1.0)
     prior.agn.log_broad_line_width_kms = dist.TruncatedNormal(
@@ -604,6 +604,10 @@ def test_removed_fsps_generation_fields_are_not_galaxy_runtime_options(field):
 @pytest.mark.parametrize("ssp_imf", ["chabrier_2003", "salpeter_1955", "kroupa_2001", "van_dokkum_2008"])
 def test_galaxy_accepts_supported_ssp_imf_provenance(ssp_imf):
     GalaxyConfig(ssp_imf=ssp_imf).validate()
+
+
+def test_default_ssp_imf_matches_public_dsps_fsps_artifact():
+    assert GalaxyConfig().ssp_imf == "kroupa_2001"
 
 
 def test_galaxy_rejects_ambiguous_ssp_provenance():


### PR DESCRIPTION
## Summary

- declare the public DSPS/FSPS SSP artifact as Kroupa 2001 and use the matching surviving-mass calibration by default
- simplify the mass-metallicity prior configuration to a single `enabled` flag that defaults to off
- make a missing low-level mass-metallicity configuration contribute exactly zero log-prior
- add regression coverage for default-off, missing, explicitly enabled, and explicitly disabled behavior

## Root cause

`MassMetallicityPriorConfig(configured=False)` omitted the prior mapping, but the model interpreted a missing mapping as an enabled prior with defaults. As a result, Chimera benchmark fits that did not request a mass-metallicity prior silently received one. This strongly penalized fixed-solar-metallicity solutions at very low stellar mass.

The recommended public DSPS FSPS-v3.2 artifact also uses the FSPS default Kroupa IMF, while jaxsedfit previously labeled it Chabrier and selected Chabrier surviving-mass bookkeeping.

## Impact

Optional mass-metallicity priors are now off unless explicitly enabled with `MassMetallicityPriorConfig(enabled=True)`. The redundant `configured` flag is removed. Default host modeling now uses Kroupa bookkeeping consistent with the documented SSP artifact.

## Validation

- `5 passed`: targeted mass-metallicity configuration and model-trace regression tests
- `6 passed`: targeted SSP IMF and host API tests
- `git diff --check`
