### PR TITLE
Smooth spectral velocity convolutions

### DIFF
--- a/src/jaxsedfit/model.py
+++ b/src/jaxsedfit/model.py
@@ -34,6 +34,7 @@ import numpyro
 import numpyro.distributions as dist
 
 from .preload import ModelContext, _build_fixed_igm_jax as _igm_transmission
+from .velocity import shift_and_broaden_lnlam as _fourier_shift_and_broaden_lnlam
 
 C_KMS = 299792.458
 C_MS = 2.99792458e8
@@ -1014,15 +1015,12 @@ def _shift_and_broaden_single_spectrum_lnlam(lnwave, spectrum, v_kms, sigma_kms)
     sigma_kms : object
         sigma_kms value.
     """
-    dln = jnp.mean(jnp.diff(lnwave))
-    sigma_ln = jnp.maximum(sigma_kms / C_KMS, 1e-5)
-    sigma_pix = sigma_ln / jnp.maximum(dln, 1e-8)
-    kern = _gaussian_kernel1d(sigma_pix, radius_mult=5.0, max_half=128)
-    wave = jnp.exp(lnwave)
-    shift_ln = v_kms / C_KMS
-    shifted_wave = jnp.exp(lnwave - shift_ln)
-    shifted = jnp.interp(shifted_wave, wave, spectrum, left=0.0, right=0.0)
-    return _convolve_same_length(shifted, kern)
+    return _fourier_shift_and_broaden_lnlam(
+        lnwave,
+        spectrum,
+        v_kms,
+        sigma_kms,
+    )
 
 
 def _powerlaw_jax(wave, norm, lam1, lam2, x0, xbrk, bend_width, cutoff):

--- a/src/jaxsedfit/spectral_model.py
+++ b/src/jaxsedfit/spectral_model.py
@@ -28,6 +28,7 @@ from .spectral_custom_components import (
     normalize_custom_line_components,
 )
 from .spectral_config import ErrorScaledHalfNormalPrior
+from .velocity import shift_and_broaden_lnlam as _fourier_shift_and_broaden_lnlam
 
 C_KMS = 299792.458
 LINE_COVERAGE_NSIGMA = 3.0
@@ -1329,8 +1330,17 @@ def _shift_and_broaden_single_spectrum_lnlam(lnwave, spectrum, v_kms, sigma_kms,
     convolution_method : object
         convolution_method value.
     """
-    sigma_ln = jnp.maximum(sigma_kms / C_KMS, 1e-5)
+    if str(convolution_method).lower() == "fft":
+        return _fourier_shift_and_broaden_lnlam(
+            lnwave,
+            spectrum,
+            v_kms,
+            sigma_kms,
+        )
+    if str(convolution_method).lower() != "direct":
+        raise ValueError("convolution method must be 'fft' or 'direct'.")
 
+    sigma_ln = jnp.maximum(sigma_kms / C_KMS, 1e-5)
     wave = jnp.exp(lnwave)
     shift_ln = v_kms / C_KMS
     shifted_wave = jnp.exp(lnwave - shift_ln)
@@ -1341,7 +1351,7 @@ def _shift_and_broaden_single_spectrum_lnlam(lnwave, spectrum, v_kms, sigma_kms,
         sigma_ln,
         radius_mult=5.0,
         max_half=512,
-        method=convolution_method,
+        method="direct",
     )
 
 
