### PR TITLE
Release MAP memory before NUTS

### DIFF
--- a/src/jaxsedfit/core.py
+++ b/src/jaxsedfit/core.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import gc
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Mapping
@@ -925,9 +926,10 @@ class JAXSEDFit:
             }
             if inference.staged_steps is not None:
                 map_kwargs["staged_steps"] = inference.staged_steps
-            map_result = self.fit_map(
+            self.fit_map(
                 **map_kwargs,
             )
+            self._compact_map_warm_start()
             nuts_kwargs = {
                 "progress_bar": progress_bar,
                 "num_warmup": inference.num_warmup,
@@ -938,10 +940,9 @@ class JAXSEDFit:
                 "max_tree_depth": inference.max_tree_depth,
                 "use_map_init": inference.use_map_init,
             }
-            nuts_result = self.fit_nuts(
+            fit_output = self.fit_nuts(
                 **nuts_kwargs,
             )
-            fit_output = {"map": map_result, "nuts": nuts_result}
         elif method == "ns":
             ns_kwargs: dict[str, Any] = {"progress_bar": progress_bar}
             if inference.ns_num_live_points is not None:
@@ -988,6 +989,35 @@ class JAXSEDFit:
             figure=fig,
             summary=self.summary() if getattr(self, "samples", None) is not None else None,
         )
+
+    def _compact_map_warm_start(self) -> None:
+        """Keep only the MAP data needed to initialize a following NUTS fit.
+
+        A combined ``optax+nuts`` run does not need the SVI optimizer state,
+        staged-fit payload, or compiled MAP executables after optimization.
+        Moving the median to host NumPy arrays before clearing JAX caches keeps
+        the NUTS initial point numerically identical while releasing those
+        transient allocations.
+        """
+        map_result = self.map_result
+        if map_result is None or "median" not in map_result:
+            return
+        compact_result = {
+            "median": {
+                key: np.asarray(value)
+                for key, value in map_result["median"].items()
+            },
+            "losses": np.asarray(map_result.get("losses", [])),
+            "staged": bool(map_result.get("staged", False)),
+        }
+        self.map_result = compact_result
+        self.samples = {
+            key: value[None, ...]
+            for key, value in compact_result["median"].items()
+        }
+        del map_result
+        gc.collect()
+        jax.clear_caches()
 
     def _run_map_svi(
         self,

--- a/tests/test_diffstar_host.py
+++ b/tests/test_diffstar_host.py
@@ -38,7 +38,7 @@ from jaxsedfit.model import (
     grahsp_photometric_model,
 )
 from jaxsedfit.preload import build_model_context
-from jaxsedfit.results import FitResult
+from jaxsedfit.results import FitResult, _FitState
 
 
 def _mock_config():
@@ -758,6 +758,35 @@ def test_fit_dispatch_methods(monkeypatch):
             },
         )
     ]
+
+
+def test_compact_map_warm_start_preserves_median_and_drops_svi_state(monkeypatch):
+    cleared = []
+    monkeypatch.setattr(jax, "clear_caches", lambda: cleared.append(True))
+
+    fitter = JAXSEDFit.__new__(JAXSEDFit)
+    fitter._fit_state = _FitState()
+    median = {
+        "scalar": jnp.asarray(1.25),
+        "vector": jnp.asarray([2.0, 3.0]),
+    }
+    fitter.map_result = {
+        "params": {"heavy_optimizer_state": jnp.ones((32, 32))},
+        "median": median,
+        "losses": np.asarray([3.0, 2.0, 1.0]),
+        "staged": True,
+        "stage1": {"params": {"heavy_stage1_state": jnp.ones((32, 32))}},
+    }
+
+    JAXSEDFit._compact_map_warm_start(fitter)
+
+    assert set(fitter.map_result) == {"median", "losses", "staged"}
+    assert fitter.map_result["staged"] is True
+    np.testing.assert_array_equal(fitter.map_result["median"]["scalar"], 1.25)
+    np.testing.assert_array_equal(fitter.map_result["median"]["vector"], [2.0, 3.0])
+    np.testing.assert_array_equal(fitter.map_result["losses"], [3.0, 2.0, 1.0])
+    np.testing.assert_array_equal(fitter.samples["vector"], [[2.0, 3.0]])
+    assert cleared == [True]
 
 
 def test_fit_nuts_reads_sampler_settings_from_config(monkeypatch):


### PR DESCRIPTION
## What changed

- Compact the MAP warm-start payload before entering NUTS in combined `optax+nuts` fits.
- Preserve the exact MAP median, loss history, and staged-fit flag needed for initialization and diagnostics.
- Drop SVI optimizer parameters and the stage-one payload, then run garbage collection and clear JAX compilation caches.
- Avoid retaining the intermediate MAP `FitResult` throughout NUTS.
- Add a regression test confirming that warm-start values remain identical while transient SVI state is removed.

## Why

Combined joint SED+spectra fits retained the full staged MAP/SVI state and compiled MAP executables while NUTS was running, even though NUTS only consumes the MAP median. This unnecessarily overlaps transient allocations between inference phases.

## Impact

The model, likelihood, priors, spectral pixels, MAP solution, and NUTS initialization are unchanged. Standalone `optax` fits continue to retain their complete MAP diagnostics. Combined fits may recompile work for NUTS after caches are cleared, trading some runtime for lower retained memory.

A completed full joint SED+spectra notebook run after this change peaked at 7.89 GB (7.35 GiB) end-to-end. Phase instrumentation identified NUTS as the remaining peak at 7.07 GiB.

## Validation

- `151 passed` across `tests/test_diffstar_host.py` and `tests/test_model_helpers.py`
- Focused dispatch, compaction, and NUTS configuration tests pass
- Full 4,000-step MAP plus 50/50 NUTS joint notebook completed without errors
