### PR TITLE
Add a supported spectroscopy API

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ continuum, spectral priors, custom spectral components, and NumPyro geometry.
 The `jaxqsofit` package provides the spectrum-focused interface on top of this
 engine; JAXSEDFit itself does not depend on `jaxqsofit`.
 
+Reusable spectral integrations should import the supported
+`jaxsedfit.spectroscopy` API rather than private helpers from the underlying
+`spectral_*` implementation modules.
+
 Documentation: [https://jaxsedfit.readthedocs.io/](https://jaxsedfit.readthedocs.io/)
 
 At a high level, `jaxsedfit` currently includes:

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -22,6 +22,7 @@ API Sections
    fitting
    config
    model
+   spectroscopy
    filters
    host
    preload

--- a/docs/api/spectroscopy.rst
+++ b/docs/api/spectroscopy.rst
@@ -1,0 +1,23 @@
+Spectroscopy Engine
+===================
+
+.. currentmodule:: jaxsedfit.spectroscopy
+
+The functions on this page are the supported integration boundary for detailed
+quasar spectral modeling. External fitters should use these names instead of
+importing implementation helpers from the ``spectral_*`` modules.
+
+.. autoclass:: SpectralComponentConfig
+   :members:
+
+.. autofunction:: build_spectral_prior_config
+
+.. autofunction:: build_joint_tied_line_meta
+
+.. autofunction:: evaluate_joint_spectral_components
+
+.. autofunction:: render_joint_feature_state
+
+.. autofunction:: line_complex_dense_mass_blocks
+
+.. autofunction:: normal_lognormal_standardization_reparam

--- a/src/jaxsedfit/core.py
+++ b/src/jaxsedfit/core.py
@@ -30,6 +30,10 @@ from numpyro.infer.reparam import Reparam
 from numpyro.diagnostics import print_summary as print_diagnostics_summary
 
 from .config import FitConfig, fit_config_from_mapping, serialize_config
+from .inference import (
+    nuts_metric_diagnostics,
+    nuts_transition_diagnostics,
+)
 from .model import grahsp_photometric_model
 from .preload import ModelContext, build_model_context
 from .results import FitResult, _FitState, median_mapping
@@ -100,7 +104,7 @@ def _nuts_geometry_reparam_config(
             "jaxqsofit_normal_lognormal_standardization"
         )
         if feature_metadata is not None:
-            from .spectral_reparameterization import (
+            from .spectroscopy import (
                 normal_lognormal_standardization_reparam,
             )
 
@@ -219,173 +223,6 @@ def _print_physical_nuts_summary(mcmc, replacements):
         )
 
 
-def _nuts_transition_diagnostics(mcmc, max_tree_depth: int) -> dict[str, Any]:
-    """Summarize transition-level NUTS diagnostics without dropping raw fields."""
-    raw_fields = mcmc.get_extra_fields(group_by_chain=True)
-    fields = {name: np.asarray(value) for name, value in raw_fields.items()}
-    num_steps = np.asarray(fields.get("num_steps", []), dtype=float)
-    accept_prob = np.asarray(fields.get("accept_prob", []), dtype=float)
-    diverging = np.asarray(fields.get("diverging", []), dtype=bool)
-    energy = np.asarray(fields.get("energy", []), dtype=float)
-    max_num_steps = 2 ** int(max_tree_depth) - 1
-    final_level_min_steps = 2 ** max(int(max_tree_depth) - 1, 0)
-    finite_steps = num_steps[np.isfinite(num_steps) & (num_steps >= 0.0)]
-    depth_lower_bound = (
-        np.ceil(np.log2(finite_steps + 1.0))
-        if finite_steps.size
-        else np.asarray([], dtype=float)
-    )
-
-    if energy.ndim == 1:
-        energy = energy[None, :]
-    bfmi = []
-    for chain_energy in energy:
-        finite = chain_energy[np.isfinite(chain_energy)]
-        variance = np.var(finite) if finite.size > 1 else np.nan
-        bfmi.append(
-            float(np.mean(np.diff(finite) ** 2) / variance)
-            if finite.size > 1 and variance > 0.0
-            else np.nan
-        )
-
-    return {
-        "extra_fields": fields,
-        "n_transitions": int(diverging.size),
-        "n_divergent": int(np.count_nonzero(diverging)),
-        "divergence_fraction": (
-            float(np.mean(diverging)) if diverging.size else np.nan
-        ),
-        "mean_accept_prob": (
-            float(np.nanmean(accept_prob)) if accept_prob.size else np.nan
-        ),
-        "mean_num_steps": (
-            float(np.mean(finite_steps)) if finite_steps.size else np.nan
-        ),
-        "median_num_steps": (
-            float(np.nanmedian(num_steps)) if num_steps.size else np.nan
-        ),
-        "p90_num_steps": (
-            float(np.nanpercentile(num_steps, 90.0)) if num_steps.size else np.nan
-        ),
-        "p99_num_steps": (
-            float(np.nanpercentile(num_steps, 99.0)) if num_steps.size else np.nan
-        ),
-        "total_num_steps": (
-            int(np.nansum(num_steps)) if num_steps.size else 0
-        ),
-        "max_num_steps": (
-            int(np.nanmax(num_steps)) if num_steps.size else 0
-        ),
-        "max_tree_depth": int(max_tree_depth),
-        "median_tree_depth_lower_bound": (
-            float(np.median(depth_lower_bound))
-            if depth_lower_bound.size
-            else np.nan
-        ),
-        "p90_tree_depth_lower_bound": (
-            float(np.percentile(depth_lower_bound, 90.0))
-            if depth_lower_bound.size
-            else np.nan
-        ),
-        # Entering the final allowed level requires at least 2**(depth-1)
-        # leapfrog steps. This is useful for detecting expensive trajectories,
-        # but is not itself proof that the depth limit truncated the tree.
-        "final_tree_level_fraction": (
-            float(np.mean(num_steps >= final_level_min_steps))
-            if num_steps.size
-            else np.nan
-        ),
-        "n_max_num_steps": (
-            int(np.count_nonzero(num_steps >= max_num_steps)) if num_steps.size else 0
-        ),
-        # NumPyro exposes leapfrog counts, not the realized tree depth. A full
-        # 2**depth-1 trajectory is therefore a conservative saturation flag;
-        # shorter trajectories may also have entered the final tree level.
-        "max_num_steps_fraction": (
-            float(np.mean(num_steps >= max_num_steps)) if num_steps.size else np.nan
-        ),
-        "full_trajectory_fraction": (
-            float(np.mean(num_steps >= max_num_steps)) if num_steps.size else np.nan
-        ),
-        "bfmi": np.asarray(bfmi, dtype=float),
-    }
-
-
-def _nuts_metric_diagnostics(mcmc) -> dict[str, Any]:
-    """Summarize the adapted step size and mass-matrix conditioning."""
-    last_state = getattr(mcmc, "last_state", None)
-    adapt_state = getattr(last_state, "adapt_state", None)
-    inverse_mass = getattr(adapt_state, "inverse_mass_matrix", None)
-    step_size = getattr(adapt_state, "step_size", None)
-    if inverse_mass is None:
-        return {}
-    matrices = inverse_mass if isinstance(inverse_mass, dict) else {("all",): inverse_mass}
-    num_chains = int(getattr(mcmc, "num_chains", 1))
-    blocks = []
-    for site_names, value in matrices.items():
-        array = np.asarray(value, dtype=float)
-        chain_values = [array]
-        if num_chains > 1 and array.ndim >= 2 and array.shape[0] == num_chains:
-            chain_values = list(array)
-        for chain_index, chain_value in enumerate(chain_values):
-            dimension = (
-                chain_value.size
-                if chain_value.ndim == 1
-                else chain_value.shape[-1]
-            )
-            if chain_value.ndim == 1:
-                eigenvalues = chain_value
-            elif np.all(np.isfinite(chain_value)):
-                try:
-                    eigenvalues = np.linalg.eigvalsh(chain_value)
-                except np.linalg.LinAlgError:
-                    eigenvalues = np.full(dimension, np.nan, dtype=float)
-            else:
-                # LAPACK does not reliably propagate NaNs: some backends can
-                # return plausible finite eigenvalues for a nonfinite matrix.
-                # Every eigenvalue is undefined in that case.
-                eigenvalues = np.full(dimension, np.nan, dtype=float)
-            n_nonpositive = int(
-                np.count_nonzero(np.isfinite(eigenvalues) & (eigenvalues <= 0.0))
-            )
-            n_nonfinite = int(np.count_nonzero(~np.isfinite(eigenvalues)))
-            finite_positive = eigenvalues[
-                np.isfinite(eigenvalues) & (eigenvalues > 0.0)
-            ]
-            min_eigenvalue = (
-                float(np.min(finite_positive)) if finite_positive.size else np.nan
-            )
-            max_eigenvalue = (
-                float(np.max(finite_positive)) if finite_positive.size else np.nan
-            )
-            blocks.append(
-                {
-                    "sites": tuple(site_names),
-                    "chain": chain_index,
-                    "dimension": int(dimension),
-                    "min_eigenvalue": min_eigenvalue,
-                    "max_eigenvalue": max_eigenvalue,
-                    "n_nonpositive_eigenvalues": n_nonpositive,
-                    "n_nonfinite_eigenvalues": n_nonfinite,
-                    "condition_number": (
-                        np.inf
-                        if n_nonpositive or n_nonfinite
-                        else (
-                            max_eigenvalue / min_eigenvalue
-                            if min_eigenvalue > 0.0
-                            else np.nan
-                        )
-                    ),
-                }
-            )
-    return {
-        "adapted_step_size": (
-            np.asarray(step_size, dtype=float) if step_size is not None else np.asarray([])
-        ),
-        "blocks": blocks,
-    }
-
-
 def _joint_dense_mass_blocks(
     latent_values: Mapping[str, Any],
     context: ModelContext | None = None,
@@ -427,11 +264,11 @@ def _joint_dense_mass_blocks(
         jqf_cfg = cfg.spectroscopy_config.jaxqsofit
         if bool(jqf_cfg.use_spectral_lines) and bool(jqf_cfg.use_tied_lines):
             try:
-                from .spectral_components import (
+                from .spectroscopy import (
                     SpectralComponentConfig,
                     build_joint_tied_line_meta,
+                    line_complex_dense_mass_blocks,
                 )
-                from .spectral_geometry import line_complex_dense_mass_blocks
                 from .model import _fixed_spectral_line_coverage_rest
 
                 component_cfg = SpectralComponentConfig(
@@ -1511,11 +1348,11 @@ class JAXSEDFit:
             reparameterized_sites,
             group_by_chain=False,
         )
-        transition_diagnostics = _nuts_transition_diagnostics(
+        transition_diagnostics = nuts_transition_diagnostics(
             mcmc,
             max_tree_depth=max_tree_depth,
         )
-        metric_diagnostics = _nuts_metric_diagnostics(mcmc)
+        metric_diagnostics = nuts_metric_diagnostics(mcmc)
         self.nuts_result = {
             "mcmc": mcmc,
             "mass_matrix_structure": mass_matrix_structure,

--- a/src/jaxsedfit/inference.py
+++ b/src/jaxsedfit/inference.py
@@ -1,0 +1,199 @@
+"""Inference diagnostics shared by SED and standalone spectral fitters."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+import numpy as np
+
+
+def summarize_nuts_transition_fields(
+    extra_fields: Mapping[str, Any],
+    max_tree_depth: int,
+    *,
+    include_raw_fields: bool = False,
+) -> dict[str, Any]:
+    """Summarize grouped NumPyro transition fields."""
+    fields = {name: np.asarray(value) for name, value in extra_fields.items()}
+    num_steps = np.asarray(fields.get("num_steps", []), dtype=float)
+    accept_prob = np.asarray(fields.get("accept_prob", []), dtype=float)
+    diverging = np.asarray(fields.get("diverging", []), dtype=bool)
+    energy = np.asarray(fields.get("energy", []), dtype=float)
+    max_num_steps = 2 ** int(max_tree_depth) - 1
+    final_level_min_steps = 2 ** max(int(max_tree_depth) - 1, 0)
+    finite_steps = num_steps[np.isfinite(num_steps) & (num_steps >= 0.0)]
+    depth_lower_bound = (
+        np.ceil(np.log2(finite_steps + 1.0))
+        if finite_steps.size
+        else np.asarray([], dtype=float)
+    )
+    if energy.ndim == 1:
+        energy = energy[None, :]
+    bfmi = []
+    for chain_energy in energy:
+        finite = chain_energy[np.isfinite(chain_energy)]
+        variance = np.var(finite) if finite.size > 1 else np.nan
+        bfmi.append(
+            float(np.mean(np.diff(finite) ** 2) / variance)
+            if finite.size > 1 and variance > 0.0
+            else np.nan
+        )
+    summary = {
+        "n_transitions": int(diverging.size),
+        "n_divergent": int(np.count_nonzero(diverging)),
+        "divergence_fraction": (
+            float(np.mean(diverging)) if diverging.size else np.nan
+        ),
+        "mean_accept_prob": (
+            float(np.nanmean(accept_prob)) if accept_prob.size else np.nan
+        ),
+        "mean_num_steps": (
+            float(np.mean(finite_steps)) if finite_steps.size else np.nan
+        ),
+        "median_num_steps": (
+            float(np.nanmedian(num_steps)) if num_steps.size else np.nan
+        ),
+        "p90_num_steps": (
+            float(np.nanpercentile(num_steps, 90.0)) if num_steps.size else np.nan
+        ),
+        "p99_num_steps": (
+            float(np.nanpercentile(num_steps, 99.0)) if num_steps.size else np.nan
+        ),
+        "total_num_steps": int(np.nansum(num_steps)) if num_steps.size else 0,
+        "max_num_steps": int(np.nanmax(num_steps)) if num_steps.size else 0,
+        "max_tree_depth": int(max_tree_depth),
+        "median_tree_depth_lower_bound": (
+            float(np.median(depth_lower_bound))
+            if depth_lower_bound.size
+            else np.nan
+        ),
+        "p90_tree_depth_lower_bound": (
+            float(np.percentile(depth_lower_bound, 90.0))
+            if depth_lower_bound.size
+            else np.nan
+        ),
+        "final_tree_level_fraction": (
+            float(np.mean(num_steps >= final_level_min_steps))
+            if num_steps.size
+            else np.nan
+        ),
+        "n_max_num_steps": (
+            int(np.count_nonzero(num_steps >= max_num_steps))
+            if num_steps.size
+            else 0
+        ),
+        "max_num_steps_fraction": (
+            float(np.mean(num_steps >= max_num_steps))
+            if num_steps.size
+            else np.nan
+        ),
+        "full_trajectory_fraction": (
+            float(np.mean(num_steps >= max_num_steps))
+            if num_steps.size
+            else np.nan
+        ),
+        "bfmi": np.asarray(bfmi, dtype=float),
+    }
+    if include_raw_fields:
+        summary["extra_fields"] = fields
+    return summary
+
+
+def nuts_transition_diagnostics(mcmc, max_tree_depth: int) -> dict[str, Any]:
+    """Summarize transitions from a fitted NumPyro MCMC object."""
+    return summarize_nuts_transition_fields(
+        mcmc.get_extra_fields(group_by_chain=True),
+        max_tree_depth,
+        include_raw_fields=True,
+    )
+
+
+def nuts_metric_diagnostics(mcmc) -> dict[str, Any]:
+    """Summarize the adapted step size and mass-matrix conditioning."""
+    last_state = getattr(mcmc, "last_state", None)
+    adapt_state = getattr(last_state, "adapt_state", None)
+    inverse_mass = getattr(adapt_state, "inverse_mass_matrix", None)
+    step_size = getattr(adapt_state, "step_size", None)
+    if inverse_mass is None:
+        return {}
+    matrices = (
+        inverse_mass
+        if isinstance(inverse_mass, dict)
+        else {("all",): inverse_mass}
+    )
+    num_chains = int(getattr(mcmc, "num_chains", 1))
+    blocks = []
+    for site_names, value in matrices.items():
+        array = np.asarray(value, dtype=float)
+        chain_values = [array]
+        if num_chains > 1 and array.ndim >= 2 and array.shape[0] == num_chains:
+            chain_values = list(array)
+        for chain_index, chain_value in enumerate(chain_values):
+            dimension = (
+                chain_value.size
+                if chain_value.ndim == 1
+                else chain_value.shape[-1]
+            )
+            if chain_value.ndim == 1:
+                eigenvalues = chain_value
+            elif np.all(np.isfinite(chain_value)):
+                try:
+                    eigenvalues = np.linalg.eigvalsh(chain_value)
+                except np.linalg.LinAlgError:
+                    eigenvalues = np.full(dimension, np.nan, dtype=float)
+            else:
+                eigenvalues = np.full(dimension, np.nan, dtype=float)
+            n_nonpositive = int(
+                np.count_nonzero(
+                    np.isfinite(eigenvalues) & (eigenvalues <= 0.0)
+                )
+            )
+            n_nonfinite = int(np.count_nonzero(~np.isfinite(eigenvalues)))
+            finite_positive = eigenvalues[
+                np.isfinite(eigenvalues) & (eigenvalues > 0.0)
+            ]
+            min_eigenvalue = (
+                float(np.min(finite_positive))
+                if finite_positive.size
+                else np.nan
+            )
+            max_eigenvalue = (
+                float(np.max(finite_positive))
+                if finite_positive.size
+                else np.nan
+            )
+            blocks.append(
+                {
+                    "sites": tuple(site_names),
+                    "chain": chain_index,
+                    "dimension": int(dimension),
+                    "min_eigenvalue": min_eigenvalue,
+                    "max_eigenvalue": max_eigenvalue,
+                    "n_nonpositive_eigenvalues": n_nonpositive,
+                    "n_nonfinite_eigenvalues": n_nonfinite,
+                    "condition_number": (
+                        np.inf
+                        if n_nonpositive or n_nonfinite
+                        else (
+                            max_eigenvalue / min_eigenvalue
+                            if min_eigenvalue > 0.0
+                            else np.nan
+                        )
+                    ),
+                }
+            )
+    return {
+        "adapted_step_size": (
+            np.asarray(step_size, dtype=float)
+            if step_size is not None
+            else np.asarray([])
+        ),
+        "blocks": blocks,
+    }
+
+
+__all__ = [
+    "nuts_metric_diagnostics",
+    "nuts_transition_diagnostics",
+    "summarize_nuts_transition_fields",
+]

--- a/src/jaxsedfit/model.py
+++ b/src/jaxsedfit/model.py
@@ -3146,7 +3146,7 @@ def _evaluate_jaxqsofit_backend(
         sampled line, Fe II, and Balmer amplitudes.
     """
     try:
-        from .spectral_components import (
+        from .spectroscopy import (
             SpectralComponentConfig,
             evaluate_joint_spectral_components,
         )
@@ -3221,7 +3221,7 @@ def _project_jaxqsofit_smooth_state_filters(
     for these broad components; its result is interpolated onto the native
     filter curves before exact filter quadrature.
     """
-    from .spectral_components import render_joint_feature_state
+    from .spectroscopy import render_joint_feature_state
 
     curves = context.packed_filter_curves_jax
     valid_filter_waves = [

--- a/src/jaxsedfit/preload.py
+++ b/src/jaxsedfit/preload.py
@@ -521,7 +521,7 @@ def _build_jaxqsofit_prior_config(cfg: FitConfig, spec_fluxes: np.ndarray, spec_
     if not bool(jqf_cfg.use_spectral_smart_priors):
         return None
     try:
-        from .spectral_defaults import _build_default_prior_config
+        from .spectroscopy import build_spectral_prior_config
     except Exception as exc:  # pragma: no cover - exercised only without optional dependency
         raise ImportError(
             "Unable to load the built-in spectral smart-prior machinery."
@@ -534,7 +534,7 @@ def _build_jaxqsofit_prior_config(cfg: FitConfig, spec_fluxes: np.ndarray, spec_
     if flux_for_priors.size == 0:
         flux_for_priors = np.asarray([max(float(jqf_cfg.line_flux_scale_mjy), 1.0e-8)], dtype=float)
     flux_rest = flux_for_priors * (1.0 + float(cfg.observation.redshift))
-    prior_config = _build_default_prior_config(
+    prior_config = build_spectral_prior_config(
         flux_rest,
         include_elg_narrow_lines=bool(jqf_cfg.include_elg_narrow_lines),
         include_high_ionization_lines=bool(jqf_cfg.include_high_ionization_lines),

--- a/src/jaxsedfit/spectroscopy.py
+++ b/src/jaxsedfit/spectroscopy.py
@@ -1,0 +1,52 @@
+"""Supported public interface to the detailed quasar spectral engine.
+
+Joint SED+spectrum fitting and the standalone :mod:`jaxqsofit` interface
+should import through this module instead of depending on implementation
+helpers spread across the ``spectral_*`` modules.
+"""
+
+from __future__ import annotations
+
+from .spectral_components import (
+    SpectralComponentConfig,
+    build_joint_tied_line_meta,
+    evaluate_joint_spectral_components,
+    render_joint_feature_state,
+)
+from .spectral_geometry import line_complex_dense_mass_blocks
+from .spectral_reparameterization import (
+    NORMAL_LOGNORMAL_STANDARDIZATION,
+    NormalLogNormalStandardizeReparam,
+    normal_lognormal_standardization_reparam,
+    standardized_prior_site,
+)
+
+
+def build_spectral_prior_config(
+    flux,
+    *,
+    include_elg_narrow_lines: bool = False,
+    include_high_ionization_lines: bool = False,
+):
+    """Build scale-aware default priors for the detailed spectral engine."""
+    from .spectral_defaults import _build_default_prior_config
+
+    return _build_default_prior_config(
+        flux,
+        include_elg_narrow_lines=include_elg_narrow_lines,
+        include_high_ionization_lines=include_high_ionization_lines,
+    )
+
+
+__all__ = [
+    "NORMAL_LOGNORMAL_STANDARDIZATION",
+    "NormalLogNormalStandardizeReparam",
+    "SpectralComponentConfig",
+    "build_joint_tied_line_meta",
+    "build_spectral_prior_config",
+    "evaluate_joint_spectral_components",
+    "line_complex_dense_mass_blocks",
+    "normal_lognormal_standardization_reparam",
+    "render_joint_feature_state",
+    "standardized_prior_site",
+]

--- a/tests/test_model_helpers.py
+++ b/tests/test_model_helpers.py
@@ -1570,7 +1570,7 @@ def test_jaxqsofit_fixed_narrow_width_component_reports_tied_width():
 
 
 def test_jaxqsofit_backend_does_not_fix_narrow_width_without_explicit_override(monkeypatch):
-    from jaxsedfit import spectral_components
+    from jaxsedfit import spectroscopy
     captured = {}
 
     def fake_evaluate_joint_spectral_components(wave_obs, redshift, continuum_mjy, *, config, **kwargs):
@@ -1588,7 +1588,7 @@ def test_jaxqsofit_backend_does_not_fix_narrow_width_without_explicit_override(m
         }
 
     monkeypatch.setattr(
-        spectral_components,
+        spectroscopy,
         "evaluate_joint_spectral_components",
         fake_evaluate_joint_spectral_components,
     )

--- a/tests/test_nuts_geometry.py
+++ b/tests/test_nuts_geometry.py
@@ -14,11 +14,13 @@ from jaxsedfit.core import (
     _AdditivePivotReparam,
     _joint_dense_mass_blocks,
     _nuts_geometry_reparam_config,
-    _nuts_metric_diagnostics,
-    _nuts_transition_diagnostics,
     _physical_nuts_samples,
     _prepare_nuts_reparameterization,
     _remap_dense_mass_sites,
+)
+from jaxsedfit.inference import (
+    nuts_metric_diagnostics,
+    nuts_transition_diagnostics,
 )
 from jaxsedfit.config import InferenceConfig
 from jaxsedfit.model import _spectrum_continuum_log_pivot
@@ -378,7 +380,7 @@ class _TransitionMCMC:
 
 
 def test_transition_diagnostics_distinguish_final_level_from_full_trajectory():
-    diagnostics = _nuts_transition_diagnostics(_TransitionMCMC(), max_tree_depth=4)
+    diagnostics = nuts_transition_diagnostics(_TransitionMCMC(), max_tree_depth=4)
 
     assert diagnostics["n_transitions"] == 4
     assert diagnostics["n_divergent"] == 1
@@ -409,7 +411,7 @@ def test_metric_diagnostics_flag_nonpositive_and_nonfinite_eigenvalues():
         ),
     )
 
-    diagnostics = _nuts_metric_diagnostics(mcmc)
+    diagnostics = nuts_metric_diagnostics(mcmc)
     blocks = {tuple(block["sites"]): block for block in diagnostics["blocks"]}
     assert blocks[("x", "y")]["n_nonpositive_eigenvalues"] == 1
     assert np.isinf(blocks[("x", "y")]["condition_number"])

--- a/tests/test_spectral_components.py
+++ b/tests/test_spectral_components.py
@@ -1,0 +1,381 @@
+import numpy as np
+import jax
+from numpyro.handlers import seed, substitute, trace
+
+from jaxsedfit.spectroscopy import (
+    SpectralComponentConfig,
+    evaluate_joint_spectral_components,
+    render_joint_feature_state,
+)
+from jaxsedfit.spectroscopy import (
+    NORMAL_LOGNORMAL_STANDARDIZATION,
+    build_spectral_prior_config as build_default_prior_config,
+)
+
+
+def test_evaluate_joint_spectral_components_uses_external_continuum():
+    wave_obs = np.linspace(4500.0, 7500.0, 64)
+    continuum = np.full_like(wave_obs, 2.0)
+
+    tr = trace(seed(evaluate_joint_spectral_components, jax.random.PRNGKey(3))).get_trace(
+        wave_obs=wave_obs,
+        redshift=0.1,
+        continuum_mjy=continuum,
+        config=SpectralComponentConfig(
+            use_lines=False,
+            use_feii=False,
+            use_balmer_continuum=False,
+            use_multiplicative_tilt=False,
+        ),
+    )
+
+    assert np.allclose(np.asarray(tr["jqf_total_model"]["value"]), continuum)
+    assert np.allclose(np.asarray(tr["jqf_line_model"]["value"]), 0.0)
+
+
+def test_evaluate_joint_spectral_components_adds_line_sites():
+    wave_obs = np.linspace(4500.0, 7500.0, 64)
+    continuum = np.full_like(wave_obs, 2.0)
+
+    tr = trace(seed(evaluate_joint_spectral_components, jax.random.PRNGKey(4))).get_trace(
+        wave_obs=wave_obs,
+        redshift=0.1,
+        continuum_mjy=continuum,
+        config=SpectralComponentConfig(
+            use_lines=True,
+            use_feii=False,
+            use_balmer_continuum=False,
+            line_centers_rest=(4861.33,),
+            line_names=("Hbeta",),
+            broad_line_names=("Hbeta",),
+        ),
+    )
+
+    assert "jqf_line_amp_Hbeta" in tr
+    assert "jqf_line_fwhm_Hbeta" in tr
+    assert "jqf_line_velocity_Hbeta" in tr
+    assert np.asarray(tr["jqf_total_model"]["value"]).shape == wave_obs.shape
+
+
+def test_joint_feature_amplitudes_can_use_observed_spectrum_coordinates():
+    wave_obs = np.linspace(3000.0, 7000.0, 128)
+    template_wave = np.linspace(2000.0, 8000.0, 256)
+    template_flux = np.ones_like(template_wave)
+    cfg = SpectralComponentConfig(
+        use_lines=True,
+        use_tied_lines=False,
+        line_centers_rest=(4861.33,),
+        line_names=("Hbeta",),
+        broad_line_names=("Hbeta",),
+        use_feii=True,
+        use_balmer_continuum=True,
+        broadening_convolution="direct",
+    )
+    params = {
+        "jqf_line_amp_Hbeta": 0.2,
+        "jqf_line_fwhm_Hbeta": 3000.0,
+        "jqf_line_velocity_Hbeta": 0.0,
+        "jqf_feii_norm": 0.1,
+        "jqf_feii_fwhm": 1000.0,
+        "jqf_feii_shift": 0.0,
+        "jqf_balmer_norm": 0.1,
+        "jqf_balmer_tau": 1.0,
+        "jqf_balmer_vel": 3000.0,
+    }
+
+    def evaluate(scale):
+        fn = substitute(
+            seed(evaluate_joint_spectral_components, jax.random.PRNGKey(17)),
+            data=params,
+        )
+        return fn(
+            wave_obs=wave_obs,
+            redshift=0.0,
+            continuum_mjy=np.zeros_like(wave_obs),
+            config=cfg,
+            feii_template_wave_rest=template_wave,
+            feii_template_flux=template_flux,
+            feature_amplitude_scale=scale,
+        )
+
+    unit = evaluate(1.0)
+    doubled = evaluate(2.0)
+    for name in ("lines", "feii", "balmer"):
+        np.testing.assert_allclose(
+            np.asarray(doubled[name]),
+            0.5 * np.asarray(unit[name]),
+            rtol=1e-10,
+            atol=1e-12,
+        )
+
+
+def test_joint_feii_balmer_sites_advertise_nuts_standardization_only():
+    wave_obs = np.linspace(3000.0, 7000.0, 32)
+    template_wave = np.linspace(2000.0, 8000.0, 64)
+    tr = trace(
+        seed(evaluate_joint_spectral_components, jax.random.PRNGKey(18))
+    ).get_trace(
+        wave_obs=wave_obs,
+        redshift=0.0,
+        continuum_mjy=np.ones_like(wave_obs),
+        config=SpectralComponentConfig(
+            use_lines=False,
+            use_feii=True,
+            use_balmer_continuum=True,
+            broadening_convolution="direct",
+        ),
+        feii_template_wave_rest=template_wave,
+        feii_template_flux=np.ones_like(template_wave),
+    )
+    expected = {
+        "jqf_feii_norm",
+        "jqf_feii_fwhm",
+        "jqf_feii_shift",
+        "jqf_balmer_norm",
+        "jqf_balmer_tau",
+        "jqf_balmer_vel",
+    }
+    advertised = {
+        name
+        for name, site in tr.items()
+        if NORMAL_LOGNORMAL_STANDARDIZATION in (site.get("infer") or {})
+    }
+
+    assert advertised == expected
+    for name in expected:
+        assert tr[name]["type"] == "sample"
+        assert (
+            tr[name]["infer"][NORMAL_LOGNORMAL_STANDARDIZATION][
+                "auxiliary_name"
+            ]
+            == f"{name}_std"
+        )
+
+
+def test_evaluate_joint_spectral_components_uses_default_tied_lines():
+    wave_obs = np.linspace(4700.0, 5100.0, 96)
+    continuum = np.full_like(wave_obs, 2.0)
+
+    tr = trace(seed(evaluate_joint_spectral_components, jax.random.PRNGKey(5))).get_trace(
+        wave_obs=wave_obs,
+        redshift=0.0,
+        continuum_mjy=continuum,
+        config=SpectralComponentConfig(
+            use_lines=True,
+            use_tied_lines=True,
+            use_feii=False,
+            use_balmer_continuum=False,
+            line_flux_scale_mjy=2.0,
+        ),
+    )
+
+    assert "jqf_line_dmu_independent_group_std" in tr
+    assert "jqf_line_log_fwhm_delta_group_std" in tr
+    assert "jqf_line_amp_group" in tr
+    assert tr["jqf_line_dmu_group"]["type"] == "deterministic"
+    assert tr["jqf_line_sig_group"]["type"] == "deterministic"
+    assert tr["jqf_line_amp_group"]["type"] == "deterministic"
+    assert any(
+        name.startswith("jqf_line_amp_") and name != "jqf_line_amp_group"
+        for name in tr
+    )
+    assert "jqf_line_amp_per_component" in tr
+    assert "jqf_line_model_broad" in tr
+    assert "jqf_line_model_narrow" in tr
+    assert np.asarray(tr["jqf_total_model"]["value"]).shape == wave_obs.shape
+
+
+def test_joint_feature_state_renders_same_tied_lines_on_another_grid():
+    wave_obs = np.linspace(4700.0, 5100.0, 96)
+    cfg = SpectralComponentConfig(
+        use_lines=True,
+        use_tied_lines=True,
+        use_feii=False,
+        use_balmer_continuum=False,
+        line_flux_scale_mjy=2.0,
+    )
+    fn = seed(evaluate_joint_spectral_components, jax.random.PRNGKey(15))
+    result = fn(
+        wave_obs=wave_obs,
+        redshift=0.0,
+        continuum_mjy=np.zeros_like(wave_obs),
+        config=cfg,
+    )
+
+    rendered = render_joint_feature_state(wave_obs, 0.0, result["state"], config=cfg)
+
+    np.testing.assert_allclose(np.asarray(rendered["lines"]), np.asarray(result["lines"]), rtol=1e-12, atol=1e-12)
+    assert set(("line_amp_per_component", "line_mu_per_component", "line_sig_per_component", "line_broad_mask_per_component")) <= set(result["state"])
+
+
+def test_evaluate_joint_spectral_components_filters_tied_lines_to_coverage():
+    wave_obs = np.linspace(4850.0, 5010.0, 64)
+    continuum = np.full_like(wave_obs, 1.0)
+    line_table = [
+        {
+            "lambda": 4862.68,
+            "linename": "Hb",
+            "compname": "Hb",
+            "inisca": 0.1,
+            "minsca": 1.0e-4,
+            "maxsca": 1.0,
+            "inisig": 1.0e-3,
+            "minsig": 1.0e-4,
+            "maxsig": 1.0e-2,
+            "voff": 0.01,
+            "vindex": 0,
+            "windex": 0,
+            "findex": 0,
+            "fvalue": 1.0,
+        },
+        {
+            "lambda": 6564.61,
+            "linename": "Ha",
+            "compname": "Ha",
+            "inisca": 0.1,
+            "minsca": 1.0e-4,
+            "maxsca": 1.0,
+            "inisig": 1.0e-3,
+            "minsig": 1.0e-4,
+            "maxsig": 1.0e-2,
+            "voff": 0.01,
+            "vindex": 0,
+            "windex": 0,
+            "findex": 0,
+            "fvalue": 1.0,
+        },
+    ]
+
+    tr = trace(seed(evaluate_joint_spectral_components, jax.random.PRNGKey(8))).get_trace(
+        wave_obs=wave_obs,
+        redshift=0.0,
+        continuum_mjy=continuum,
+        config=SpectralComponentConfig(
+            use_lines=True,
+            use_tied_lines=True,
+            use_feii=False,
+            use_balmer_continuum=False,
+            line_table=line_table,
+            line_coverage_rest=(4800.0, 5050.0),
+        ),
+    )
+
+    assert np.asarray(tr["jqf_line_amp_per_component"]["value"]).shape == (1,)
+
+
+def test_evaluate_joint_spectral_components_accepts_prior_config_object_as_line_prior_config():
+    wave_obs = np.linspace(4700.0, 5100.0, 96)
+    continuum = np.full_like(wave_obs, 2.0)
+    prior_config = build_default_prior_config(
+        continuum,
+        include_elg_narrow_lines=False,
+        include_high_ionization_lines=False,
+    )
+
+    tr = trace(seed(evaluate_joint_spectral_components, jax.random.PRNGKey(6))).get_trace(
+        wave_obs=wave_obs,
+        redshift=0.0,
+        continuum_mjy=continuum,
+        config=SpectralComponentConfig(
+            use_lines=True,
+            use_tied_lines=True,
+            use_feii=False,
+            use_balmer_continuum=False,
+            line_prior_config=prior_config,
+        ),
+    )
+
+    assert "jqf_line_dmu_independent_group_std" in tr
+    assert tr["jqf_line_dmu_group"]["type"] == "deterministic"
+    assert "jqf_line_amp_per_component" in tr
+    assert np.asarray(tr["jqf_total_model"]["value"]).shape == wave_obs.shape
+
+
+def test_evaluate_joint_spectral_components_reports_fixed_narrow_line_controls():
+    wave_obs = np.linspace(4990.0, 5010.0, 96)
+    continuum = np.full_like(wave_obs, 1.0)
+
+    tr = trace(seed(evaluate_joint_spectral_components, jax.random.PRNGKey(6))).get_trace(
+        wave_obs=wave_obs,
+        redshift=0.0,
+        continuum_mjy=continuum,
+        config=SpectralComponentConfig(
+            use_lines=True,
+            use_tied_lines=False,
+            use_feii=False,
+            use_balmer_continuum=False,
+            line_centers_rest=(5000.0,),
+            line_names=("OIII5007c",),
+            fixed_narrow_fwhm_kms=321.0,
+            fixed_narrow_amp_scale=2.5,
+        ),
+    )
+
+    assert tr["jqf_line_narrow_fwhm_kms"]["value"] == 321.0
+    assert tr["jqf_line_narrow_amp_scale"]["value"] == 2.5
+    assert np.nanmax(np.asarray(tr["jqf_line_model_narrow"]["value"])) > 0.0
+
+
+def test_evaluate_joint_spectral_components_converts_feii_template_to_fnu_shape():
+    wave_obs = np.array([2000.0, 3000.0, 4000.0])
+    continuum = np.zeros_like(wave_obs)
+    template_wave = np.array([1000.0, 5000.0])
+    template_flux = np.ones_like(template_wave)
+    fn = substitute(
+        seed(evaluate_joint_spectral_components, jax.random.PRNGKey(7)),
+        data={
+            "jqf_feii_norm": 1.0,
+            "jqf_feii_fwhm": 1.0,
+            "jqf_feii_shift": 0.0,
+        },
+    )
+
+    tr = trace(fn).get_trace(
+        wave_obs=wave_obs,
+        redshift=0.0,
+        continuum_mjy=continuum,
+        config=SpectralComponentConfig(
+            use_lines=False,
+            use_feii=True,
+            use_balmer_continuum=False,
+            feii_fnu_pivot_rest=3000.0,
+        ),
+        feii_template_wave_rest=template_wave,
+        feii_template_flux=template_flux,
+    )
+    feii = np.asarray(tr["jqf_feii_model"]["value"])
+
+    assert feii[2] / feii[0] > 3.9
+    assert np.isclose(feii[1] / feii[0], (3000.0 / 2000.0) ** 2, rtol=0.05)
+
+
+def test_feii_template_arrays_can_be_traced_under_jit():
+    wave_obs = np.linspace(2000.0, 4000.0, 32)
+    template_wave = np.linspace(1000.0, 5000.0, 64)
+    template_flux = np.ones_like(template_wave)
+    cfg = SpectralComponentConfig(
+        use_lines=False,
+        use_feii=True,
+        use_balmer_continuum=False,
+        broadening_convolution="direct",
+        feii_fnu_pivot_rest=3000.0,
+    )
+
+    def render(twave, tflux):
+        fn = substitute(
+            seed(evaluate_joint_spectral_components, jax.random.PRNGKey(21)),
+            data={"jqf_feii_norm": 1.0, "jqf_feii_fwhm": 1000.0, "jqf_feii_shift": 0.0},
+        )
+        return fn(
+            wave_obs=wave_obs,
+            redshift=0.0,
+            continuum_mjy=np.zeros_like(wave_obs),
+            config=cfg,
+            feii_template_wave_rest=twave,
+            feii_template_flux=tflux,
+        )["feii"]
+
+    result = jax.jit(render)(template_wave, template_flux)
+
+    assert np.asarray(result).shape == wave_obs.shape
+    assert np.all(np.isfinite(np.asarray(result)))

--- a/tests/test_spectral_defaults.py
+++ b/tests/test_spectral_defaults.py
@@ -1,0 +1,580 @@
+import numpy as np
+import numpyro.distributions as dist
+import pytest
+
+from jaxsedfit.spectral_config import (
+    AGNConfig,
+    BALConfig,
+    ContinuumConfig,
+    ContinuumPriorConfig,
+    FeIIPriorConfig,
+    FitConfig,
+    HostConfig,
+    HostPriorConfig,
+    InferenceConfig,
+    LineConfig,
+    LinePriorConfig,
+    Observation,
+    PriorConfig,
+    SpectroscopyData,
+)
+from jaxsedfit.spectral_defaults import (
+    DEFAULT_ELG_NARROW_LINE_PRIOR_ROWS,
+    DEFAULT_HIGH_IONIZATION_LINE_PRIOR_ROWS,
+    DEFAULT_LINE_PRIOR_ROWS,
+    _build_default_prior_config as build_default_prior_config,
+    append_optional_line_rows,
+    build_default_bal_components,
+)
+
+
+def test_prior_config_object_exposes_model_mapping():
+    prior = PriorConfig(
+        continuum=ContinuumPriorConfig(power_law_pivot=3000.0, polynomial_pivot=2800.0),
+        host=HostPriorConfig(redshift_weight_enabled=False),
+        lines=LinePriorConfig(
+            dmu_scale_mult=0.2,
+            sig_scale_mult=0.3,
+            amp_scale_mult=0.4,
+            extra_amp_scale_mult=0.5,
+        ),
+        feii=FeIIPriorConfig(
+            fwhm=dist.Normal(loc=np.log(1000.0), scale=0.2),
+            shift=dist.Normal(loc=0.0, scale=100.0),
+        ),
+    )
+    prior.powerlaw.slope = dist.Normal(loc=-1.5, scale=0.3)
+    mapping = prior.to_mapping()
+
+    assert mapping["PL_pivot"] == 3000.0
+    assert mapping["poly_pivot"] == 2800.0
+    assert mapping["host_redshift_prior"]["enabled"] is False
+    assert mapping["line_dmu_scale_mult"] == 0.2
+    assert mapping["line_extra_amp_scale_mult"] == 0.5
+    assert float(mapping["log_Fe_FWHM"].scale) == 0.2
+    assert float(mapping["Fe_shift"].scale) == 100.0
+    assert isinstance(mapping["PL_slope"], dist.Normal)
+
+
+def test_inference_defaults_use_standardized_line_block_geometry():
+    inference = InferenceConfig()
+
+    assert inference.num_warmup == 250
+    assert inference.num_samples == 250
+    assert inference.target_accept_prob == 0.82
+    assert inference.dense_mass is False
+    assert inference.line_block_dense_mass is True
+    assert inference.standardize_active_priors is True
+    assert inference.warmup_max_tree_depth is None
+
+
+def test_feii_fractional_error_maps_to_likelihood_site():
+    prior = PriorConfig(
+        feii=FeIIPriorConfig(
+            fractional_error=dist.TruncatedNormal(0.2, 0.05, low=0.0, high=0.5)
+        )
+    )
+
+    mapping = prior.to_mapping()
+
+    assert mapping["frac_fe_jitter"].__class__.__name__ == "TwoSidedTruncatedDistribution"
+    assert np.isclose(mapping["frac_fe_jitter"].base_dist.loc, 0.2)
+    assert np.isclose(mapping["frac_fe_jitter"].base_dist.scale, 0.05)
+
+
+def test_fit_config_to_dict_serializes_numpyro_priors():
+    prior = PriorConfig()
+    prior.powerlaw.slope = dist.Normal(loc=-1.5, scale=0.3)
+    cfg = FitConfig(
+        observation=Observation(redshift=0.1),
+        spectroscopy=SpectroscopyData(wave_obs=[4000.0, 5000.0], fluxes=[1.0, 1.1], mask=[True, False]),
+        prior_config=prior,
+    )
+
+    data = cfg.to_dict()
+
+    assert "wavelength_dispersion" not in data["spectroscopy"]
+    assert data["spectroscopy"]["mask"] == [True, False]
+    assert data["prior_config"]["continuum"]["powerlaw"]["slope"] == {
+        "dist": "Normal",
+        "loc": -1.5,
+        "scale": 0.3,
+    }
+
+
+def test_continuum_config_broadening_convolution_default_and_validation():
+    assert ContinuumConfig().broadening_convolution == "fft"
+    assert ContinuumConfig(broadening_convolution="direct").broadening_convolution == "direct"
+    with pytest.raises(ValueError, match="broadening_convolution"):
+        ContinuumConfig(broadening_convolution="scipy")
+
+
+def test_agn_type_presets_configure_component_switches():
+    cfg = FitConfig(
+        observation=Observation(redshift=0.1),
+        spectroscopy=SpectroscopyData(wave_obs=[4000.0, 5000.0], fluxes=[1.0, 1.1]),
+        agn=AGNConfig(agn_type=2),
+    )
+
+    cfg.apply_agn_type_defaults()
+
+    assert cfg.lines.enabled is True
+    assert cfg.lines.use_broad_lines is False
+    assert cfg.lines.use_narrow_lines is True
+    assert cfg.continuum.fit_feii is False
+    assert cfg.continuum.fit_balmer_continuum is False
+    assert cfg.host.enabled is True
+
+    cfg.set_agn_type(1)
+
+    assert cfg.agn.agn_type == 1
+    assert cfg.lines.use_broad_lines is True
+    assert cfg.lines.use_narrow_lines is True
+    assert cfg.continuum.fit_feii is True
+    assert cfg.continuum.fit_balmer_continuum is True
+
+
+def test_agn_config_rejects_unknown_type():
+    with pytest.raises(ValueError, match="AGNConfig.agn_type"):
+        AGNConfig(agn_type=3)
+
+
+def test_fit_config_coerces_agn_and_line_mappings():
+    cfg = FitConfig(
+        observation=Observation(redshift=0.1),
+        spectroscopy=SpectroscopyData(wave_obs=[4000.0, 5000.0], fluxes=[1.0, 1.1]),
+        agn={"agn_type": 2},
+        lines={"enabled": True, "use_broad_lines": False, "use_narrow_lines": True},
+    )
+
+    assert isinstance(cfg.agn, AGNConfig)
+    assert isinstance(cfg.lines, LineConfig)
+    assert cfg.agn.agn_type == 2
+    assert cfg.lines.use_broad_lines is False
+
+
+def test_line_config_owns_optional_builtin_line_switches():
+    lines = LineConfig(
+        include_elg_narrow_lines=True,
+        include_high_ionization_lines=True,
+    )
+    assert lines.include_elg_narrow_lines is True
+    assert lines.include_high_ionization_lines is True
+
+    prior = PriorConfig.from_spectrum(flux=np.array([1.0, 2.0, 3.0])).to_mapping()
+    append_optional_line_rows(
+        prior,
+        np.array([1.0, 2.0, 3.0]),
+        include_elg_narrow_lines=lines.include_elg_narrow_lines,
+        include_high_ionization_lines=lines.include_high_ionization_lines,
+    )
+    names = {row["linename"] for row in prior["line"]["table"]}
+    assert "OII3726" in names
+    assert "NeV3346" in names
+    assert "FeX6374" in names
+
+
+def test_prior_config_from_spectrum_exposes_semantic_prior_sections():
+    flux = np.array([1.0, 2.0, 3.0], dtype=float)
+
+    prior = PriorConfig.from_spectrum(
+        flux=flux,
+        redshift=1.0,
+    )
+    prior.powerlaw.slope = dist.TruncatedNormal(loc=-1.5, scale=0.3, low=-3.5, high=0.5)
+    prior.fe.uv_norm = dist.LogNormal(np.log(max(1.0e-3 * np.median(np.abs(flux)), 1.0e-10)), 0.04)
+    prior.fe.op_over_uv = dist.Normal(loc=0.0, scale=0.4)
+    prior.lines.dmu_scale_mult = 0.25
+    prior.lines.sig_scale_mult = 0.25
+    prior.lines.amp_scale_mult = 0.20
+    prior.host.stellar_mass = dist.TruncatedNormal(loc=10.6, scale=0.4, low=9.5, high=12.0)
+    prior.host.aperture_scale = dist.Normal(loc=0.0, scale=0.5)
+    prior.host.sfh_age_gyr = dist.Normal(loc=np.log(7.0), scale=0.3)
+    prior.host.sfh_tau_over_age = dist.Normal(loc=np.log(0.25), scale=0.3)
+    prior.host.metallicity = dist.Normal(loc=0.0, scale=0.2)
+    prior.host.metallicity_scatter = dist.Normal(loc=np.log(0.1), scale=0.3)
+    prior.host.template_age_prior = {"type": "prefer_old", "pivot_gyr": 1.0, "strength": 2.0}
+    prior.host.sfh_model = "delayed"
+
+    mapping = prior.to_mapping()
+
+    assert mapping["PL_slope"].__class__.__name__ == "TwoSidedTruncatedDistribution"
+    assert isinstance(mapping["log_Fe_uv_norm"], dist.LogNormal)
+    assert isinstance(mapping["log_Fe_op_over_uv"], dist.Normal)
+    assert mapping["line_dmu_scale_mult"] == 0.25
+    assert mapping["line_sig_scale_mult"] == 0.25
+    assert mapping["line_amp_scale_mult"] == 0.20
+    assert mapping["log_stellar_mass"].__class__.__name__ == "TwoSidedTruncatedDistribution"
+    for key in ("log_host_aperture_scale", "log_sfh_age_gyr", "log_sfh_tau_over_age", "gal_lgmet", "log_gal_lgmet_scatter"):
+        assert isinstance(mapping[key], dist.Normal)
+    assert mapping["host_template_age_prior"] == {"type": "prefer_old", "pivot_gyr": 1.0, "strength": 2.0}
+    assert mapping["host_sfh_model"] == "delayed"
+    assert np.isclose(mapping["cont_norm"].loc, np.log(2.0 * np.median(np.abs(flux))))
+
+
+def test_prior_config_coerces_nested_semantic_sections():
+    prior = PriorConfig(
+        continuum={"powerlaw": {"slope": dist.Normal(loc=-1.2, scale=0.2)}},
+        feii={"uv_norm": dist.Normal(loc=-5.0, scale=0.1)},
+        lines={"dmu_scale_mult": 0.1, "sig_scale_mult": 0.2, "amp_scale_mult": 0.3},
+        host={"sfh_model": "delayed", "stellar_mass": dist.Normal(loc=10.5, scale=0.2)},
+    )
+    mapping = prior.to_mapping()
+
+    assert isinstance(mapping["PL_slope"], dist.Normal)
+    assert isinstance(mapping["log_Fe_uv_norm"], dist.Normal)
+    assert mapping["line_dmu_scale_mult"] == 0.1
+    assert mapping["line_sig_scale_mult"] == 0.2
+    assert mapping["line_amp_scale_mult"] == 0.3
+    assert mapping["host_sfh_model"] == "delayed"
+    assert isinstance(mapping["log_stellar_mass"], dist.Normal)
+
+
+def test_fit_config_coerces_bal_mapping():
+    cfg = FitConfig(
+        observation=Observation(redshift=0.1),
+        spectroscopy=SpectroscopyData(wave_obs=[4000.0, 5000.0], fluxes=[1.0, 1.1]),
+        bal={
+            "enabled": True,
+            "tau_scale": 0.4,
+            "covering_loc": 0.2,
+            "covering_scale": 0.1,
+            "covering_high": 0.8,
+        }
+    )
+
+    assert isinstance(cfg.bal, BALConfig)
+    assert cfg.bal.enabled is True
+    assert np.isclose(cfg.bal.tau_scale, 0.4)
+    assert np.isclose(cfg.bal.covering_loc, 0.2)
+    assert np.isclose(cfg.bal.covering_scale, 0.1)
+    assert np.isclose(cfg.bal.covering_high, 0.8)
+
+
+def test_fit_config_coerces_prior_config_mapping():
+    cfg = FitConfig(
+        observation=Observation(redshift=0.1),
+        spectroscopy=SpectroscopyData(wave_obs=[4000.0, 5000.0], fluxes=[1.0, 1.1]),
+        host=HostConfig(sfh_model="flexible"),
+        prior_config={"continuum": {"power_law_pivot": 2500.0}},
+    )
+
+    assert isinstance(cfg.prior_config, PriorConfig)
+    assert cfg.host.sfh_model == "flexible"
+    assert cfg.prior_config.to_mapping()["PL_pivot"] == 2500.0
+
+
+def test_build_default_prior_config_has_expected_keys():
+    flux = np.array([1.0, 2.0, 3.0, 4.0], dtype=float)
+    cfg = build_default_prior_config(flux)
+    mapping = cfg.to_mapping()
+
+    required = [
+        'cont_norm',
+        'PL_norm',
+        'PL_slope',
+        'PL_pivot',
+        'poly_pivot',
+        'log_ebv',
+        'log_frac_host',
+        'tau_host',
+        'raw_w',
+        'line_dmu_scale_mult',
+        'line_sig_scale_mult',
+        'line_amp_scale_mult',
+        'line',
+        'student_t_df',
+    ]
+    for k in required:
+        assert k in mapping
+    assert isinstance(cfg, PriorConfig)
+    assert mapping["poly_pivot"] is None
+    assert mapping["log_stellar_mass"].__class__.__name__ == "TwoSidedTruncatedDistribution"
+    assert mapping["log_Balmer_vel"].__class__.__name__ == "TwoSidedTruncatedDistribution"
+    assert isinstance(mapping["log_host_aperture_scale"], dist.Normal)
+    assert mapping["host_template_age_prior"] == {
+        "type": "prefer_old",
+        "pivot_gyr": 1.0,
+        "strength": 1.0,
+        "min_logit": -3.0,
+        "max_logit": 2.0,
+    }
+    assert isinstance(mapping["log_sfh_tau_over_age"], dist.Normal)
+    assert mapping["log_gal_sigma_kms"].__class__.__name__ == "TwoSidedTruncatedDistribution"
+    assert isinstance(mapping["log_ebv"], dist.Normal)
+
+
+def test_build_default_prior_config_scales_with_flux_median():
+    flux = np.array([10.0, 20.0, 30.0], dtype=float)
+    cfg = build_default_prior_config(flux)
+
+    expected = np.log(np.median(np.abs(flux)))
+    mapping = cfg.to_mapping()
+
+    got = float(mapping['cont_norm'].loc)
+    assert np.isfinite(got)
+    assert np.isclose(got, expected)
+    assert isinstance(mapping['cont_norm'], dist.LogNormal)
+    assert isinstance(mapping['PL_slope'], dist.Normal)
+    assert isinstance(mapping['tau_host'], dist.HalfNormal)
+
+
+def test_default_line_initializations_are_interior_to_scaled_bounds():
+    mapping = build_default_prior_config(np.array([50.0, 75.0, 125.0], dtype=float)).to_mapping()
+    rows = mapping["line"]["table"]
+
+    for row in rows:
+        span = row["maxsca"] - row["minsca"]
+        expected_fraction = 0.05 if "_br" in row["linename"].lower() else 0.02
+        assert span > 0.0
+        assert row["inisca"] > row["minsca"]
+        assert row["inisca"] < row["maxsca"]
+        assert (row["inisca"] - row["minsca"]) / span >= expected_fraction - 1e-12
+
+
+def test_fixed_atomic_doublet_ratios_are_integrated_flux_ratios():
+    def integrated_ratio(rows, numerator, denominator):
+        by_name = {row["linename"]: row for row in rows}
+        num = by_name[numerator]
+        den = by_name[denominator]
+        return (num["fvalue"] * num["lambda"]) / (den["fvalue"] * den["lambda"])
+
+    assert integrated_ratio(DEFAULT_LINE_PRIOR_ROWS, "NII6585", "NII6549") == pytest.approx(3.0)
+    assert integrated_ratio(DEFAULT_ELG_NARROW_LINE_PRIOR_ROWS, "NII6583", "NII6548") == pytest.approx(3.0)
+    assert integrated_ratio(DEFAULT_ELG_NARROW_LINE_PRIOR_ROWS, "SIII9531", "SIII9069") == pytest.approx(2.5)
+
+
+def test_default_line_scale_bounds_ignore_single_extreme_pixel():
+    baseline = np.ones(2000)
+    contaminated = baseline.copy()
+    contaminated[-1] = 1.0e9
+
+    baseline_rows = build_default_prior_config(baseline).to_mapping()["line"]["table"]
+    contaminated_rows = build_default_prior_config(contaminated).to_mapping()["line"]["table"]
+
+    np.testing.assert_allclose(
+        [row["maxsca"] for row in contaminated_rows],
+        [row["maxsca"] for row in baseline_rows],
+    )
+
+
+def test_build_default_prior_config_accepts_manual_pl_pivot():
+    flux = np.array([1.0, 2.0, 3.0], dtype=float)
+    cfg = build_default_prior_config(flux, pl_pivot=3000.0)
+    mapping = cfg.to_mapping()
+    assert mapping["PL_pivot"] == 3000.0
+
+
+def test_build_default_prior_config_uses_explicit_dist_fields():
+    flux = np.array([1.0, 2.0, 3.0], dtype=float)
+    cfg = build_default_prior_config(flux)
+    mapping = cfg.to_mapping()
+
+    assert isinstance(mapping["log_frac_host"], dist.StudentT)
+    assert mapping["host_redshift_prior"]["enabled"] is False
+    assert mapping["host_redshift_prior"]["z_mid"] == 1.0
+    assert mapping["host_redshift_prior"]["width"] == 0.2
+    assert mapping["host_redshift_prior"]["lowz_loc_offset"] == 0.0
+    assert mapping["host_redshift_prior"]["highz_loc_offset"] == -8.0
+    assert mapping["host_redshift_prior"]["lowz_scale_mult"] == 1.0
+    assert mapping["host_redshift_prior"]["highz_scale_mult"] == 0.05
+    assert mapping["host_redshift_prior"]["lowz_df"] == 3.0
+    assert mapping["host_redshift_prior"]["highz_df"] == 20.0
+    assert isinstance(mapping["Fe_uv_norm"], dist.LogNormal)
+    assert np.isclose(mapping["Fe_uv_norm"].loc, np.log(0.03 * 2.0))
+    assert float(mapping["Fe_uv_norm"].scale) == 1.0
+    assert isinstance(mapping["log_Fe_op_over_uv"], dist.Normal)
+    assert isinstance(mapping["Fe_FWHM"], dist.LogNormal)
+    assert isinstance(mapping["Fe_shift"], dist.Normal)
+    assert isinstance(mapping["frac_jitter"], dist.HalfNormal)
+    assert mapping["frac_fe_jitter"] == {"dist": "Delta", "value": 0.20}
+    assert mapping["add_jitter"] == {"dist": "Delta", "value": 0.0}
+
+
+def test_build_default_bal_components_exposes_common_bal_lines():
+    comps = build_default_bal_components(np.array([1.0, 2.0, 3.0], dtype=float))
+
+    names = [comp.name for comp in comps]
+    assert names == ["bal_nv", "bal_siiv", "bal_civ"]
+    assert comps[2].metadata["component_type"] == "bal_absorption"
+    assert comps[2].metadata["line_lambda"] == 1549.06
+    assert comps[2].metadata["shared_parameter_sites"]["v_out"] == "custom_bal_v_out"
+    assert comps[2].metadata["shared_parameter_sites"]["tau_peak"] == "custom_bal_tau_peak"
+    assert comps[2].metadata["shared_parameter_sites"]["covering"] == "custom_bal_covering"
+    assert comps[2].metadata["shared_parameter_sites"]["fwhm_kms"] == "custom_bal_fwhm_kms"
+    assert np.isclose(comps[0].parameter_priors["tau_peak"].scale, 0.25)
+    assert np.isclose(comps[1].parameter_priors["tau_peak"].scale, 0.25)
+    tau_cfg = comps[2].parameter_priors["tau_peak"]
+    assert isinstance(tau_cfg, dist.HalfNormal)
+    assert np.isclose(tau_cfg.scale, 0.25)
+    covering_cfg = comps[2].parameter_priors["covering"]
+    assert covering_cfg.__class__.__name__ == "TwoSidedTruncatedDistribution"
+    assert covering_cfg.base_dist.loc == 0.15
+    assert covering_cfg.base_dist.scale == 0.12
+    assert covering_cfg.low == 0.0
+    assert covering_cfg.high == 0.70
+    v_out_cfg = comps[2].parameter_priors["v_out"]
+    assert v_out_cfg.base_dist.loc == 6000.0
+    assert v_out_cfg.base_dist.scale == 2500.0
+    assert v_out_cfg.low == 3000.0
+    assert v_out_cfg.high == 12000.0
+    fwhm_cfg = comps[2].parameter_priors["fwhm_kms"]
+    assert fwhm_cfg.base_dist.loc == 8000.0
+    assert fwhm_cfg.base_dist.scale == 2500.0
+    assert fwhm_cfg.low == 2000.0
+    assert fwhm_cfg.high == 15000.0
+    shape_cfg = comps[2].parameter_priors["shape_power"]
+    assert shape_cfg.base_dist.loc == 2.0
+    assert shape_cfg.low == 2.0
+    assert shape_cfg.high == 12.0
+
+
+def test_build_default_bal_components_accepts_prior_overrides():
+    comps = build_default_bal_components(
+        np.array([1.0, 2.0, 3.0], dtype=float),
+        tau_scale=0.6,
+        covering_loc=0.4,
+        covering_scale=0.1,
+        covering_high=0.85,
+        fwhm_kms_loc=6000.0,
+        fwhm_kms_scale=1500.0,
+        fwhm_kms_low=2500.0,
+        fwhm_kms_high=12000.0,
+    )
+
+    for comp in comps:
+        assert np.isclose(comp.parameter_priors["tau_peak"].scale, 0.6)
+        covering_cfg = comp.parameter_priors["covering"]
+        assert np.isclose(covering_cfg.base_dist.loc, 0.4)
+        assert np.isclose(covering_cfg.base_dist.scale, 0.1)
+        assert np.isclose(covering_cfg.high, 0.85)
+        fwhm_cfg = comp.parameter_priors["fwhm_kms"]
+        assert np.isclose(fwhm_cfg.base_dist.loc, 6000.0)
+        assert np.isclose(fwhm_cfg.base_dist.scale, 1500.0)
+        assert np.isclose(fwhm_cfg.low, 2500.0)
+        assert np.isclose(fwhm_cfg.high, 12000.0)
+
+
+def test_default_line_table_contains_expanded_uv_complexes():
+    cfg = build_default_prior_config(np.array([1.0, 2.0, 3.0], dtype=float))
+    rows = cfg.to_mapping()["line"]["table"]
+    by_name = {row["linename"]: row for row in rows}
+
+    expected_names = {
+        "CIII_br",
+        "CIII_na",
+        "SiIII1892",
+        "AlIII1857",
+        "SiII1816",
+        "NIII1750",
+        "NIV1718",
+        "CIV_br",
+        "HeII1640",
+        "OIII1663",
+        "HeII1640_br",
+        "OIII1663_br",
+        "SiIV_OIV1_br",
+        "SiIV_OIV2_br",
+        "CII1335",
+        "OI1304",
+        "Lya_br",
+        "NV1240_br",
+    }
+    assert expected_names.issubset(by_name)
+    assert "CIII_br" in by_name
+    assert by_name["CIII_br"]["ngauss"] == 2
+    assert by_name["CIV_br"]["ngauss"] == 3
+    assert by_name["Lya_br"]["ngauss"] == 3
+
+
+def test_optional_line_tables_do_not_duplicate_hei7065():
+    cfg = build_default_prior_config(
+        np.array([1.0, 2.0, 3.0], dtype=float),
+        include_elg_narrow_lines=True,
+        include_high_ionization_lines=True,
+    )
+    rows = cfg.to_mapping()["line"]["table"]
+    hei7065 = [row for row in rows if row["linename"] == "HeI7065"]
+
+    assert len(hei7065) == 1
+    assert np.isclose(hei7065[0]["lambda"], 7067.17)
+
+
+def test_principal_paschen_lines_are_default_with_independent_amplitudes():
+    by_name = {row["linename"]: row for row in DEFAULT_LINE_PRIOR_ROWS}
+
+    expected = {
+        "Pae_na", "Pad_na", "Pag_br", "Pag_na", "Pab_br", "Pab_na",
+        "Paa_br", "Paa_na", "HeI10830_br", "HeI10830_na",
+    }
+    assert expected.issubset(by_name)
+    assert all(by_name[name]["findex"] == 0 for name in expected)
+    assert by_name["Pag_br"]["ngauss"] == 1
+    assert by_name["Pab_br"]["ngauss"] == 1
+    assert by_name["Paa_br"]["ngauss"] == 1
+
+
+def test_optional_elg_table_only_contains_higher_order_paschen_lines():
+    names = {row["linename"] for row in DEFAULT_ELG_NARROW_LINE_PRIOR_ROWS}
+
+    assert {"Pa9", "Pa10", "Pa11", "Pa12"}.issubset(names)
+    assert names.isdisjoint({"Pae", "Pad", "Pag", "Pab", "Paa"})
+
+
+def test_optional_fixed_doublet_ratios_are_physical():
+    elg_by_name = {row["linename"]: row for row in DEFAULT_ELG_NARROW_LINE_PRIOR_ROWS}
+    high_ion_by_name = {row["linename"]: row for row in DEFAULT_HIGH_IONIZATION_LINE_PRIOR_ROWS}
+
+    assert np.isclose(
+        elg_by_name["OIII5007"]["fvalue"] * elg_by_name["OIII5007"]["lambda"]
+        / (elg_by_name["OIII4959"]["fvalue"] * elg_by_name["OIII4959"]["lambda"]),
+        2.98,
+    )
+    assert np.isclose(
+        elg_by_name["OI6300"]["fvalue"] * elg_by_name["OI6300"]["lambda"]
+        / (elg_by_name["OI6363"]["fvalue"] * elg_by_name["OI6363"]["lambda"]),
+        3.05,
+    )
+    assert np.isclose(
+        elg_by_name["NII6583"]["fvalue"] * elg_by_name["NII6583"]["lambda"]
+        / (elg_by_name["NII6548"]["fvalue"] * elg_by_name["NII6548"]["lambda"]),
+        3.0,
+    )
+    assert np.isclose(
+        high_ion_by_name["NeV3426_hi"]["fvalue"] * high_ion_by_name["NeV3426_hi"]["lambda"]
+        / (high_ion_by_name["NeV3346"]["fvalue"] * high_ion_by_name["NeV3346"]["lambda"]),
+        2.7,
+    )
+
+
+def test_default_oiii_doublets_are_tied_with_physical_ratio():
+    cfg = build_default_prior_config(np.array([1.0, 2.0, 3.0], dtype=float))
+    by_name = {row["linename"]: row for row in cfg.to_mapping()["line"]["table"]}
+
+    assert by_name["OIII4959c"]["findex"] == by_name["OIII5007c"]["findex"]
+    assert by_name["OIII4959w"]["findex"] == by_name["OIII5007w"]["findex"]
+    assert by_name["OIII4959c"]["findex"] != by_name["OIII4959w"]["findex"]
+    assert np.isclose(
+        by_name["OIII5007c"]["fvalue"] * by_name["OIII5007c"]["lambda"]
+        / (by_name["OIII4959c"]["fvalue"] * by_name["OIII4959c"]["lambda"]),
+        2.98,
+    )
+    assert np.isclose(
+        by_name["OIII5007w"]["fvalue"] * by_name["OIII5007w"]["lambda"]
+        / (by_name["OIII4959w"]["fvalue"] * by_name["OIII4959w"]["lambda"]),
+        2.98,
+    )
+
+
+def test_combined_optional_config_preserves_oi_doublet_ratio():
+    cfg = build_default_prior_config(
+        np.array([1.0, 2.0, 3.0], dtype=float),
+        include_elg_narrow_lines=True,
+    )
+    by_name = {row["linename"]: row for row in cfg.to_mapping()["line"]["table"]}
+
+    assert np.isclose(
+        by_name["OI6300"]["fvalue"] * by_name["OI6300"]["lambda"]
+        / (by_name["OI6363"]["fvalue"] * by_name["OI6363"]["lambda"]),
+        3.05,
+    )

--- a/tests/test_spectral_reparameterization.py
+++ b/tests/test_spectral_reparameterization.py
@@ -1,0 +1,76 @@
+import numpy as np
+import numpyro
+import numpyro.distributions as dist
+from numpyro.handlers import reparam
+from numpyro.infer.util import log_density
+
+from jaxsedfit.spectroscopy import (
+    NORMAL_LOGNORMAL_STANDARDIZATION,
+    NormalLogNormalStandardizeReparam,
+    normal_lognormal_standardization_reparam,
+    standardized_prior_site,
+)
+
+
+def _standardizable_prior_model(prior):
+    return numpyro.sample(
+        "physical",
+        prior,
+        infer={
+            NORMAL_LOGNORMAL_STANDARDIZATION: {
+                "auxiliary_name": standardized_prior_site("physical"),
+            }
+        },
+    )
+
+
+def test_normal_lognormal_standardization_is_exact_and_maps_initial_values():
+    wrapped = reparam(
+        _standardizable_prior_model,
+        config=normal_lognormal_standardization_reparam,
+    )
+    standardized = np.asarray(-0.4)
+    priors = (
+        dist.Normal(2.0, 3.0),
+        dist.LogNormal(np.log(2.0), 0.7),
+    )
+
+    for prior in priors:
+        unconstrained = prior.loc + prior.scale * standardized
+        physical = (
+            np.exp(np.asarray(unconstrained))
+            if isinstance(prior, dist.LogNormal)
+            else np.asarray(unconstrained)
+        )
+        original_density, _ = log_density(
+            _standardizable_prior_model,
+            (),
+            {"prior": prior},
+            {"physical": physical},
+        )
+        standardized_density, standardized_trace = log_density(
+            wrapped,
+            (),
+            {"prior": prior},
+            {"physical_std": standardized},
+        )
+        log_abs_det = np.log(float(prior.scale))
+        if isinstance(prior, dist.LogNormal):
+            log_abs_det += np.log(float(physical))
+        np.testing.assert_allclose(
+            standardized_density,
+            original_density + log_abs_det,
+            rtol=1.0e-12,
+        )
+        assert standardized_trace["physical"]["type"] == "deterministic"
+        np.testing.assert_allclose(
+            standardized_trace["physical"]["value"],
+            physical,
+            rtol=1.0e-12,
+        )
+        reparameterizer = NormalLogNormalStandardizeReparam("physical_std")
+        np.testing.assert_allclose(
+            reparameterizer.transform_initial_value(prior, physical),
+            standardized,
+            rtol=1.0e-12,
+        )


### PR DESCRIPTION
## Summary

- add a documented `jaxsedfit.spectroscopy` integration API for detailed quasar spectral modeling
- route joint fitting through the supported API rather than private `spectral_*` helpers
- centralize generic NUTS transition and mass-matrix diagnostics in `jaxsedfit.inference`
- remove duplicate diagnostics implementations from the fitter core
- move authoritative spectral component, default-prior, and reparameterization tests from jaxqsofit into the implementation-owning repository

## Why

After moving the shared spectral engine into jaxsedfit, callers still depended on implementation modules and the authoritative unit tests remained in jaxqsofit. This PR establishes a stable integration boundary, aligns test ownership with code ownership, and prevents the two fitters' diagnostics implementations from drifting.

## Scientific impact

None intended. This is interface extraction, test movement, and exact code deduplication; model equations, priors, likelihoods, parameter names, and predictions are unchanged.

## Validation

- full test suite: 389 passed
- `git diff --check` passed
