### PR TITLE
Render joint spectral lines in SED plots

### DIFF
--- a/src/jaxsedfit/core.py
+++ b/src/jaxsedfit/core.py
@@ -663,6 +663,7 @@ class JAXSEDFit:
             "jqf_balmer_photometry",
             "jqf_extrapolated_broad_photometry",
             "jqf_extrapolated_narrow_photometry",
+            "jqf_line_obs_sed",
             "rest_wave",
             "obs_wave",
             "redshift_fit",

--- a/src/jaxsedfit/model.py
+++ b/src/jaxsedfit/model.py
@@ -4527,16 +4527,11 @@ def evaluate_photometric_state(
             # a globally rescaled copy of the native jaxsedfit line template.
             from .spectroscopy import render_joint_feature_state
 
-            jqf_sed_line_cfg = replace(
-                jqf_components["component_config"],
-                use_feii=False,
-                use_balmer_continuum=False,
-            )
             jqf_sed_lines_mjy = render_joint_feature_state(
                 obs_wave,
                 redshift,
                 jqf_state,
-                config=jqf_sed_line_cfg,
+                config=jqf_components["component_config"],
             )["lines"]
             jqf_line_obs_sed = jqf_sed_lines_mjy / jnp.maximum(
                 1.0e-10 / 299792458.0 * 1.0e29 * obs_wave**2,

--- a/src/jaxsedfit/model.py
+++ b/src/jaxsedfit/model.py
@@ -4337,6 +4337,7 @@ def evaluate_photometric_state(
     jqf_extrapolated_broad_photometry = jnp.zeros_like(pred_fluxes)
     jqf_extrapolated_narrow_photometry = jnp.zeros_like(pred_fluxes)
     jqf_photometry_adjustment = jnp.zeros_like(pred_fluxes)
+    jqf_line_obs_sed = jnp.zeros_like(obs_wave)
     if spectroscopy_enabled:
         backend = str(cfg.spectroscopy_config.backend).lower()
         if backend == "jaxqsofit":
@@ -4521,6 +4522,26 @@ def evaluate_photometric_state(
                 numpyro.deterministic("jqf_line_model_aperture", jqf_line_model_aperture)
                 numpyro.deterministic("jqf_line_model_narrow_aperture", jqf_components["line_narrow"])
             jqf_state = jqf_components["state"]
+            # Render the sampled spectral-line state on the SED grid as well.
+            # This is the same posterior line model used by the spectrum, not
+            # a globally rescaled copy of the native jaxsedfit line template.
+            from .spectroscopy import render_joint_feature_state
+
+            jqf_sed_line_cfg = replace(
+                jqf_components["component_config"],
+                use_feii=False,
+                use_balmer_continuum=False,
+            )
+            jqf_sed_lines_mjy = render_joint_feature_state(
+                obs_wave,
+                redshift,
+                jqf_state,
+                config=jqf_sed_line_cfg,
+            )["lines"]
+            jqf_line_obs_sed = jqf_sed_lines_mjy / jnp.maximum(
+                1.0e-10 / 299792458.0 * 1.0e29 * obs_wave**2,
+                1.0e-30,
+            )
             jqf_broad_photometry = _project_jaxqsofit_line_state_filters(
                 context, jqf_state, redshift, broad_only=True
             )
@@ -4880,6 +4901,7 @@ def evaluate_photometric_state(
     numpyro.deterministic("jqf_balmer_photometry", jqf_balmer_photometry)
     numpyro.deterministic("jqf_extrapolated_broad_photometry", jqf_extrapolated_broad_photometry)
     numpyro.deterministic("jqf_extrapolated_narrow_photometry", jqf_extrapolated_narrow_photometry)
+    numpyro.deterministic("jqf_line_obs_sed", jqf_line_obs_sed)
     numpyro.deterministic("spec_continuum_model_fluxes", spec_continuum_model_fluxes)
     numpyro.deterministic("spec_host_model_fluxes", spec_host_model_fluxes)
     numpyro.deterministic("spec_disk_model_fluxes", spec_disk_model_fluxes)

--- a/src/jaxsedfit/plotting.py
+++ b/src/jaxsedfit/plotting.py
@@ -426,7 +426,10 @@ def _site_sum(pred: dict[str, Any], keys: tuple[str, ...]) -> np.ndarray:
 
 
 def _bridged_jaxsedfit_agn_lines(pred: dict[str, Any]) -> np.ndarray | None:
-    """Return native jaxsedfit line shapes normalized to joint-fit photometry."""
+    """Return the joint-fit line SED, falling back to the native line shape."""
+    if "jqf_line_obs_sed" in pred:
+        return np.asarray(pred["jqf_line_obs_sed"], dtype=float)
+
     native_sed_keys = (
         "line_bl_obs_sed",
         "line_nl_obs_sed",

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -29,6 +29,20 @@ def test_joint_line_bridge_rescales_native_jaxsedfit_shape():
     np.testing.assert_allclose(bridged, 3.0 * np.array([[1.5, 2.5, 1.5]]))
 
 
+def test_joint_line_bridge_prefers_rendered_jaxqsofit_sed():
+    rendered = np.array([[0.1, 0.4, 0.2]])
+    pred = {
+        "jqf_line_obs_sed": rendered,
+        "line_bl_obs_sed": np.array([[10.0, 20.0, 10.0]]),
+        "line_fluxes": np.array([[1.0, 1.0]]),
+        "jqf_line_photometry": np.array([[100.0, 100.0]]),
+    }
+
+    bridged = _bridged_jaxsedfit_agn_lines(pred)
+
+    np.testing.assert_array_equal(bridged, rendered)
+
+
 def test_plot_fit_sed_writes_output(tmp_path):
     class _Filter:
         def __init__(self, lam):


### PR DESCRIPTION
## Summary

- render the sampled jaxqsofit broad and narrow line state directly on the SED wavelength grid
- expose the rendered line SED through posterior prediction
- make the SED plot prefer the joint-fit line profile while retaining the legacy bridge for older saved results

## Root cause

The joint SED plot previously displayed the native jaxsedfit line template after applying one global scale derived from summed filter fluxes. Differences between the native template and the spectrally fitted line families could make that scale very large, producing unphysical-looking line peaks even when the spectral and broadband fits were good.

## Impact

New posterior predictions display the actual fitted jaxqsofit broad and narrow profiles. Existing results that do not contain the new deterministic site continue to use the previous fallback behavior.

## Validation

- `conda run -n jaxcpu env PYTHONPATH=src pytest -q tests/test_plotting.py tests/test_model_helpers.py -k "jaxqsofit or joint_line_bridge"`
- 14 passed