### PR TITLE
Stage joint continuum before emission lines

### DIFF
--- a/src/jaxsedfit/core.py
+++ b/src/jaxsedfit/core.py
@@ -566,12 +566,13 @@ class JAXSEDFit:
         return grahsp_photometric_model(self.context, include_components=False)
 
     def _continuum_init_model(self):
-        """Return the MAP warm-start model with detailed AGN features disabled."""
+        """Return the MAP warm start with smooth continuum features but no lines."""
         return grahsp_photometric_model(
             self.context,
             include_components=False,
-            include_sed_agn_features=False,
-            include_spectral_features=False,
+            include_sed_agn_features=True,
+            include_spectral_features=True,
+            include_spectral_lines=False,
         )
 
     @staticmethod
@@ -1086,8 +1087,9 @@ class JAXSEDFit:
                     stage1_median,
                     stage_name="Stage 1 continuum/host MAP initialization",
                     attr_prefix="init_stage1",
-                    include_sed_agn_features=False,
-                    include_spectral_features=False,
+                    include_sed_agn_features=True,
+                    include_spectral_features=True,
+                    include_spectral_lines=False,
                 )
 
         svi_result, median = self._run_map_svi(
@@ -1117,6 +1119,7 @@ class JAXSEDFit:
                 attr_prefix="init_stage2" if staged else "init_map",
                 include_sed_agn_features=True,
                 include_spectral_features=True,
+                include_spectral_lines=True,
             )
         self.samples = {k: np.asarray(v)[None, ...] for k, v in median.items()}
         self.predictive = None
@@ -1130,6 +1133,7 @@ class JAXSEDFit:
         attr_prefix: str,
         include_sed_agn_features: bool,
         include_spectral_features: bool,
+        include_spectral_lines: bool,
     ):
         """Plot and retain one MAP solution using the standard SED figure.
 
@@ -1142,6 +1146,7 @@ class JAXSEDFit:
             include_components=True,
             include_sed_agn_features=include_sed_agn_features,
             include_spectral_features=include_spectral_features,
+            include_spectral_lines=include_spectral_lines,
         )
         pred = Predictive(
             model,

--- a/src/jaxsedfit/model.py
+++ b/src/jaxsedfit/model.py
@@ -3217,6 +3217,7 @@ def _evaluate_jaxqsofit_backend(
     fixed_narrow_fwhm_kms=None,
     fixed_narrow_amp_scale=None,
     feature_amplitude_scale=1.0,
+    include_lines=True,
 ):
     """Evaluate the built-in detailed spectral components.
 
