### PR TITLE
Fix photo-z physics and censored likelihoods

### DIFF
--- a/src/jaxsedfit/config.py
+++ b/src/jaxsedfit/config.py
@@ -29,8 +29,12 @@ class Observation:
         mode = str(self.redshift_mode).lower()
         if mode not in {"fixed", "fit"}:
             raise ValueError("observation.redshift_mode must be either 'fixed' or 'fit'.")
-        if not np.isfinite(float(self.redshift)) or float(self.redshift) < 0.0:
-            raise ValueError("observation.redshift must be finite and non-negative.")
+        if not np.isfinite(float(self.redshift)) or float(self.redshift) <= 0.0:
+            raise ValueError(
+                "observation.redshift must be finite and strictly positive; "
+                "a source at z=0 requires an explicit distance, which jaxsedfit "
+                "does not currently accept."
+            )
         if not np.isfinite(float(self.redshift_err)) or float(self.redshift_err) < 0.0:
             raise ValueError("observation.redshift_err must be finite and non-negative.")
         self.redshift_mode = mode
@@ -592,6 +596,8 @@ class RedshiftPriorConfig:
             raise ValueError("redshift prior z_grid and pdf must be finite.")
         if np.any(np.diff(z_grid) <= 0.0):
             raise ValueError("redshift prior z_grid must be strictly increasing.")
+        if z_grid[0] <= 0.0:
+            raise ValueError("redshift prior z_grid must be strictly positive.")
         if np.any(pdf < 0.0):
             raise ValueError("redshift prior pdf must be non-negative.")
         norm = float(np.trapezoid(pdf, z_grid))

--- a/src/jaxsedfit/model.py
+++ b/src/jaxsedfit/model.py
@@ -176,6 +176,21 @@ def _luminosity_distance_m_jax(redshift, h0: float, om0: float):
     return jnp.reshape(d_l_m, ()) if scalar_input else d_l_m
 
 
+def _flat_lcdm_age_gyr_jax(redshift, h0: float, om0: float):
+    """Return the cosmic age for a flat matter-plus-Lambda cosmology."""
+    z = jnp.maximum(jnp.asarray(redshift, dtype=jnp.float64), 0.0)
+    omega_m = jnp.clip(jnp.asarray(om0, dtype=jnp.float64), 1.0e-8, 1.0 - 1.0e-8)
+    omega_l = 1.0 - omega_m
+    hubble_time_gyr = 977.7922216807892 / jnp.asarray(h0, dtype=jnp.float64)
+    argument = jnp.sqrt(omega_l / omega_m) / (1.0 + z) ** 1.5
+    return (
+        2.0
+        * hubble_time_gyr
+        / (3.0 * jnp.sqrt(omega_l))
+        * jnp.arcsinh(argument)
+    )
+
+
 def _prior_distribution(prior_config: dict[str, Any], key: str, default_distribution):
     """Read a NumPyro distribution-like prior from the flat prior mapping.
 
@@ -1942,6 +1957,7 @@ def _build_diffstar_host(
     *,
     full_output: bool = True,
     shared_gal_lgmet=None,
+    redshift=None,
 ):
     """Build the host-galaxy SED from Diffstar SFH and a precomputed SSP basis.
 
