### PR TITLE
Fix masked Student-t likelihood gradients

### DIFF
--- a/src/jaxsedfit/model.py
+++ b/src/jaxsedfit/model.py
@@ -2889,11 +2889,19 @@ def photometric_loglike(
         data_dist = dist.StudentT(df=student_t_df, loc=pred_fluxes, scale=scale)
     else:
         raise ValueError("likelihood.likelihood_family must be one of: 'gaussian', 'student_t'.")
-    logl_data = jnp.sum(jnp.where(data_mask, data_dist.log_prob(obs_fluxes), 0.0))
+    # Mask distribution inputs before evaluating them. JAX differentiates
+    # both branches of ``where``; masking only the returned log probabilities
+    # allows an unstable inactive tail (notably Student-t CDF gradients) to
+    # poison the full gradient with NaNs.
+    detection_obs = jnp.where(data_mask, obs_fluxes, pred_fluxes)
+    logl_data = jnp.sum(jnp.where(data_mask, data_dist.log_prob(detection_obs), 0.0))
     # Censored measurements must use the same sampling family as detections.
     # In particular, the default Student-t likelihood has substantially
     # heavier upper-tail probability than a Gaussian at fixed scale.
-    log_cdf = jnp.log(jnp.clip(data_dist.cdf(obs_fluxes), 1.0e-300, 1.0))
+    # A one-scale offset avoids the undefined Student-t CDF derivative at its
+    # exact center while remaining a parameter-independent standardized value.
+    limit_obs = jnp.where(upper_limits, obs_fluxes, pred_fluxes + scale)
+    log_cdf = jnp.log(jnp.clip(data_dist.cdf(limit_obs), 1.0e-300, 1.0))
     logl_lim = jnp.sum(jnp.where(upper_limits, log_cdf, 0.0))
     invalid = active & ~(input_valid & auxiliary_valid & variance_valid)
     penalty = -1.0e6 * jnp.sum(invalid.astype(jnp.float64))

--- a/tests/test_model_helpers.py
+++ b/tests/test_model_helpers.py
@@ -1067,6 +1067,52 @@ def test_upper_limit_uses_configured_sampling_family():
     assert student > gaussian
 
 
+def test_student_t_masks_inactive_distribution_inputs_before_evaluation(monkeypatch):
+    """Inactive Student-t tails must not contaminate NUTS gradients."""
+    original_cdf = dist.StudentT.cdf
+    seen = {}
+
+    def _recording_cdf(self, value):
+        seen["value"] = value
+        seen["loc"] = self.loc
+        return original_cdf(self, value)
+
+    monkeypatch.setattr(dist.StudentT, "cdf", _recording_cdf)
+    pred_fluxes = jnp.asarray([1.0e-12, 2.0])
+    obs_fluxes = jnp.asarray([1.0e6, 1.5])
+
+    def loglike(pred):
+        return photometric_loglike(
+            pred_fluxes=pred,
+            obs_fluxes=obs_fluxes,
+            obs_errors=jnp.asarray([1.0e-8, 0.2]),
+            upper_limits=jnp.asarray([False, True]),
+            data_mask=jnp.asarray([True, False]),
+            systematics_width=0.0,
+            likelihood_family="student_t",
+            student_t_df=5.0,
+            agn_component=jnp.zeros(2),
+            agn_bol_lum_w=1.0e37,
+            agn_nev=0.1,
+            variability_uncertainty=False,
+            attenuation_model_uncertainty=False,
+            transmitted_fraction=jnp.ones(2),
+            lyman_break_uncertainty=False,
+            filter_wavelength=jnp.asarray([5000.0, 10000.0]),
+            redshift=0.5,
+        )
+
+    loglike(pred_fluxes)
+    seen_value = np.asarray(seen["value"])
+    seen_loc = np.asarray(seen["loc"])
+    monkeypatch.setattr(dist.StudentT, "cdf", original_cdf)
+    gradient = np.asarray(jax.grad(loglike)(pred_fluxes))
+
+    assert seen_value[0] > seen_loc[0]
+    assert seen_value[1] == pytest.approx(obs_fluxes[1])
+    assert np.all(np.isfinite(gradient))
+
+
 def test_lyman_break_uncertainty_threshold_uses_angstroms():
     kwargs = dict(
         pred_fluxes=np.asarray([100.0]),


### PR DESCRIPTION
## What changed

- Mask inactive detection and upper-limit inputs before evaluating the likelihood distributions.
- Evaluate inactive Student-t CDF entries at a fixed standardized offset of +1, avoiding its undefined/unstable derivative at the distribution center and in extreme tails.
- Add a regression test that reproduces the mixed detection/upper-limit gradient path and asserts finite gradients.

## Root cause

The previous code applied `jnp.where` only after evaluating `StudentT.cdf`. JAX differentiates both branches, so an inactive CDF evaluation could still introduce NaNs into the full gradient. This caused `initialize_model` to reject otherwise finite parameter states with `RuntimeError: Cannot find valid initial parameters`, accounting for the large high-Lbol failure count.

The active detection and upper-limit likelihood values are unchanged. The masks are fixed data, and the inactive CDF input has a parameter-independent standardized residual, so the corrected target remains smooth for NUTS.

## Validation

- `pytest tests/test_model_helpers.py`: 113 passed
- The exact previously failing object `0750_011521...` now initializes with finite gradients and potential energy 523.8256085545032.
- `git diff --check` passes.