### PR TITLE
Plot joint Fe II and Balmer continuum

### DIFF
--- a/src/jaxsedfit/core.py
+++ b/src/jaxsedfit/core.py
@@ -664,6 +664,8 @@ class JAXSEDFit:
             "jqf_extrapolated_broad_photometry",
             "jqf_extrapolated_narrow_photometry",
             "jqf_line_obs_sed",
+            "jqf_feii_obs_sed",
+            "jqf_balmer_obs_sed",
             "rest_wave",
             "obs_wave",
             "redshift_fit",

--- a/src/jaxsedfit/model.py
+++ b/src/jaxsedfit/model.py
@@ -4338,6 +4338,8 @@ def evaluate_photometric_state(
     jqf_extrapolated_narrow_photometry = jnp.zeros_like(pred_fluxes)
     jqf_photometry_adjustment = jnp.zeros_like(pred_fluxes)
     jqf_line_obs_sed = jnp.zeros_like(obs_wave)
+    jqf_feii_obs_sed = jnp.zeros_like(obs_wave)
+    jqf_balmer_obs_sed = jnp.zeros_like(obs_wave)
     if spectroscopy_enabled:
         backend = str(cfg.spectroscopy_config.backend).lower()
         if backend == "jaxqsofit":
@@ -4522,9 +4524,9 @@ def evaluate_photometric_state(
                 numpyro.deterministic("jqf_line_model_aperture", jqf_line_model_aperture)
                 numpyro.deterministic("jqf_line_model_narrow_aperture", jqf_components["line_narrow"])
             jqf_state = jqf_components["state"]
-            # Render the sampled spectral-line state on the SED grid as well.
-            # This is the same posterior line model used by the spectrum, not
-            # a globally rescaled copy of the native jaxsedfit line template.
+            # Render the sampled spectral-feature state on the SED grid as
+            # well. These are the same posterior line, Fe II, and Balmer
+            # models used by the spectrum, not rescaled native templates.
             from .spectroscopy import render_joint_feature_state
 
             jqf_sed_lines_mjy = render_joint_feature_state(
@@ -4533,10 +4535,27 @@ def evaluate_photometric_state(
                 jqf_state,
                 config=jqf_components["component_config"],
             )["lines"]
-            jqf_line_obs_sed = jqf_sed_lines_mjy / jnp.maximum(
+            sed_mjy_per_flambda = jnp.maximum(
                 1.0e-10 / 299792458.0 * 1.0e29 * obs_wave**2,
                 1.0e-30,
             )
+            jqf_line_obs_sed = jqf_sed_lines_mjy / sed_mjy_per_flambda
+            # Fe II and Balmer broadening are comparatively expensive FFTs.
+            # Render them only for component predictions used by plotting, not
+            # during every likelihood evaluation in MAP or NUTS.
+            if include_components and (
+                "feii_norm" in jqf_state or "balmer_norm" in jqf_state
+            ):
+                jqf_sed_smooth_mjy = render_joint_feature_state(
+                    obs_wave,
+                    redshift,
+                    jqf_state,
+                    config=jqf_components["component_config"],
+                    feii_template_wave_rest=feii_template_wave_native,
+                    feii_template_flux=feii_template_flux_native,
+                )
+                jqf_feii_obs_sed = jqf_sed_smooth_mjy["feii"] / sed_mjy_per_flambda
+                jqf_balmer_obs_sed = jqf_sed_smooth_mjy["balmer"] / sed_mjy_per_flambda
             jqf_broad_photometry = _project_jaxqsofit_line_state_filters(
                 context, jqf_state, redshift, broad_only=True
             )
@@ -4897,6 +4916,8 @@ def evaluate_photometric_state(
     numpyro.deterministic("jqf_extrapolated_broad_photometry", jqf_extrapolated_broad_photometry)
     numpyro.deterministic("jqf_extrapolated_narrow_photometry", jqf_extrapolated_narrow_photometry)
     numpyro.deterministic("jqf_line_obs_sed", jqf_line_obs_sed)
+    numpyro.deterministic("jqf_feii_obs_sed", jqf_feii_obs_sed)
+    numpyro.deterministic("jqf_balmer_obs_sed", jqf_balmer_obs_sed)
     numpyro.deterministic("spec_continuum_model_fluxes", spec_continuum_model_fluxes)
     numpyro.deterministic("spec_host_model_fluxes", spec_host_model_fluxes)
     numpyro.deterministic("spec_disk_model_fluxes", spec_disk_model_fluxes)

--- a/src/jaxsedfit/plotting.py
+++ b/src/jaxsedfit/plotting.py
@@ -15,7 +15,8 @@ _COMPONENT_STYLE = [
     (("dust_obs_sed",), "Host dust", "#b7791f", 1.5),
     (("disk_obs_sed",), "AGN disk", "#c05621", 1.2),
     (("torus_obs_sed",), "Torus", "#805ad5", 1.2),
-    (("line_bl_obs_sed", "line_nl_obs_sed", "line_liner_obs_sed", "feii_obs_sed"), "AGN lines", "#d53f8c", 1.0),
+    (("line_bl_obs_sed", "line_nl_obs_sed", "line_liner_obs_sed"), "AGN lines", "#d53f8c", 1.0),
+    (("feii_obs_sed",), "Fe II", "#38a169", 1.0),
     (("balmer_obs_sed",), "Balmer cont.", "#dd6b20", 1.0),
     (("agn_obs_sed",), "AGN total", "#718096", 1.4),
     (("total_obs_sed",), "Model total", "#000000", 2.0),
@@ -590,6 +591,10 @@ def plot_fit_sed(
         for keys, label, color, lw in _COMPONENT_STYLE:
             if label == "AGN lines" and bridged_agn_lines is not None:
                 component_draws = bridged_agn_lines
+            elif label == "Fe II" and "jqf_feii_obs_sed" in pred:
+                component_draws = np.asarray(pred["jqf_feii_obs_sed"], dtype=float)
+            elif label == "Balmer cont." and "jqf_balmer_obs_sed" in pred:
+                component_draws = np.asarray(pred["jqf_balmer_obs_sed"], dtype=float)
             elif any(key in pred for key in keys):
                 component_draws = _site_sum(pred, keys)
             else:

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 from jaxsedfit.plotting import (
+    _COMPONENT_STYLE,
     _bridged_jaxsedfit_agn_lines,
     _grouped_trace_samples,
     plot_corner,
@@ -41,6 +42,13 @@ def test_joint_line_bridge_prefers_rendered_jaxqsofit_sed():
     bridged = _bridged_jaxsedfit_agn_lines(pred)
 
     np.testing.assert_array_equal(bridged, rendered)
+
+
+def test_component_style_separates_feii_from_agn_lines():
+    styles = {label: keys for keys, label, *_ in _COMPONENT_STYLE}
+
+    assert "feii_obs_sed" not in styles["AGN lines"]
+    assert styles["Fe II"] == ("feii_obs_sed",)
 
 
 def test_plot_fit_sed_writes_output(tmp_path):
@@ -98,6 +106,8 @@ def test_plot_fit_sed_writes_output(tmp_path):
                 "spec_wave_obs": np.array([[1800.0, 2200.0, 2600.0]]),
                 "jqf_line_model_aperture": np.array([[0.2, 0.3, 0.4]]),
                 "jqf_feii_model": np.array([[0.1, 0.1, 0.1]]),
+                "jqf_feii_obs_sed": (0.06 * flux)[None, :],
+                "jqf_balmer_obs_sed": (0.04 * flux)[None, :],
             }
 
     output = tmp_path / "sed_plot.png"
@@ -115,6 +125,8 @@ def test_plot_fit_sed_writes_output(tmp_path):
     agn_line_curves = [line for line in fig.axes[0].lines if line.get_label() == "AGN lines"]
     assert len(agn_line_curves) == 1
     assert np.array_equal(agn_line_curves[0].get_xdata(), wave)
+    assert len([line for line in fig.axes[0].lines if line.get_label() == "Fe II"]) == 1
+    assert len([line for line in fig.axes[0].lines if line.get_label() == "Balmer cont."]) == 1
     assert output.exists()
     assert output.stat().st_size > 0
 


### PR DESCRIPTION
## Summary

- render the posterior jaxqsofit Fe II and Balmer-continuum states on the SED wavelength grid
- expose both smooth components through posterior component prediction
- plot Fe II separately from broad/narrow emission lines
- preserve native component curves as fallbacks for non-joint fits and older results

## Motivation

Joint fits already include jaxqsofit Fe II and Balmer continuum in the spectrum and filter-integrated photometric model, but the continuous SED decomposition still used disabled native jaxsedfit sites. This could omit the fitted Balmer continuum and misclassify Fe II as part of the AGN-line curve.

## Performance

The Fe II and Balmer broadening FFTs run only for component predictions used by plotting, not during MAP or NUTS likelihood evaluations.

## Validation

- `conda run -n jaxcpu env PYTHONPATH=src pytest -q tests/test_model_assembly.py::test_jaxqsofit_backend_owns_feii_and_balmer_components tests/test_plotting.py tests/test_model_helpers.py -k "jaxqsofit or joint_line_bridge or component_style or owns_feii_and_balmer"` — 16 passed
- `conda run -n jaxcpu env PYTHONPATH=src pytest -q tests/test_plotting.py` — 13 passed