### PR TITLE
Fix SED plot and benchmark chi-square diagnostics

### DIFF
--- a/src/jaxsedfit/benchmark.py
+++ b/src/jaxsedfit/benchmark.py
@@ -558,7 +558,7 @@ def _reduced_chi2_for_fit(fitter: Any) -> float:
         att_unc = 10 ** log_unc_frac / tf
         sys_variance = sys_variance + (att_unc * pred_fluxes) ** 2
     if cfg.lyman_break_uncertainty:
-        ly_unc = np.where(filter_wavelength / (1.0 + redshift) < 150.0, 1.0e8, 0.0)
+        ly_unc = np.where(filter_wavelength / (1.0 + redshift) < 1500.0, 1.0e8, 0.0)
         sys_variance = sys_variance + (ly_unc * pred_fluxes) ** 2
     total_variance = np.nan_to_num(obs_variance + sys_variance + var_variance, nan=1.0e30, posinf=1.0e30, neginf=1.0e30)
     sigma = np.sqrt(np.clip(total_variance, 1e-30, 1.0e60))

--- a/src/jaxsedfit/plotting.py
+++ b/src/jaxsedfit/plotting.py
@@ -527,6 +527,18 @@ def _median_effective_variance(fitter, pred: dict[str, Any]) -> np.ndarray:
         else float(getattr(cfg, "agn_systematics_width", 0.0))
     )
     sys_variance = (systematics_width * obs_fluxes) ** 2 + (agn_systematics_width * agn_fluxes) ** 2
+    if "nebular_lines_fluxes" in pred:
+        nebular_lines = np.asarray(
+            _median_site(pred, "nebular_lines_fluxes"), dtype=float
+        )
+        nebular_line_uncertainty_dex = max(
+            float(getattr(cfg, "local_nebular_line_uncertainty_dex", 0.0)),
+            0.0,
+        )
+        nebular_line_sigma = np.expm1(
+            np.log(10.0) * nebular_line_uncertainty_dex
+        )
+        sys_variance = sys_variance + (nebular_line_sigma * nebular_lines) ** 2
     var_variance = np.where(bool(cfg.variability_uncertainty), agn_variability_nev * agn_fluxes**2, 0.0)
     if cfg.attenuation_model_uncertainty:
         tf = np.clip(transmitted_fraction, 1e-4, 1.0)
@@ -535,7 +547,7 @@ def _median_effective_variance(fitter, pred: dict[str, Any]) -> np.ndarray:
         att_unc = 10 ** log_unc_frac / tf
         sys_variance = sys_variance + (att_unc * pred_fluxes) ** 2
     if cfg.lyman_break_uncertainty:
-        ly_unc = np.where(filter_wavelength / (1.0 + redshift) < 150.0, 1.0e8, 0.0)
+        ly_unc = np.where(filter_wavelength / (1.0 + redshift) < 1500.0, 1.0e8, 0.0)
         sys_variance = sys_variance + (ly_unc * pred_fluxes) ** 2
     return np.nan_to_num(obs_variance + sys_variance + var_variance, nan=1.0e30, posinf=1.0e30, neginf=1.0e30)
 