@@ -3258,7 +3259,7 @@ def _evaluate_jaxqsofit_backend(
 
     jqf_cfg = cfg.spectroscopy_config.jaxqsofit
     component_cfg = SpectralComponentConfig(
-        use_lines=bool(jqf_cfg.use_spectral_lines),
+        use_lines=bool(jqf_cfg.use_spectral_lines and include_lines),
         use_tied_lines=bool(jqf_cfg.use_tied_lines),
         use_feii=bool(jqf_cfg.use_spectral_feii),
         use_balmer_continuum=bool(jqf_cfg.use_spectral_balmer_continuum),
@@ -3498,6 +3499,7 @@ def evaluate_photometric_state(
     add_likelihood: bool = True,
     return_state: bool = True,
     force_component_fluxes: bool = False,
+    include_spectral_lines: bool = True,
 ):
     """Evaluate one jaxsedfit photometric model state inside a NumPyro trace.
 
@@ -3511,6 +3513,10 @@ def evaluate_photometric_state(
         include_sed_agn_features value.
     include_spectral_features : object
         include_spectral_features value.
+    include_spectral_lines : object
+        Whether detailed broad and narrow emission lines are active. Smooth
+        spectral features such as Fe II and Balmer continuum remain controlled
+        by ``include_spectral_features``.
     add_likelihood : object
         add_likelihood value.
     return_state : object
@@ -3556,10 +3562,19 @@ def evaluate_photometric_state(
         spectroscopy_enabled
         and str(cfg.spectroscopy_config.backend).lower() == "jaxqsofit"
     )
+    configured_spectral_lines = bool(
+        jaxqsofit_backend_enabled
+        and jqf_cfg.use_spectral_lines
+    )
     shared_jaxqsofit_lines = bool(
         jaxqsofit_backend_enabled
         and jqf_cfg.use_spectral_lines
         and jqf_cfg.use_photometric_lines
+    )
+    active_spectral_lines = bool(
+        configured_spectral_lines
+        and include_spectral_features
+        and include_spectral_lines
     )
     use_native_feii = bool(
         include_sed_agn_features
@@ -3787,7 +3802,9 @@ def evaluate_photometric_state(
         )
 
         if include_sed_agn_features:
-            if shared_jaxqsofit_lines:
+            if shared_jaxqsofit_lines or (
+                configured_spectral_lines and not active_spectral_lines
+            ):
                 broad_lines_strength = jnp.asarray(1.0, dtype=jnp.float64)
                 narrow_lines_strength = jnp.asarray(DEFAULT_NARROW_LINES_STRENGTH, dtype=jnp.float64)
                 broad_line_width = jnp.asarray(DEFAULT_BROAD_LINE_WIDTH_KMS, dtype=jnp.float64)
@@ -3870,7 +3887,10 @@ def evaluate_photometric_state(
         l_broadlines = 0.02 * l_agn_lambda_5100 * broad_lines_strength
         l_narrowlines = 0.002 * l_agn_lambda_5100 * narrow_lines_strength
 
-        if skip_coarse_agn_line_grid:
+        suppress_joint_stage_lines = bool(
+            configured_spectral_lines and not active_spectral_lines
+        )
+        if skip_coarse_agn_line_grid or suppress_joint_stage_lines:
             line_bl_rest = jnp.zeros_like(rest_wave)
             line_nl_rest = jnp.zeros_like(rest_wave)
             line_liner_rest = jnp.zeros_like(rest_wave)
@@ -4154,6 +4174,7 @@ def evaluate_photometric_state(
     correct_agn_line_photometry = (
         fit_agn
         and include_sed_agn_features
+        and not (configured_spectral_lines and not active_spectral_lines)
         and bool(cfg.likelihood.use_local_line_photometry)
     )
     if correct_agn_line_photometry:
@@ -4508,9 +4529,12 @@ def evaluate_photometric_state(
                 feii_template_flux_native,
                 line_coverage_rest=jaxqsofit_line_coverage_rest,
                 feature_amplitude_scale=feature_amplitude_scale,
+                include_lines=include_spectral_lines,
             )
             jqf_cfg = cfg.spectroscopy_config.jaxqsofit
-            if host_capture_enabled and bool(jqf_cfg.use_spectral_lines):
+            if host_capture_enabled and bool(
+                jqf_cfg.use_spectral_lines and include_spectral_lines
+            ):
                 spec_capture_at_pixel = spec_host_capture_fraction_by_spectrum[spec_spectrum_index]
                 jqf_line_model_aperture = _apply_extended_capture(
                     jqf_components["lines"],
@@ -4602,7 +4626,11 @@ def evaluate_photometric_state(
                 jaxqsofit_line_coverage_rest,
                 sed_feii_scale,
             )
-            if bool(jqf_cfg.use_spectral_lines) and bool(jqf_cfg.use_photometric_lines):
+            if bool(
+                jqf_cfg.use_spectral_lines
+                and jqf_cfg.use_photometric_lines
+                and include_spectral_lines
+            ):
                 line_narrow_template = jnp.where(agn_type == 3, line_liner, line_sy2)
                 extrap_broad_lumin, extrap_narrow_lumin, extrap_broad_width, extrap_narrow_width = (
                     _jaxqsofit_family_extrapolation(
@@ -4653,7 +4681,9 @@ def evaluate_photometric_state(
                 + jqf_extrapolated_narrow_photometry
             )
             native_replaced_photometry = jnp.where(
-                bool(jqf_cfg.use_spectral_lines), local_agn_line_fluxes, jnp.zeros_like(local_agn_line_fluxes)
+                bool(jqf_cfg.use_spectral_lines and include_spectral_lines),
+                local_agn_line_fluxes,
+                jnp.zeros_like(local_agn_line_fluxes),
             )
             jqf_photometry_adjustment = shared_jqf_photometry - native_replaced_photometry
             pred_fluxes = pred_fluxes + jqf_photometry_adjustment
@@ -5106,6 +5136,7 @@ def grahsp_photometric_model(
     include_components: bool = False,
     include_sed_agn_features: bool = True,
     include_spectral_features: bool = True,
+    include_spectral_lines: bool = True,
 ):
     """NumPyro model for one jaxsedfit photometric fit or predictive expansion.
 
@@ -5119,12 +5150,15 @@ def grahsp_photometric_model(
         include_sed_agn_features value.
     include_spectral_features : object
         include_spectral_features value.
+    include_spectral_lines : object
+        include_spectral_lines value.
     """
     return evaluate_photometric_state(
         context,
         include_components=include_components,
         include_sed_agn_features=include_sed_agn_features,
         include_spectral_features=include_spectral_features,
+        include_spectral_lines=include_spectral_lines,
         add_likelihood=True,
         return_state=False,
     )
@@ -5135,6 +5169,7 @@ def sed_numpyro_model(
     include_components: bool = False,
     include_sed_agn_features: bool = True,
     include_spectral_features: bool = True,
+    include_spectral_lines: bool = True,
 ):
     """NumPyro SED model for one configured ``jaxsedfit`` target.
 
@@ -5152,12 +5187,15 @@ def sed_numpyro_model(
         include_sed_agn_features value.
     include_spectral_features : object
         include_spectral_features value.
+    include_spectral_lines : object
+        include_spectral_lines value.
     """
     return grahsp_photometric_model(
         context,
         include_components=include_components,
         include_sed_agn_features=include_sed_agn_features,
         include_spectral_features=include_spectral_features,
+        include_spectral_lines=include_spectral_lines,
     )
 
 
@@ -5169,6 +5207,7 @@ def evaluate_sed_model(
     add_likelihood: bool = True,
     return_state: bool = True,
     force_component_fluxes: bool = False,
+    include_spectral_lines: bool = True,
 ):
     """Evaluate the SED model state for a configured target.
 
@@ -5186,6 +5225,8 @@ def evaluate_sed_model(
         include_sed_agn_features value.
     include_spectral_features : object
         include_spectral_features value.
+    include_spectral_lines : object
+        include_spectral_lines value.
     add_likelihood : object
         add_likelihood value.
     return_state : object
@@ -5198,6 +5239,7 @@ def evaluate_sed_model(
         include_components=include_components,
         include_sed_agn_features=include_sed_agn_features,
         include_spectral_features=include_spectral_features,
+        include_spectral_lines=include_spectral_lines,
         add_likelihood=add_likelihood,
         return_state=return_state,
         force_component_fluxes=force_component_fluxes,

--- a/tests/test_diffstar_host.py
+++ b/tests/test_diffstar_host.py
@@ -871,10 +871,12 @@ def test_fit_map_plot_init_plots_both_staged_map_solutions(monkeypatch):
     fitter.fit_map(progress_bar=False)
 
     assert [call[1]["attr_prefix"] for call in calls] == ["init_stage1", "init_stage2"]
-    assert calls[0][1]["include_sed_agn_features"] is False
-    assert calls[0][1]["include_spectral_features"] is False
+    assert calls[0][1]["include_sed_agn_features"] is True
+    assert calls[0][1]["include_spectral_features"] is True
+    assert calls[0][1]["include_spectral_lines"] is False
     assert calls[1][1]["include_sed_agn_features"] is True
     assert calls[1][1]["include_spectral_features"] is True
+    assert calls[1][1]["include_spectral_lines"] is True
 
 
 def test_joint_dense_mass_blocks_follow_active_sites():

--- a/tests/test_model_assembly.py
+++ b/tests/test_model_assembly.py
@@ -729,6 +729,33 @@ def test_host_kinematics_enabled_with_spectroscopy_samples_and_broadens(monkeypa
     assert "gal_sigma_kms" in tr
 
 
+def test_joint_continuum_stage_keeps_feii_and_balmer_but_omits_lines(monkeypatch):
+    _patch_ssp(monkeypatch)
+    cfg = _cfg(fit_host=False, spectroscopy_enabled=True)
+    cfg.spectroscopy_config.backend = "jaxqsofit"
+    cfg.spectroscopy_config.jaxqsofit.use_spectral_lines = True
+    cfg.spectroscopy_config.jaxqsofit.use_spectral_feii = True
+    cfg.spectroscopy_config.jaxqsofit.use_spectral_balmer_continuum = True
+    context = build_model_context(cfg)
+
+    tr = trace(
+        seed(
+            lambda: grahsp_photometric_model(
+                context,
+                include_sed_agn_features=True,
+                include_spectral_features=True,
+                include_spectral_lines=False,
+            ),
+            jax.random.PRNGKey(41),
+        )
+    ).get_trace()
+
+    assert "jqf_feii_norm" in tr
+    assert "jqf_balmer_norm" in tr
+    assert not any(name.startswith("jqf_line_amp") for name in tr)
+    assert not any(name.startswith("jqf_line_fwhm") for name in tr)
+
+
 def test_agn_only_context_skips_host_ssp_loading(monkeypatch):
     monkeypatch.setattr("jaxsedfit.preload._SSP_DATA_CACHE", {})
     monkeypatch.setattr("jaxsedfit.preload._HOST_BASIS_CACHE", {})


### PR DESCRIPTION
## Summary

- separate the spectral-line switch from the broader spectral-feature switch
- make Stage 1 fit the shared continuum, Fe II, and Balmer continuum without emission lines
- enable the complete continuum-plus-lines model in Stage 2
- add regression coverage for the Stage 1 model sites and updated model signatures

## Why

The previous joint MAP warm-up enabled the full jaxqsofit feature model immediately. That allowed emission-line parameters to participate before the shared host and AGN continuum had settled, making the initial geometry unnecessarily difficult and unlike jaxqsofit's continuum-then-lines staging.

The new Stage 1 retains the smooth continuum features needed for a realistic spectral baseline while omitting emission-line sites. Stage 2 then starts from that continuum solution and enables the full line model.

## Impact

SED-only fitting is unchanged. The change affects staged joint SED+spectral MAP initialization using the jaxqsofit backend.

## Validation

- 125 targeted and broader tests passed
- regression test verifies that Stage 1 retains Fe II and Balmer-continuum sites while omitting line-amplitude and line-width sites
- full suite previously reached 413 passing tests with one unrelated failure caused by an existing unstaged photometric-CDF worktree change