@@ -1958,9 +1974,23 @@ def _build_diffstar_host(
     ssp_lg_age_gyr = context.host_basis_jax.ssp_lg_age_gyr
     host_basis_rest = context.host_basis_jax.rest_llambda
     surviving_frac_by_age = context.host_basis_jax.surviving_frac_by_age
-    gal_t_table = context.host_basis_jax.gal_t_table
-    t_obs_gyr = jnp.asarray(context.t_obs_gyr, dtype=jnp.float64)
     galaxy_cfg = context.fit_config.galaxy
+    if redshift is None:
+        redshift = jnp.asarray(context.fit_config.observation.redshift, dtype=jnp.float64)
+    if bool(getattr(context.fit_config.observation, "fits_redshift", False)):
+        t_obs_gyr = _flat_lcdm_age_gyr_jax(
+            redshift,
+            galaxy_cfg.cosmology_h0,
+            galaxy_cfg.cosmology_om0,
+        )
+        gal_t_table = jnp.geomspace(
+            jnp.asarray(galaxy_cfg.sfh_t_min_gyr, dtype=jnp.float64),
+            jnp.maximum(t_obs_gyr, galaxy_cfg.sfh_t_min_gyr * 1.01),
+            context.host_basis_jax.gal_t_table.size,
+        )
+    else:
+        gal_t_table = context.host_basis_jax.gal_t_table
+        t_obs_gyr = jnp.asarray(context.t_obs_gyr, dtype=jnp.float64)
 
     log_stellar_mass = _sample_log_stellar_mass(prior_config)
 
@@ -1988,7 +2018,7 @@ def _build_diffstar_host(
         gal_lgmet,
         prior_config,
         ssp_lgmet=ssp_lgmet,
-        redshift=float(context.fit_config.observation.redshift),
+        redshift=redshift,
         metallicity_coordinate=galaxy_cfg.ssp_metallicity_coordinate,
         solar_metallicity=galaxy_cfg.ssp_solar_metallicity,
     )
@@ -2056,6 +2086,7 @@ def _build_delayed_host(
     *,
     full_output: bool = True,
     shared_gal_lgmet=None,
+    redshift=None,
 ):
     """Build the host-galaxy SED from a CIGALE-like delayed-tau SFH.
 
@@ -2072,30 +2103,47 @@ def _build_delayed_host(
     ssp_lg_age_gyr = context.host_basis_jax.ssp_lg_age_gyr
     host_basis_rest = context.host_basis_jax.rest_llambda
     surviving_frac_by_age = context.host_basis_jax.surviving_frac_by_age
-    gal_t_table = context.host_basis_jax.gal_t_table
-    t_obs_gyr = jnp.asarray(context.t_obs_gyr, dtype=jnp.float64)
     cfg = context.fit_config.galaxy
+    if redshift is None:
+        redshift = jnp.asarray(context.fit_config.observation.redshift, dtype=jnp.float64)
+    if bool(getattr(context.fit_config.observation, "fits_redshift", False)):
+        t_obs_gyr = _flat_lcdm_age_gyr_jax(
+            redshift,
+            cfg.cosmology_h0,
+            cfg.cosmology_om0,
+        )
+        gal_t_table = jnp.geomspace(
+            jnp.asarray(cfg.sfh_t_min_gyr, dtype=jnp.float64),
+            jnp.maximum(t_obs_gyr, cfg.sfh_t_min_gyr * 1.01),
+            context.host_basis_jax.gal_t_table.size,
+        )
+    else:
+        gal_t_table = context.host_basis_jax.gal_t_table
+        t_obs_gyr = jnp.asarray(context.t_obs_gyr, dtype=jnp.float64)
 
     log_stellar_mass = _sample_log_stellar_mass(prior_config)
     physical_min_age = max(float(cfg.sfh_t_min_gyr), 1.0e-3)
-    physical_max_age = max(float(context.t_obs_gyr), physical_min_age * 1.01)
+    physical_max_age = jnp.maximum(t_obs_gyr, physical_min_age * 1.01)
     if "log_sfh_age_gyr" in prior_config:
         log_age_gyr = _sample_bounded_normal(
             prior_config,
             "log_sfh_age_gyr",
-            np.log(min(3.0, physical_max_age)),
+            jnp.log(jnp.minimum(3.0, physical_max_age)),
             1.0,
             np.log(physical_min_age),
-            np.log(physical_max_age),
+            jnp.log(physical_max_age),
         )
     else:
         # Continuous equivalent of the GRAHSP age_main grid: log-uniform
         # from 10^2.2 Myr to 10 Gyr, capped by the age of the Universe.
-        default_max_age = min(10.0, physical_max_age)
-        default_min_age = min(max(10.0**-0.8, physical_min_age), default_max_age / 1.01)
+        default_max_age = jnp.minimum(10.0, physical_max_age)
+        default_min_age = jnp.minimum(
+            max(10.0**-0.8, physical_min_age),
+            default_max_age / 1.01,
+        )
         log_age_gyr = numpyro.sample(
             "log_sfh_age_gyr",
-            dist.Uniform(np.log(default_min_age), np.log(default_max_age)),
+            dist.Uniform(jnp.log(default_min_age), jnp.log(default_max_age)),
         )
     age_gyr = jnp.exp(log_age_gyr)
     if "log_sfh_tau_over_age" in prior_config:
@@ -2207,7 +2255,7 @@ def _build_delayed_host(
         gal_lgmet,
         prior_config,
         ssp_lgmet=ssp_lgmet,
-        redshift=float(context.fit_config.observation.redshift),
+        redshift=redshift,
         metallicity_coordinate=cfg.ssp_metallicity_coordinate,
         solar_metallicity=cfg.ssp_solar_metallicity,
     )
@@ -2278,6 +2326,7 @@ def _build_host_state(
     *,
     full_output: bool = True,
     shared_gal_lgmet=None,
+    redshift=None,
 ):
     """Dispatch to the configured host SFH model.
 
@@ -2305,6 +2354,7 @@ def _build_host_state(
             prior_config,
             full_output=full_output,
             shared_gal_lgmet=shared_gal_lgmet,
+            redshift=redshift,
         )
     if model_name in {"diffstar", "dsps_diffstar"}:
         return _build_diffstar_host(
@@ -2312,6 +2362,7 @@ def _build_host_state(
             prior_config,
             full_output=full_output,
             shared_gal_lgmet=shared_gal_lgmet,
+            redshift=redshift,
         )
     raise ValueError("galaxy.host_sfh_model must be one of: 'delayed', 'delayed_burst', 'diffstar'.")
 
@@ -2625,7 +2676,7 @@ def _sample_redshift(context: ModelContext, prior_config: dict[str, Any], cfg) -
             dist.TruncatedNormal(
                 cfg.observation.redshift,
                 max(cfg.observation.redshift_err, 1e-3),
-                low=0.0,
+                low=1.0e-8,
             ),
         )
 
@@ -2839,7 +2890,11 @@ def photometric_loglike(
     else:
         raise ValueError("likelihood.likelihood_family must be one of: 'gaussian', 'student_t'.")
     logl_data = jnp.sum(jnp.where(data_mask, data_dist.log_prob(obs_fluxes), 0.0))
-    logl_lim = jnp.sum(jnp.where(upper_limits, -0.5 * _chi2_upper_limit(obs_fluxes, pred_fluxes, total_variance), 0.0))
+    # Censored measurements must use the same sampling family as detections.
+    # In particular, the default Student-t likelihood has substantially
+    # heavier upper-tail probability than a Gaussian at fixed scale.
+    log_cdf = jnp.log(jnp.clip(data_dist.cdf(obs_fluxes), 1.0e-300, 1.0))
+    logl_lim = jnp.sum(jnp.where(upper_limits, log_cdf, 0.0))
     invalid = active & ~(input_valid & auxiliary_valid & variance_valid)
     penalty = -1.0e6 * jnp.sum(invalid.astype(jnp.float64))
     return logl_data + logl_lim + penalty
@@ -3498,6 +3553,18 @@ def evaluate_photometric_state(
         and not spectroscopy_enabled
         and not cfg.likelihood.attenuation_model_uncertainty
     )
+    if cfg.observation.fits_redshift:
+        redshift = _sample_redshift(context, prior_config, cfg)
+        luminosity_distance_m = _luminosity_distance_m_jax(
+            redshift,
+            cfg.galaxy.cosmology_h0,
+            cfg.galaxy.cosmology_om0,
+        )
+        igm = _igm_transmission(context.igm_cache_jax, redshift)
+    else:
+        redshift = context.fixed_redshift_jax
+        luminosity_distance_m = context.fixed_luminosity_distance_m_jax
+        igm = context.fixed_igm_jax
     needs_spec_host_basis = bool(
         spectroscopy_enabled
         and str(cfg.spectroscopy_config.backend).lower() == "jaxqsofit"
@@ -3512,6 +3579,7 @@ def evaluate_photometric_state(
             prior_config,
             full_output=include_components or needs_spec_host_basis,
             shared_gal_lgmet=shared_gal_lgmet,
+            redshift=redshift,
         )
         if fit_host
         else _empty_host_state(context)
@@ -3928,18 +3996,6 @@ def evaluate_photometric_state(
         )
     else:
         agn_systematics_width = jnp.asarray(float(cfg.likelihood.agn_systematics_width), dtype=jnp.float64)
-    if cfg.observation.fits_redshift:
-        redshift = _sample_redshift(context, prior_config, cfg)
-        luminosity_distance_m = _luminosity_distance_m_jax(
-            redshift,
-            cfg.galaxy.cosmology_h0,
-            cfg.galaxy.cosmology_om0,
-        )
-        igm = _igm_transmission(context.igm_cache_jax, redshift)
-    else:
-        redshift = context.fixed_redshift_jax
-        luminosity_distance_m = context.fixed_luminosity_distance_m_jax
-        igm = context.fixed_igm_jax
     nebular = _build_nebular_components(
         context,
         host_state,

--- a/src/jaxsedfit/preload.py
+++ b/src/jaxsedfit/preload.py
@@ -1527,7 +1527,7 @@ def _redshift_projection_grid(cfg: FitConfig) -> np.ndarray:
     else:
         sigma = max(float(cfg.observation.redshift_err), 1.0e-3)
         width = max(float(cfg.likelihood.redshift_projection_sigma), 1.0) * sigma
-        low = max(0.0, float(cfg.observation.redshift) - width)
+        low = max(1.0e-8, float(cfg.observation.redshift) - width)
         high = max(low + 1.0e-6, float(cfg.observation.redshift) + width)
     return np.linspace(low, high, n_grid, dtype=float)
 

--- a/tests/test_diffstar_host.py
+++ b/tests/test_diffstar_host.py
@@ -31,6 +31,7 @@ from jaxsedfit.model import (
     _delayed_sfh_cumulative_mass,
     _default_gal_lgmet_loc,
     _diffstar_ssp_age_weights,
+    _flat_lcdm_age_gyr_jax,
     _mass_metallicity_relation_logprior,
     _luminosity_distance_m_jax,
     _ssp_log_age_bin_edges,
@@ -597,6 +598,9 @@ def test_tabulated_redshift_pdf_prior_is_supported(monkeypatch):
     assert "redshift_pdf_prior" in tr
     prior_value = np.asarray(tr["redshift_pdf_prior"]["value"], dtype=float)
     assert np.all(np.isfinite(prior_value))
+    cosmic_age = float(np.asarray(_flat_lcdm_age_gyr_jax(redshift, 70.0, 0.3)))
+    age_upper = float(np.exp(np.asarray(tr["log_sfh_age_gyr"]["fn"].support.upper_bound)))
+    assert age_upper == pytest.approx(min(10.0, cosmic_age), rel=1.0e-10)
 
 
 def test_luminosity_distance_jax_depends_on_redshift():

--- a/tests/test_model_helpers.py
+++ b/tests/test_model_helpers.py
@@ -127,7 +127,7 @@ def test_likelihood_defaults_include_local_line_photometry():
 
 @pytest.mark.parametrize("redshift", [-0.1, np.nan, np.inf])
 def test_observation_rejects_invalid_redshift(redshift):
-    with pytest.raises(ValueError, match="finite and non-negative"):
+    with pytest.raises(ValueError, match="finite and strictly positive"):
         Observation(redshift=redshift).validate()
 
 
@@ -1033,6 +1033,40 @@ def test_upper_limit_likelihood_uses_standard_deviation_not_variance():
     assert chi2_scaled == pytest.approx(chi2, rel=1.0e-12)
 
 
+def test_upper_limit_uses_configured_sampling_family():
+    kwargs = dict(
+        pred_fluxes=np.asarray([1.5]),
+        obs_fluxes=np.asarray([1.0]),
+        obs_errors=np.asarray([0.2]),
+        upper_limits=np.asarray([True]),
+        data_mask=np.asarray([False]),
+        systematics_width=0.0,
+        student_t_df=5.0,
+        agn_component=np.asarray([0.0]),
+        agn_bol_lum_w=1.0e38,
+        agn_nev=0.1,
+        variability_uncertainty=False,
+        attenuation_model_uncertainty=False,
+        transmitted_fraction=np.asarray([1.0]),
+        lyman_break_uncertainty=False,
+        filter_wavelength=np.asarray([5000.0]),
+        redshift=0.1,
+    )
+
+    gaussian = float(photometric_loglike(**kwargs, likelihood_family="gaussian"))
+    student = float(photometric_loglike(**kwargs, likelihood_family="student_t"))
+    expected_gaussian = float(
+        np.log(np.asarray(dist.Normal(1.5, 0.2).cdf(np.asarray(1.0))))
+    )
+    expected_student = float(
+        np.log(np.asarray(dist.StudentT(5.0, 1.5, 0.2).cdf(np.asarray(1.0))))
+    )
+
+    assert gaussian == pytest.approx(expected_gaussian, rel=1.0e-12)
+    assert student == pytest.approx(expected_student, rel=1.0e-12)
+    assert student > gaussian
+
+
 def test_lyman_break_uncertainty_threshold_uses_angstroms():
     kwargs = dict(
         pred_fluxes=np.asarray([100.0]),
@@ -1593,7 +1627,7 @@ def test_jaxqsofit_backend_does_not_fix_narrow_width_without_explicit_override(m
         fake_evaluate_joint_spectral_components,
     )
     cfg = FitConfig(
-        observation=Observation(redshift=0.0),
+        observation=Observation(redshift=1.0e-4),
         photometry=PhotometryData(filter_names=["f1"], fluxes=[1.0], errors=[0.1]),
         spectroscopy_config=SpectroscopyConfig(
             enabled=True,
@@ -1862,7 +1896,7 @@ def test_jaxqsofit_backend_keeps_nebular_width_fixed_without_nebular_prior(monke
     monkeypatch.setattr("jaxsedfit.preload._load_ssp_templates", lambda fn: _SSPData())
 
     cfg = FitConfig(
-        observation=Observation(object_id="obj", redshift=0.0),
+        observation=Observation(object_id="obj", redshift=1.0e-4),
         photometry=PhotometryData(filter_names=["f1"], fluxes=[1.0], errors=[0.1]),
         filters=FilterSet(curves=[FilterCurve(name="f1", wave=[1000.0, 2000.0, 3000.0], transmission=[0.0, 1.0, 0.0])]),
         galaxy=GalaxyConfig(dsps_ssp_fn="fake.h5", n_wave=64, fit_host=True),
@@ -2002,7 +2036,7 @@ def test_jaxsedfit_jaxqsofit_backend_uses_nested_tied_line_config(monkeypatch):
     monkeypatch.setattr("jaxsedfit.preload._load_ssp_templates", lambda fn: _SSPData())
 
     cfg = FitConfig(
-        observation=Observation(object_id="obj", redshift=0.0),
+        observation=Observation(object_id="obj", redshift=1.0e-4),
         photometry=PhotometryData(
             filter_names=["f1"],
             fluxes=[1.0],
@@ -2136,7 +2170,7 @@ def test_jaxsedfit_jaxqsofit_tied_line_backend_runs_svi_jit(monkeypatch):
         }
     ]
     cfg = FitConfig(
-        observation=Observation(object_id="obj", redshift=0.0),
+        observation=Observation(object_id="obj", redshift=1.0e-4),
         photometry=PhotometryData(filter_names=["f1"], fluxes=[1.0], errors=[0.1]),
         filters=FilterSet(curves=[FilterCurve(name="f1", wave=[1000.0, 2000.0, 3000.0], transmission=[0.0, 1.0, 0.0])]),
         galaxy=GalaxyConfig(dsps_ssp_fn="fake.h5", n_wave=64, fit_host=False),
@@ -2278,6 +2312,30 @@ def test_config_rejects_invalid_redshift_pdf():
         ),
     )
     with pytest.raises(ValueError, match="strictly increasing"):
+        cfg.validate()
+
+
+def test_config_rejects_zero_redshift_without_explicit_distance():
+    cfg = FitConfig(
+        observation=Observation(object_id="local", redshift=0.0),
+        photometry=PhotometryData(filter_names=["f1"], fluxes=[1.0], errors=[0.1]),
+    )
+    with pytest.raises(ValueError, match="strictly positive"):
+        cfg.validate()
+
+
+def test_config_rejects_redshift_pdf_touching_zero():
+    cfg = FitConfig(
+        observation=Observation(object_id="obj", redshift=0.1, redshift_mode="fit"),
+        photometry=PhotometryData(filter_names=["f1"], fluxes=[1.0], errors=[0.1]),
+        prior_config=PriorConfig(
+            redshift=RedshiftPriorConfig(
+                z_grid=[0.0, 0.1, 0.2],
+                pdf=[0.2, 0.5, 0.3],
+            )
+        ),
+    )
+    with pytest.raises(ValueError, match="strictly positive"):
         cfg.validate()
 
 


### PR DESCRIPTION
## Summary

- sample fitted redshift before constructing the host stellar population
- recompute the flat-ΛCDM cosmic age, SFH time grid, and stellar-age ceiling at each sampled redshift
- evaluate the evolving mass–metallicity prior at the sampled redshift
- exclude the singular `z = 0` boundary from observations, tabulated photo-z priors, and cached projection grids
- use the configured Gaussian or Student-t CDF for censored upper-limit measurements

## Root cause and impact

Photo-z fits previously updated luminosity distance and IGM transmission while leaving host ages, SFHs, and the optional evolving mass–metallicity prior fixed at the catalog redshift. This could admit stellar populations older than the Universe and bias inferred host properties across a broad redshift posterior. The zero-redshift boundary also produced a finite but unphysical flux scale after distance clamping. Finally, upper limits always used Gaussian censoring even when detections used the default Student-t likelihood.

Fixed-redshift fits retain their existing precomputed age, distance, IGM, and filter-projection paths; the new dynamic calculations are conditional on fitted-redshift mode.

## Validation

- `conda run -n jaxcpu env PYTHONPATH=src pytest -q tests`
- 395 passed
- `git diff --check`