@@ -1455,13 +1465,25 @@ def _convolve_velocity_space(lnwave, signal, sigma_ln, radius_mult=5.0, max_half
     """
     lnwave = jnp.asarray(lnwave, dtype=jnp.float64)
     signal = jnp.asarray(signal, dtype=jnp.float64)
+    method = str(method).lower()
+    if method == "fft":
+        return _fourier_shift_and_broaden_lnlam(
+            lnwave,
+            signal,
+            0.0,
+            C_KMS * jnp.asarray(sigma_ln, dtype=jnp.float64),
+            max_pad=max_half,
+        )
+    if method != "direct":
+        raise ValueError("convolution method must be 'fft' or 'direct'.")
+
     n = lnwave.shape[0]
     ln_uniform = jnp.linspace(lnwave[0], lnwave[-1], n)
     dln = jnp.maximum((lnwave[-1] - lnwave[0]) / jnp.maximum(n - 1, 1), 1e-8)
     sigma_pix = jnp.maximum(sigma_ln, 1e-8) / dln
     kern = _gaussian_kernel1d(sigma_pix, radius_mult=radius_mult, max_half=max_half)
     signal_uniform = jnp.interp(ln_uniform, lnwave, signal, left=0.0, right=0.0)
-    convolved_uniform = _convolve_same_length(signal_uniform, kern, method=method)
+    convolved_uniform = _convolve_same_length(signal_uniform, kern, method="direct")
     return jnp.interp(lnwave, ln_uniform, convolved_uniform, left=0.0, right=0.0)
 
 
@@ -1606,7 +1628,7 @@ def _balmer_continuum_jax(
     bc = jnp.where(below_edge, bc, 0.0)
 
     lnwave = jnp.log(wave)
-    sigma_ln = jnp.maximum(balmer_vel / C_KMS, 1e-5)
+    sigma_ln = balmer_vel / C_KMS
     bc_conv = _convolve_velocity_space(lnwave, bc, sigma_ln, method=convolution_method)
     return bc_conv
 

--- a/src/jaxsedfit/velocity.py
+++ b/src/jaxsedfit/velocity.py
@@ -1,0 +1,64 @@
+"""Smooth velocity shifts and broadening for spectra on log-wavelength grids."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+
+
+C_KMS = 299792.458
+
+
+def shift_and_broaden_lnlam(
+    lnwave,
+    spectrum,
+    v_kms,
+    sigma_kms,
+    *,
+    max_pad: int = 512,
+):
+    """Doppler shift and Gaussian-broaden a spectrum in one Fourier operation.
+
+    The calculation uses an internal uniform log-wavelength grid. Zero padding
+    makes the FFT effectively linear over the returned interval, preventing
+    flux from wrapping between the two ends of the spectrum.
+    """
+    lnwave = jnp.asarray(lnwave, dtype=jnp.float64)
+    spectrum = jnp.asarray(spectrum, dtype=jnp.float64)
+    n = lnwave.shape[0]
+    if n < 2:
+        return spectrum
+
+    ln_uniform = jnp.linspace(lnwave[0], lnwave[-1], n)
+    dln = jnp.maximum((lnwave[-1] - lnwave[0]) / (n - 1), 1.0e-12)
+    spectrum_uniform = jnp.interp(
+        ln_uniform,
+        lnwave,
+        spectrum,
+        left=0.0,
+        right=0.0,
+    )
+
+    # This static padding keeps compiled FFT shapes stable. Short arrays get a
+    # full signal length on each side; long spectra cap the added work.
+    pad = min(n, int(max_pad))
+    padded = jnp.pad(spectrum_uniform, (pad, pad))
+    npad = n + 2 * pad
+
+    angular_frequency = 2.0 * jnp.pi * jnp.fft.rfftfreq(npad, d=dln)
+    shift_ln = jnp.asarray(v_kms, dtype=jnp.float64) / C_KMS
+    sigma_ln = jnp.asarray(sigma_kms, dtype=jnp.float64) / C_KMS
+    # Smoothly regularize zero without introducing a gradient boundary.
+    sigma_ln = jnp.sqrt(sigma_ln**2 + 1.0e-20)
+    transfer = jnp.exp(
+        -0.5 * (angular_frequency * sigma_ln) ** 2
+        - 1j * angular_frequency * shift_ln
+    )
+    transformed = jnp.fft.irfft(jnp.fft.rfft(padded) * transfer, n=npad)
+    transformed = transformed[pad : pad + n]
+    return jnp.interp(
+        lnwave,
+        ln_uniform,
+        transformed,
+        left=0.0,
+        right=0.0,
+    )

--- a/tests/test_velocity.py
+++ b/tests/test_velocity.py
@@ -1,0 +1,198 @@
+"""Tests for smooth Fourier-domain velocity operations."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from jaxsedfit.velocity import C_KMS, shift_and_broaden_lnlam
+
+
+jax.config.update("jax_enable_x64", True)
+
+
+def _moments(lnwave, flux):
+    flux = np.asarray(flux)
+    lnwave = np.asarray(lnwave)
+    norm = np.sum(flux)
+    centroid = np.sum(lnwave * flux) / norm
+    variance = np.sum((lnwave - centroid) ** 2 * flux) / norm
+    return norm, centroid, np.sqrt(variance)
+
+
+@pytest.mark.parametrize(
+    ("velocity", "broadening"),
+    [(0.0, 150.0), (375.0, 600.0), (-725.0, 1800.0)],
+)
+def test_fourier_velocity_operator_matches_gaussian_moments(velocity, broadening):
+    lnwave = jnp.linspace(np.log(3000.0), np.log(8000.0), 4096)
+    center = np.log(5000.0)
+    intrinsic_sigma_kms = 350.0
+    spectrum = jnp.exp(
+        -0.5 * ((lnwave - center) / (intrinsic_sigma_kms / C_KMS)) ** 2
+    )
+
+    transformed = shift_and_broaden_lnlam(
+        lnwave,
+        spectrum,
+        velocity,
+        broadening,
+    )
+    norm_in, _, _ = _moments(lnwave, spectrum)
+    norm_out, center_out, sigma_out = _moments(lnwave, transformed)
+
+    assert norm_out == pytest.approx(norm_in, rel=2.0e-6)
+    assert (center_out - center) * C_KMS == pytest.approx(velocity, abs=0.5)
+    expected_sigma = np.hypot(intrinsic_sigma_kms, broadening)
+    assert sigma_out * C_KMS == pytest.approx(expected_sigma, rel=2.0e-4)
+
+
+def test_fourier_velocity_operator_does_not_wrap_flux_across_edges():
+    lnwave = jnp.linspace(np.log(4000.0), np.log(5000.0), 2048)
+    dln = float(lnwave[1] - lnwave[0])
+    spectrum = jnp.exp(-0.5 * ((lnwave - lnwave[-40]) / (2.0 * dln)) ** 2)
+
+    transformed = shift_and_broaden_lnlam(
+        lnwave,
+        spectrum,
+        2500.0,
+        300.0,
+    )
+
+    # The feature shifts out through the red edge; it must not reappear at blue.
+    assert float(jnp.max(jnp.abs(transformed[:200]))) < 1.0e-10
+
+
+def test_fourier_velocity_operator_handles_linear_wavelength_grid():
+    wave = jnp.linspace(3000.0, 8000.0, 4096)
+    lnwave = jnp.log(wave)
+    center = np.log(5100.0)
+    intrinsic_sigma_kms = 500.0
+    velocity = -450.0
+    broadening = 1300.0
+    spectrum = jnp.exp(
+        -0.5 * ((lnwave - center) / (intrinsic_sigma_kms / C_KMS)) ** 2
+    )
+
+    transformed = shift_and_broaden_lnlam(
+        lnwave,
+        spectrum,
+        velocity,
+        broadening,
+    )
+    sigma_out = np.hypot(intrinsic_sigma_kms, broadening) / C_KMS
+    expected = (
+        intrinsic_sigma_kms
+        / np.hypot(intrinsic_sigma_kms, broadening)
+        * jnp.exp(-0.5 * ((lnwave - center - velocity / C_KMS) / sigma_out) ** 2)
+    )
+
+    central = (wave > 4000.0) & (wave < 7000.0)
+    relative_l2 = jnp.linalg.norm((transformed - expected)[central]) / jnp.linalg.norm(
+        expected[central]
+    )
+    assert float(relative_l2) < 1.0e-3
+
+
+def test_fourier_velocity_operator_has_finite_smooth_parameter_gradients():
+    lnwave = jnp.linspace(np.log(3000.0), np.log(8000.0), 2048)
+    spectrum = jnp.exp(-0.5 * ((lnwave - np.log(5000.0)) / 0.002) ** 2)
+    weights = jnp.sin(jnp.linspace(0.0, 4.0 * np.pi, lnwave.size))
+
+    def objective(parameters):
+        velocity, broadening = parameters
+        model = shift_and_broaden_lnlam(
+            lnwave,
+            spectrum,
+            velocity,
+            broadening,
+        )
+        return jnp.dot(model, weights)
+
+    parameters = jnp.asarray([421.25, 777.75])
+    gradient = jax.grad(objective)(parameters)
+    jacobian = jax.jacfwd(jax.grad(objective))(parameters)
+
+    assert np.all(np.isfinite(np.asarray(gradient)))
+    assert np.all(np.isfinite(np.asarray(jacobian)))
+
+
+def test_generic_fft_velocity_convolution_uses_smooth_operator():
+    from jaxsedfit.spectral_model import _convolve_velocity_space
+
+    lnwave = jnp.linspace(np.log(3000.0), np.log(8000.0), 2048)
+    signal = jnp.exp(-0.5 * ((lnwave - np.log(5200.0)) / 0.002) ** 2)
+    sigma_ln = 1100.0 / C_KMS
+
+    actual = _convolve_velocity_space(
+        lnwave,
+        signal,
+        sigma_ln,
+        method="fft",
+    )
+    expected = shift_and_broaden_lnlam(
+        lnwave,
+        signal,
+        0.0,
+        1100.0,
+    )
+    np.testing.assert_allclose(actual, expected, rtol=1.0e-12, atol=1.0e-12)
+
+
+def test_balmer_continuum_fft_edge_and_width_gradients_are_smooth():
+    from jaxsedfit.spectral_model import _balmer_continuum_jax
+
+    wave = jnp.linspace(2500.0, 4500.0, 3072)
+    weights = jnp.cos(jnp.linspace(0.0, 3.0 * np.pi, wave.size))
+
+    def objective(velocity):
+        continuum = _balmer_continuum_jax(
+            wave,
+            1.0,
+            15000.0,
+            1.0,
+            velocity,
+            convolution_method="fft",
+        )
+        return jnp.dot(continuum, weights)
+
+    velocity = jnp.asarray(3200.0)
+    value = objective(velocity)
+    gradient = jax.grad(objective)(velocity)
+    curvature = jax.grad(jax.grad(objective))(velocity)
+    continuum = _balmer_continuum_jax(
+        wave,
+        1.0,
+        15000.0,
+        1.0,
+        velocity,
+        convolution_method="fft",
+    )
+
+    assert np.all(np.isfinite(np.asarray([value, gradient, curvature])))
+    # Broadening must carry finite BC flux across the physical 3646-A edge.
+    assert float(jnp.max(continuum[(wave > 3646.0) & (wave < 3700.0)])) > 0.0
+    assert float(jnp.min(continuum)) > -1.0e-10
+
+
+def test_model_wrappers_share_the_fourier_operator():
+    from jaxsedfit.model import _shift_and_broaden_single_spectrum_lnlam as model_op
+    from jaxsedfit.spectral_model import (
+        _shift_and_broaden_single_spectrum_lnlam as spectral_op,
+    )
+
+    lnwave = jnp.linspace(np.log(3500.0), np.log(7500.0), 1024)
+    spectrum = jnp.exp(-0.5 * ((lnwave - np.log(5100.0)) / 0.003) ** 2)
+    expected = shift_and_broaden_lnlam(lnwave, spectrum, 325.0, 900.0)
+
+    np.testing.assert_allclose(model_op(lnwave, spectrum, 325.0, 900.0), expected)
+    np.testing.assert_allclose(
+        spectral_op(
+            lnwave,
+            spectrum,
+            325.0,
+            900.0,
+            convolution_method="fft",
+        ),
+        expected,
+    )


### PR DESCRIPTION
## Summary

- add a shared zero-padded Fourier-domain operator that combines Doppler shifting and Gaussian broadening on a uniform log-wavelength grid
- use the smooth FFT path for host stellar templates, Fe II, Balmer continuum, and instrumentally broadened custom components
- convolve Fe II on its 645-point native template grid before interpolation, preventing undersampled ringing on the global SED grid
- render Balmer broadening on a dedicated high-resolution UV/optical grid
- apply host kinematics only on the dense spectroscopic host basis in fixed-redshift joint fits, leaving the coarse broadband SED unbroadened
- retain the direct-convolution backend as an explicit fallback
- add numerical tests for analytic centroids and widths, flux conservation, nonuniform wavelength grids, edge wraparound, Balmer-edge behavior, and finite first and second derivatives

## Why

The previous FFT path shifted templates with piecewise-linear interpolation and truncated Gaussian kernels with a parameter-dependent `ceil()` support. Those operations introduced interpolation knots and small discrete width boundaries into the spectral likelihood geometry. The new transfer function varies smoothly with velocity and width while zero padding prevents circular FFT wraparound.

## Validation

- `conda run -n jaxcpu pytest -q tests/test_velocity.py tests/test_spectral_components.py` — 21 passed
- focused component and host-kinematics tests — 23 passed
- spectral/model integration tests — 76 passed
- full `conda run -n jaxcpu pytest -q` — 412 passed, 1 unrelated failure in `test_student_t_masks_inactive_distribution_inputs_before_evaluation` caused by a separate uncommitted photometric-CDF worktree change that is not included in this PR
- `python -m compileall` and `git diff --check` pass

## Performance

Compiled operator evaluations remain sub-millisecond in the local CPU microbenchmark. The isolated padded Fourier operator measured approximately 25–40% slower than the previous operator. Joint Fe II now runs on the native 645-point template instead of the roughly 4,000-pixel SDSS grid, offsetting that operator-level cost in the affected fit.