@@ -571,8 +583,14 @@ def plot_fit_sed(
     x_max = max(1.0e6, float(np.nanmax(obs_wave)))
     model_flux = _median_site(pred, "pred_fluxes")
     phot_wave = np.asarray([flt.effective_wavelength for flt in fitter.context.filters], dtype=float)
-    obs_flux = np.asarray(fitter.config.photometry.fluxes, dtype=float)
-    obs_err = np.asarray(fitter.config.photometry.errors, dtype=float)
+    obs_flux = np.asarray(
+        getattr(fitter.context, "fluxes", fitter.config.photometry.fluxes),
+        dtype=float,
+    )
+    obs_err = np.asarray(
+        getattr(fitter.context, "errors", fitter.config.photometry.errors),
+        dtype=float,
+    )
     labels = list(fitter.config.photometry.filter_names)
     plotted_components: list[np.ndarray] = []
     legend_labels_seen: set[str] = set()
@@ -849,16 +867,20 @@ def plot_fit_sed(
         ax_resid.axhline(0.0, color="black", lw=1.0, ls="--")
         upper_limits = np.asarray(getattr(fitter.context, "upper_limits", np.zeros_like(obs_flux, dtype=bool)), dtype=bool)
         finite_chi2 = np.isfinite(obs_flux) & np.isfinite(model_flux) & np.isfinite(eff_sigma) & (eff_sigma > 0.0) & (~upper_limits)
-        if np.any(finite_chi2):
+        if "sed_reduced_chi2" in pred:
+            reduced_chi2 = float(
+                np.median(np.asarray(pred["sed_reduced_chi2"], dtype=float))
+            )
+        elif np.any(finite_chi2):
             chi2 = float(np.sum(((obs_flux[finite_chi2] - model_flux[finite_chi2]) / eff_sigma[finite_chi2]) ** 2))
-            # For this Bayesian SED fit, counting sampled variables as "free parameters"
-            # makes the usual dof estimate meaningless and often collapses the denominator
-            # to 1. Use chi2 per valid band as a stable visual diagnostic instead.
             reduced_chi2 = chi2 / max(1, int(np.sum(finite_chi2)))
+        else:
+            reduced_chi2 = np.nan
+        if np.isfinite(reduced_chi2):
             ax_resid.text(
                 0.98,
                 0.05,
-                rf"$\chi^2_\nu = {reduced_chi2:.2f}$",
+                rf"$\mathrm{{median}}(\chi^2/N_\mathrm{{eff}}) = {reduced_chi2:.2f}$",
                 transform=ax_resid.transAxes,
                 va="bottom",
                 ha="right",

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -124,6 +124,54 @@ def test_fit_quality_metadata_includes_reduced_chi2_and_divergence_fraction():
     assert metadata["divergence_fraction"] == pytest.approx(0.5)
 
 
+def test_fit_quality_metadata_uses_likelihood_lyman_threshold():
+    fitter = type(
+        "_LymanThresholdFitter",
+        (),
+        {
+            "nuts_result": None,
+            "predict": lambda self: {
+                "pred_fluxes": np.array([[100.0]]),
+                "agn_fluxes": np.zeros((1, 1)),
+                "redshift_fit": np.array([0.0]),
+            },
+            "context": type(
+                "_Ctx",
+                (),
+                {
+                    "fluxes": np.array([1.0]),
+                    "errors": np.array([0.1]),
+                    "upper_limits": np.array([False]),
+                    "filters": [
+                        type("_Filter", (), {"effective_wavelength": 1400.0})()
+                    ],
+                },
+            )(),
+            "config": type(
+                "_Cfg",
+                (),
+                {
+                    "likelihood": type(
+                        "_Likelihood",
+                        (),
+                        {
+                            "systematics_width": 0.0,
+                            "agn_systematics_width": 0.0,
+                            "variability_uncertainty": False,
+                            "attenuation_model_uncertainty": False,
+                            "lyman_break_uncertainty": True,
+                        },
+                    )()
+                },
+            )(),
+        },
+    )()
+
+    metadata = fit_quality_metadata(fitter)
+
+    assert metadata["reduced_chi2"] < 1.0e-10
+
+
 def test_fit_quality_metadata_uses_saved_transition_diagnostics_without_mcmc():
     fitter = type(
         "_LoadedDiagnosticFitter",

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -10,6 +10,7 @@ from jaxsedfit.plotting import (
     _COMPONENT_STYLE,
     _bridged_jaxsedfit_agn_lines,
     _grouped_trace_samples,
+    _median_effective_variance,
     plot_corner,
     plot_fit_sed,
     plot_trace,
@@ -170,6 +171,88 @@ def test_plot_fit_sed_can_disable_band_annotations(tmp_path):
     assert fig is not None
     assert output.exists()
     assert output.stat().st_size > 0
+
+
+def test_plot_fit_sed_uses_likelihood_photometry_and_saved_chi2():
+    class _Filter:
+        def __init__(self, wavelength):
+            self.effective_wavelength = wavelength
+
+    config = types.SimpleNamespace(
+        observation=types.SimpleNamespace(object_id="dereddened"),
+        photometry=types.SimpleNamespace(
+            fluxes=[1.0, 1.0],
+            errors=[0.1, 0.1],
+            filter_names=["f1", "f2"],
+        ),
+    )
+    context = types.SimpleNamespace(
+        filters=[_Filter(2000.0), _Filter(4000.0)],
+        fluxes=np.array([2.0, 4.0]),
+        errors=np.array([0.2, 0.4]),
+        upper_limits=np.array([False, False]),
+    )
+    prediction = {
+        "obs_wave": np.array([[1000.0, 2000.0, 4000.0]]),
+        "pred_fluxes": np.array([[1.5, 3.5], [1.7, 3.7]]),
+        "total_obs_sed": np.array([[1.0, 2.0, 1.0]]),
+        "sed_reduced_chi2": np.array([1.0, 3.0]),
+    }
+    fitter = types.SimpleNamespace(
+        config=config,
+        context=context,
+        predict=lambda posterior="latest": prediction,
+    )
+
+    fig = plot_fit_sed(fitter)
+
+    observed = next(
+        container
+        for container in fig.axes[0].containers
+        if container.get_label() == "Observed photometry"
+    )
+    np.testing.assert_allclose(observed.lines[0].get_ydata(), context.fluxes)
+    assert any("2.00" in text.get_text() for text in fig.axes[1].texts)
+
+
+def test_median_effective_variance_matches_nebular_and_lyman_terms():
+    filters = [
+        types.SimpleNamespace(effective_wavelength=1000.0),
+        types.SimpleNamespace(effective_wavelength=2000.0),
+    ]
+    likelihood = types.SimpleNamespace(
+        systematics_width=0.0,
+        agn_systematics_width=0.0,
+        variability_uncertainty=False,
+        attenuation_model_uncertainty=False,
+        lyman_break_uncertainty=True,
+        local_nebular_line_uncertainty_dex=0.1,
+    )
+    fitter = types.SimpleNamespace(
+        config=types.SimpleNamespace(
+            likelihood=likelihood,
+            photometry=types.SimpleNamespace(errors=[0.1, 0.1], fluxes=[1.0, 1.0]),
+        ),
+        context=types.SimpleNamespace(
+            filters=filters,
+            errors=np.array([0.1, 0.1]),
+            fluxes=np.array([1.0, 1.0]),
+        ),
+    )
+    pred = {
+        "pred_fluxes": np.array([[1.0, 1.0]]),
+        "nebular_lines_fluxes": np.array([[2.0, 2.0]]),
+        "redshift_fit": np.array([0.0]),
+    }
+
+    variance = _median_effective_variance(fitter, pred)
+
+    nebular_sigma = np.expm1(np.log(10.0) * 0.1)
+    nebular_variance = (2.0 * nebular_sigma) ** 2
+    np.testing.assert_allclose(
+        variance,
+        [0.1**2 + nebular_variance + 1.0e16, 0.1**2 + nebular_variance],
+    )
 
 
 def test_plot_corner_writes_output_and_calls_corner(tmp_path, monkeypatch):


### PR DESCRIPTION
## What changed

- plot the same Milky-Way-dereddened photometry and errors consumed by the likelihood
- annotate SED figures with the median model-generated `sed_reduced_chi2` diagnostic
- include local nebular-line uncertainty in the plotted effective variance
- align the plotting and benchmark helpers with the likelihood's established 1500 Angstrom rest-frame Lyman-region uncertainty cutoff

## Why

The SED plot mixed raw catalog photometry with a model fitted to dereddened data. It also computed chi-square after collapsing the posterior to a median model, so its annotation disagreed with the saved posterior diagnostic. For the tested object the plot showed 0.18 while the model diagnostic was 1.20 per valid band.

The likelihood already uses 1500 Angstrom for its conservative uncertainty treatment of the Lyman region. The plotting and benchmark copies still used 150 Angstrom, a stale unit-conversion value, and therefore did not reproduce the likelihood variance. This cutoff is an uncertainty-policy boundary, not the physical wavelength of the Lyman edge.

## Impact

Displayed photometry, residual error bars, the benchmark reduced chi-square, and the plot chi-square annotation now follow the fitted likelihood inputs and diagnostics. The label explicitly reports `median(chi^2 / N_eff)` rather than implying a classical degrees-of-freedom correction.

## Validation

- full suite: 415 passed, 6 skipped
- focused benchmark and plotting suites: 18 passed, 6 skipped
- regression coverage for dereddened plotting data, saved chi-square annotation, nebular uncertainty, and the 1400 Angstrom benchmark threshold case
