### PR TITLE
Prevent coarse SED convolution ringing

### DIFF
--- a/src/jaxsedfit/model.py
+++ b/src/jaxsedfit/model.py
@@ -3635,7 +3635,17 @@ def evaluate_photometric_state(
     if host_kinematics_enabled:
         gal_v_kms = _sample_prior(prior_config, "gal_v_kms", dist.Normal(0.0, 150.0))
         gal_sigma_kms = _sample_prior(prior_config, "gal_sigma_kms", dist.HalfNormal(150.0))
-        host_rest = _shift_and_broaden_single_spectrum_lnlam(jnp.log(rest_wave), host_rest, gal_v_kms, gal_sigma_kms)
+        # Fixed-redshift joint fits have a dense spectroscopic host basis below.
+        # Apply LOS kinematics there only: the global SED grid is intentionally
+        # coarse over several wavelength decades and cannot resolve a
+        # ~100-km/s convolution without severe Fourier ringing.
+        if not needs_spec_host_basis:
+            host_rest = _shift_and_broaden_single_spectrum_lnlam(
+                jnp.log(rest_wave),
+                host_rest,
+                gal_v_kms,
+                gal_sigma_kms,
+            )
     else:
         gal_v_kms = jnp.asarray(0.0, dtype=jnp.float64)
         gal_sigma_kms = jnp.asarray(0.0, dtype=jnp.float64)

--- a/src/jaxsedfit/spectral_model.py
+++ b/src/jaxsedfit/spectral_model.py
@@ -1528,12 +1528,23 @@ def _fe_template_component(
     convolution_method : object
         convolution_method value.
     """
-    # Enforce physically non-negative Fe pseudo-continuum and model broadening in velocity space.
+    # Enforce a physically non-negative Fe pseudo-continuum and do not first
+    # resample a native template onto a potentially very coarse target grid.
+    # In particular, the global SED grid spans several decades in wavelength;
+    # Fourier-shifting the handful of optical samples on that grid produces
+    # nonphysical ringing far outside the template support.
     if template_on_wave is None:
-        flux_template = jnp.maximum(flux_template, 0.0)
-        template_on_wave = jnp.interp(wave, wave_template, flux_template, left=0.0, right=0.0)
+        convolution_wave = jnp.asarray(wave_template, dtype=jnp.float64)
+        convolution_flux = jnp.maximum(
+            jnp.asarray(flux_template, dtype=jnp.float64),
+            0.0,
+        )
     else:
-        template_on_wave = jnp.maximum(jnp.asarray(template_on_wave, dtype=jnp.float64), 0.0)
+        convolution_wave = jnp.asarray(wave, dtype=jnp.float64)
+        convolution_flux = jnp.maximum(
+            jnp.asarray(template_on_wave, dtype=jnp.float64),
+            0.0,
+        )
 
     min_fwhm_kms = 1.01 * base_fwhm_kms
     transition_kms = jnp.maximum(0.01 * base_fwhm_kms, 10.0)
@@ -1541,13 +1552,23 @@ def _fe_template_component(
     fwhm_eff = jnp.sqrt(fwhm_total**2 - base_fwhm_kms**2)
     sigma_kms = fwhm_eff / (2.0 * jnp.sqrt(2.0 * jnp.log(2.0)))
     v_kms = C_KMS * shift_frac
-    lnwave = jnp.log(wave)
-    model = _shift_and_broaden_single_spectrum_lnlam(
-        lnwave,
-        template_on_wave,
+    model_on_convolution_grid = _shift_and_broaden_single_spectrum_lnlam(
+        jnp.log(convolution_wave),
+        convolution_flux,
         v_kms,
         sigma_kms,
         convolution_method=convolution_method,
+    )
+    model = (
+        model_on_convolution_grid
+        if template_on_wave is not None
+        else jnp.interp(
+            wave,
+            convolution_wave,
+            model_on_convolution_grid,
+            left=0.0,
+            right=0.0,
+        )
     )
     return norm * model
 
@@ -1615,9 +1636,28 @@ def _balmer_continuum_jax(
     convolution_method : object
         convolution_method value.
     """
-    if balmer_static_terms is None:
-        bb, tau_shape, below_edge = _balmer_static_terms_jax(wave, balmer_te=balmer_te)
+    method = str(convolution_method).lower()
+    use_local_grid = balmer_static_terms is None and method == "fft"
+    if use_local_grid:
+        # Resolve the physical 3646-A edge independently of the target SED
+        # sampling. The fixed bounds cover the UV continuum and even very broad
+        # redward edge leakage without convolving over the full IR SED grid.
+        n_local = max(int(wave.shape[0]), 2048)
+        local_min = jnp.maximum(jnp.minimum(wave[0], 2500.0), 100.0)
+        local_max = jnp.maximum(jnp.minimum(wave[-1], 8000.0), 4500.0)
+        convolution_wave = jnp.geomspace(local_min, local_max, n_local)
+        bb, tau_shape, below_edge = _balmer_static_terms_jax(
+            convolution_wave,
+            balmer_te=balmer_te,
+        )
+    elif balmer_static_terms is None:
+        convolution_wave = wave
+        bb, tau_shape, below_edge = _balmer_static_terms_jax(
+            convolution_wave,
+            balmer_te=balmer_te,
+        )
     else:
+        convolution_wave = wave
         bb, tau_shape, below_edge = balmer_static_terms
         bb = jnp.asarray(bb, dtype=jnp.float64)
         tau_shape = jnp.asarray(tau_shape, dtype=jnp.float64)
@@ -1627,9 +1667,17 @@ def _balmer_continuum_jax(
     bc = balmer_norm * (1.0 - jnp.exp(-tau)) * bb
     bc = jnp.where(below_edge, bc, 0.0)
 
-    lnwave = jnp.log(wave)
+    lnwave = jnp.log(convolution_wave)
     sigma_ln = balmer_vel / C_KMS
     bc_conv = _convolve_velocity_space(lnwave, bc, sigma_ln, method=convolution_method)
+    if use_local_grid:
+        return jnp.interp(
+            wave,
+            convolution_wave,
+            bc_conv,
+            left=0.0,
+            right=0.0,
+        )
     return bc_conv
 
 

--- a/tests/test_model_helpers.py
+++ b/tests/test_model_helpers.py
@@ -1928,7 +1928,9 @@ def test_jaxqsofit_spectrum_resolution_host_basis_uses_host_kinematics(monkeypat
     ).get_trace(context, include_components=False)
 
     assert context.spec_host_basis_jax is not None
-    assert sorted(broadened_grids) == [len(cfg.spectroscopy.wave_obs), cfg.galaxy.n_wave]
+    # Host kinematics belong on the dense spectral basis only. Applying them a
+    # second time on the coarse global SED grid produces Fourier ringing.
+    assert broadened_grids == [len(cfg.spectroscopy.wave_obs)]
     assert np.asarray(tr["pred_spectrum_fluxes"]["value"]).shape == (3,)
 
 

--- a/tests/test_velocity.py
+++ b/tests/test_velocity.py
@@ -175,6 +175,54 @@ def test_balmer_continuum_fft_edge_and_width_gradients_are_smooth():
     assert float(jnp.min(continuum)) > -1.0e-10
 
 
+def test_joint_smooth_components_do_not_ring_on_global_sed_grid():
+    from jaxsedfit.spectroscopy import (
+        SpectralComponentConfig,
+        render_joint_feature_state,
+    )
+
+    redshift = 0.3
+    wave_obs = jnp.geomspace(100.0, 3.0e6, 512)
+    template_wave = jnp.geomspace(1800.0, 6500.0, 4096)
+    template_flux = (
+        jnp.exp(-0.5 * ((template_wave - 2600.0) / 90.0) ** 2)
+        + 0.7 * jnp.exp(-0.5 * ((template_wave - 4600.0) / 180.0) ** 2)
+        + 0.4 * jnp.exp(-0.5 * ((template_wave - 5350.0) / 120.0) ** 2)
+    )
+    state = {
+        "feii_norm": jnp.asarray(0.2),
+        "feii_fwhm": jnp.asarray(3000.0),
+        "feii_shift": jnp.asarray(0.004),
+        "balmer_norm": jnp.asarray(0.1),
+        "balmer_tau": jnp.asarray(1.0),
+        "balmer_vel": jnp.asarray(3500.0),
+    }
+
+    rendered = render_joint_feature_state(
+        wave_obs,
+        redshift,
+        state,
+        config=SpectralComponentConfig(
+            use_lines=False,
+            use_feii=True,
+            use_balmer_continuum=True,
+            broadening_convolution="fft",
+        ),
+        feii_template_wave_rest=template_wave,
+        feii_template_flux=template_flux,
+    )
+    wave_rest = wave_obs / (1.0 + redshift)
+    outside_feii = (wave_rest < template_wave[0]) | (wave_rest > template_wave[-1])
+    far_ir = wave_rest > 8000.0
+
+    assert np.all(np.isfinite(np.asarray(rendered["feii"])))
+    assert np.all(np.isfinite(np.asarray(rendered["balmer"])))
+    assert float(jnp.max(jnp.abs(rendered["feii"][outside_feii]))) == 0.0
+    assert float(jnp.max(jnp.abs(rendered["balmer"][far_ir]))) == 0.0
+    assert float(jnp.min(rendered["feii"])) > -1.0e-10
+    assert float(jnp.min(rendered["balmer"])) > -1.0e-10
+
+
 def test_model_wrappers_share_the_fourier_operator():
     from jaxsedfit.model import _shift_and_broaden_single_spectrum_lnlam as model_op
     from jaxsedfit.spectral_model import (


### PR DESCRIPTION
## Summary

- convolve joint Fe II on its native 645-point template grid before interpolating onto spectrum, filter, or SED grids
- render the Balmer continuum on a dedicated high-resolution UV/optical grid before interpolation
- apply host stellar kinematics only on the dense spectroscopic host basis for fixed-redshift joint fits
- keep the coarse global SED free of unresolved velocity convolutions
- add a regression test spanning the actual 512-point, 100–3,000,000 Å SED grid

## Root cause

The global SED grid spans several decades in wavelength. Optical Fe II and stellar velocity kernels occupy fewer than one grid pixel at that sampling. Fourier shifting or broadening those undersampled components generated sinc-like ringing far outside the spectrum and template support. The dense spectroscopic grid did not show the problem, which is why the spectral fit remained visually reasonable.

## Behavior after this change

- Fe II is exactly zero outside its native wavelength support.
- Balmer continuum broadening is resolved around the physical 3646 Å edge and is zero in the far IR.
- Host velocity and dispersion still affect the spectral likelihood, but no longer distort the broadband/global SED.
- The native Fe II grid is smaller than the SDSS spectral grid, so the corrected Fe II convolution is also cheaper.

## Validation

- focused host, Fe II, Balmer, and joint-component tests — 23 passed
- spectral/model integration tests — 76 passed
- full `conda run -n jaxcpu pytest -q` — 412 passed, 1 unrelated failure in `test_student_t_masks_inactive_distribution_inputs_before_evaluation` caused by a separate uncommitted photometric-CDF worktree change not included in this PR
- `git diff --check` passes
