### PR TITLE
Unify joint spectral feature plotting

### DIFF
--- a/src/jaxsedfit/core.py
+++ b/src/jaxsedfit/core.py
@@ -2388,6 +2388,14 @@ class JAXSEDFit:
         plotter.f_bc_model = component("jqf_balmer_model")
         jqf_line_site = "jqf_line_model_aperture" if "jqf_line_model_aperture" in pred else "jqf_line_model"
         plotter.f_line_model = component(jqf_line_site)
+        jqf_broad_line_site = "jqf_line_model_broad"
+        jqf_narrow_line_site = (
+            "jqf_line_model_narrow_aperture"
+            if "jqf_line_model_narrow_aperture" in pred
+            else "jqf_line_model_narrow"
+        )
+        broad_line_component = component(jqf_broad_line_site)
+        narrow_line_component = component(jqf_narrow_line_site)
         spec_torus_component = component("spec_torus_model_fluxes")
         custom_components = {
             "jaxsedfit_torus": spec_torus_component if keep_component(spec_torus_component) else obs_sed_component("torus_obs_sed"),
@@ -2448,7 +2456,22 @@ class JAXSEDFit:
                 if band is not None:
                     pred_bands[name] = band
         plotter.f_poly_model = np.ones_like(wave_rest)
-        plotter.custom_line_components = {}
+        plotter.custom_line_components = {
+            name: model
+            for name, model in (
+                ("broad_lines", broad_line_component),
+                ("narrow_lines", narrow_line_component),
+            )
+            if keep_component(model)
+        }
+        for name, site in (
+            ("broad_lines", jqf_broad_line_site),
+            ("narrow_lines", jqf_narrow_line_site),
+        ):
+            if name in plotter.custom_line_components:
+                band = band_from_draws(spectrum_draws(site))
+                if band is not None:
+                    pred_bands[name] = band
         plotter.pred_bands = pred_bands
         plotter.use_psf_phot = False
         plotter.psf_model = np.array([])

--- a/src/jaxsedfit/model.py
+++ b/src/jaxsedfit/model.py
@@ -4851,6 +4851,18 @@ def evaluate_photometric_state(
             and include_spectral_lines
             and cfg.spectroscopy_config.jaxqsofit.use_spectral_lines
         )
+        joint_feii_rendering = bool(
+            spectroscopy_enabled
+            and str(cfg.spectroscopy_config.backend).lower() == "jaxqsofit"
+            and include_spectral_features
+            and cfg.spectroscopy_config.jaxqsofit.use_spectral_feii
+        )
+        joint_balmer_rendering = bool(
+            spectroscopy_enabled
+            and str(cfg.spectroscopy_config.backend).lower() == "jaxqsofit"
+            and include_spectral_features
+            and cfg.spectroscopy_config.jaxqsofit.use_spectral_balmer_continuum
+        )
         plotted_total_obs = total_obs
         plotted_agn_obs = agn_obs
         if joint_line_rendering:
@@ -4860,6 +4872,17 @@ def evaluate_photometric_state(
             # native UV lines in the black and AGN-total curves.
             plotted_total_obs = plotted_total_obs - line_obs + jqf_line_obs_sed
             plotted_agn_obs = plotted_agn_obs - line_obs + jqf_line_obs_sed
+        if joint_feii_rendering:
+            # Joint fitting disables the native SED Fe II component. Add the
+            # fitted JAXQSOFit state back to the continuous plotted totals,
+            # matching the component curve and photometric likelihood.
+            plotted_total_obs = plotted_total_obs - feii_obs + jqf_feii_obs_sed
+            plotted_agn_obs = plotted_agn_obs - feii_obs + jqf_feii_obs_sed
+        if joint_balmer_rendering:
+            # As above, use the fitted spectral Balmer continuum in the total
+            # curves. This remains active in continuum-only warm-up stages.
+            plotted_total_obs = plotted_total_obs - balmer_obs + jqf_balmer_obs_sed
+            plotted_agn_obs = plotted_agn_obs - balmer_obs + jqf_balmer_obs_sed
         if joint_line_rendering and correct_nebular_line_photometry:
             # Locally rendered nebular profiles are plotted below.  Remove the
             # undersampled coarse-grid version from the continuous total first.

--- a/tests/test_model_helpers.py
+++ b/tests/test_model_helpers.py
@@ -2109,8 +2109,8 @@ def test_jaxsedfit_jaxqsofit_backend_uses_nested_tied_line_config(monkeypatch):
             jaxqsofit=JaxQSOFitConfig(
                 use_spectral_lines=True,
                 use_tied_lines=True,
-                use_spectral_feii=False,
-                use_spectral_balmer_continuum=False,
+                use_spectral_feii=True,
+                use_spectral_balmer_continuum=True,
                 line_flux_scale_mjy=0.1,
             ),
         ),
@@ -2166,8 +2166,8 @@ def test_jaxsedfit_jaxqsofit_backend_uses_nested_tied_line_config(monkeypatch):
     expected_agn_obs = (
         np.asarray(tr["disk_obs_sed"]["value"])
         + np.asarray(tr["torus_obs_sed"]["value"])
-        + np.asarray(tr["feii_obs_sed"]["value"])
-        + np.asarray(tr["balmer_obs_sed"]["value"])
+        + np.asarray(tr["jqf_feii_obs_sed"]["value"])
+        + np.asarray(tr["jqf_balmer_obs_sed"]["value"])
         + np.asarray(tr["jqf_line_obs_sed"]["value"])
     )
     np.testing.assert_allclose(
@@ -2289,6 +2289,7 @@ def test_plot_jaxqsofit_spectrum_adapts_joint_predictive(monkeypatch):
         captured["host"] = np.asarray(self.host)
         captured["line"] = np.asarray(self.f_line_model)
         captured["custom_components"] = dict(self.custom_components)
+        captured["custom_line_components"] = dict(self.custom_line_components)
         captured["pred_bands"] = self.pred_bands
         captured["kwargs"] = kwargs
         self.fig = "fig"
@@ -2316,6 +2317,9 @@ def test_plot_jaxqsofit_spectrum_adapts_joint_predictive(monkeypatch):
         "jqf_continuum_model": np.asarray([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]]),
         "jqf_line_model": np.asarray([[0.1, 0.2, 0.3], [0.3, 0.4, 0.5]]),
         "jqf_line_model_aperture": np.asarray([[1.0, 1.0, 1.0], [3.0, 3.0, 3.0]]),
+        "jqf_line_model_broad": np.asarray([[0.6, 0.7, 0.8], [0.8, 0.9, 1.0]]),
+        "jqf_line_model_narrow": np.asarray([[0.4, 0.3, 0.2], [0.6, 0.5, 0.4]]),
+        "jqf_line_model_narrow_aperture": np.asarray([[0.2, 0.15, 0.1], [0.3, 0.25, 0.2]]),
         "spectrum_scale_fit": np.asarray([2.0, 2.0]),
         "spectrum_host_capture_fraction": np.asarray([0.5, 0.5]),
         "host_obs_sed": np.asarray([[1.0e-20, 2.0e-20, 3.0e-20], [1.0e-20, 2.0e-20, 3.0e-20]]),
@@ -2345,10 +2349,29 @@ def test_plot_jaxqsofit_spectrum_adapts_joint_predictive(monkeypatch):
     assert "jaxsedfit_host_dust" in captured["custom_components"]
     assert "jaxsedfit_sed_lines" not in captured["custom_components"]
     assert "jaxsedfit_nebular_lines" not in captured["custom_components"]
+    assert set(captured["custom_line_components"]) == {"broad_lines", "narrow_lines"}
+    np.testing.assert_allclose(
+        captured["custom_line_components"]["broad_lines"],
+        JAXSEDFit._mjy_to_rest_flambda_1e17(
+            np.asarray([4000.0, 5000.0, 6000.0]),
+            2.0 * np.asarray([0.7, 0.8, 0.9]),
+            1.0,
+        ),
+    )
+    np.testing.assert_allclose(
+        captured["custom_line_components"]["narrow_lines"],
+        JAXSEDFit._mjy_to_rest_flambda_1e17(
+            np.asarray([4000.0, 5000.0, 6000.0]),
+            2.0 * np.asarray([0.25, 0.2, 0.15]),
+            1.0,
+        ),
+    )
     assert "total_model" in captured["pred_bands"]
     assert "host" in captured["pred_bands"]
     assert "PL" in captured["pred_bands"]
     assert "jaxsedfit_torus" in captured["pred_bands"]
+    assert "broad_lines" in captured["pred_bands"]
+    assert "narrow_lines" in captured["pred_bands"]
     lo, hi = captured["pred_bands"]["total_model"]
     assert lo.shape == captured["wave"].shape
     assert hi.shape == captured["wave"].shape


### PR DESCRIPTION
## Summary

- include the fitted JAXQSOFit Fe II and Balmer-continuum states in the continuous joint-fit total and AGN SED curves
- show broad and narrow line components separately in `plot_jaxqsofit_spectrum`, alongside the total-line curve
- use the aperture-corrected narrow-line component when host capture is active
- include posterior uncertainty bands for the broad and narrow line decompositions

## Root cause

Joint fitting disables the native SED Fe II and Balmer-continuum components, but the plotted continuous totals previously substituted only the fitted JAXQSOFit line state. This made the individual Fe II/Balmer curves disagree with the black total. Separately, the spectrum adapter passed only the summed line model to the JAXQSOFit plotter even though broad and narrow deterministic components were available.

## Impact

The plotted SED total now matches the fitted smooth AGN feature state, including during continuum-only warm-up. Spectrum plots expose the broad/narrow decomposition and correctly apply narrow-line aperture capture.

## Validation

- `2 passed, 111 deselected` for the focused joint-model and spectrum-adapter regressions
- `24 passed` for `tests/test_plotting.py` and `tests/test_spectral_components.py`
- `git diff --check`
